### PR TITLE
don't validate the bam before fastq creation

### DIFF
--- a/definitions/tools/bam_to_fastq.cwl
+++ b/definitions/tools/bam_to_fastq.cwl
@@ -3,7 +3,7 @@
 cwlVersion: v1.0
 class: CommandLineTool
 label: "Picard: BAM to FASTQ"
-baseCommand: ["/usr/bin/java", "-Xmx4g", "-jar", "/opt/picard/picard.jar", "SamToFastq"]
+baseCommand: ["/usr/bin/java", "-Xmx4g", "-jar", "/opt/picard/picard.jar", "SamToFastq", "VALIDATION_STRINGENCY=LENIENT"]
 requirements:
     - class: DockerRequirement
       dockerPull: "mgibio/rnaseq"

--- a/definitions/tools/bam_to_fastq.cwl
+++ b/definitions/tools/bam_to_fastq.cwl
@@ -3,7 +3,7 @@
 cwlVersion: v1.0
 class: CommandLineTool
 label: "Picard: BAM to FASTQ"
-baseCommand: ["/usr/bin/java", "-Xmx4g", "-jar", "/opt/picard/picard.jar", "SamToFastq", "VALIDATION_STRINGENCY=LENIENT"]
+baseCommand: ["/usr/bin/java", "-Xmx4g", "-jar", "/opt/picard/picard.jar", "SamToFastq", "VALIDATION_STRINGENCY=SILENT"]
 requirements:
     - class: DockerRequirement
       dockerPull: "mgibio/rnaseq"


### PR DESCRIPTION
wastes time and may fail on LIMS data that has eland alignment info