### PR TITLE
Temporary workaround for exome workflow merge issue

### DIFF
--- a/definitions/subworkflows/bam_to_bqsr_workflow.cwl
+++ b/definitions/subworkflows/bam_to_bqsr_workflow.cwl
@@ -46,7 +46,7 @@ steps:
         out:
             [tagged_bam]
     merge:
-        run: ../tools/merge_bams.cwl
+        run: ../tools/merge_bams_temp.cwl
         in:
             bams: align/tagged_bam
         out:

--- a/definitions/tools/merge_bams_temp.cwl
+++ b/definitions/tools/merge_bams_temp.cwl
@@ -1,0 +1,24 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: "Samtools: merge"
+baseCommand: ["/opt/samtools/bin/samtools", "merge"]
+requirements:
+    - class: ResourceRequirement
+      ramMin: 8000
+      coresMin: 4
+    - class: DockerRequirement
+      dockerPull: "mgibio/cle"
+arguments: ["merged.bam"]
+inputs:
+    bams:
+        type: File[]
+        inputBinding:
+            position: 1
+outputs:
+    merged_bam:
+        type: File
+        outputBinding:
+            glob: "merged.bam"
+


### PR DESCRIPTION
Currently, the bam_to_bqsr_workflow.cwl subworkflow's merge step does not work with the merge_bams.cwl tool. This change is intended to be a temporary fix while the issue is resolved; for further discussion, see the issue