### PR TITLE
README tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ CWL workflow defintions for executing MGI Cancer Genomics analysis.
 
 ** PLEASE USE THE toil_compatibility BRANCH **
 
-At this time, the toil_compatibility branch relies on large, aka. fat, Docker images. Below is a mapping of workflow to Docker image name, all available on [DockerHub](https://hub.docker.com/u/mgibio/)
+At this time, the toil_compatibility branch relies on large, a/k/a fat, Docker images. Below is a mapping of workflow to Docker image name, all available on [DockerHub](https://hub.docker.com/u/mgibio/):
 
 | Workflow | Docker Image | Main CWL |
 | --- | --- | --- |
-| unaligned_bam_to_bqsr | mgibio/dna-alignment | unaligned_bam_to_bgsr/workflow.cwl |
+| unaligned_bam_to_bqsr | mgibio/dna-alignment | unaligned_bam_to_bqsr/workflow.cwl |
 | detect_variants | mgibio/cle | detect_variants/detect_variants.cwl |
 | rnaseq | mgibio/rnaseq | rnaseq/workflow.cwl |
 | tumor_only_exome | mgibio/cle | exome_workflow.cwl |


### PR DESCRIPTION
* Fix typo in workflow path.
* Use a more standard form for "also known as".
* Add punctuation to introduce the table.