### PR TITLE
Output gathering

### DIFF
--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -348,6 +348,16 @@ steps:
                                     }
                                     return outArr;
                                 }
-                                return flatten(self, []);
+                                var no_secondaries = flatten(self, []);
+                                var all_files = []; 
+                                var arrLen = no_secondaries.length;
+                                for (var i = 0; i < arrLen; i++) {
+                                    all_files.push(no_secondaries[i]);
+                                    var secondaryLen = no_secondaries[i].secondaryFiles.length;
+                                    for (var j = 0; j < secondaryLen; j++) {
+                                        all_files.push(no_secondaries[i].secondaryFiles[j]);
+                                    }
+                                }
+                                return all_files;
                             }
         out: [gathered_files]

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -5,6 +5,7 @@ class: Workflow
 label: "exome alignment and somatic variant detection"
 requirements:
     - class: SubworkflowFeatureRequirement
+    - class: StepInputExpressionRequirement
 inputs:
     reference: string
     tumor_bams:
@@ -111,6 +112,8 @@ inputs:
     custom_gnomad_vcf:
         type: File?
         secondaryFiles: [.tbi]
+    output_dir: 
+        type: string
 outputs:
     tumor_cram:
         type: File
@@ -243,6 +246,9 @@ outputs:
     normal_bam_readcount_tsv:
         type: File
         outputSource: detect_variants/normal_bam_readcount_tsv
+    final_outputs:
+        type: string[]
+        outputSource: gatherer/gathered_files
 steps:
     tumor_alignment_and_qc:
         run: exome_alignment.cwl
@@ -323,4 +329,25 @@ steps:
             custom_gnomad_vcf: custom_gnomad_vcf
         out:
             [mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, docm_unfiltered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_bam_readcount_tsv, normal_bam_readcount_tsv]
-
+    gatherer:
+        run: ../tools/gatherer.cwl
+        in:
+            output_dir: output_dir
+            all_files:
+                source: [tumor_alignment_and_qc/cram, tumor_alignment_and_qc/mark_duplicates_metrics, tumor_alignment_and_qc/insert_size_metrics, tumor_alignment_and_qc/alignment_summary_metrics, tumor_alignment_and_qc/hs_metrics, tumor_alignment_and_qc/per_target_coverage_metrics, tumor_alignment_and_qc/per_target_hs_metrics, tumor_alignment_and_qc/per_base_coverage_metrics, tumor_alignment_and_qc/per_base_hs_metrics, tumor_alignment_and_qc/flagstats, tumor_alignment_and_qc/verify_bam_id_metrics, tumor_alignment_and_qc/verify_bam_id_depth, normal_alignment_and_qc/cram, normal_alignment_and_qc/mark_duplicates_metrics, normal_alignment_and_qc/insert_size_metrics, normal_alignment_and_qc/alignment_summary_metrics, normal_alignment_and_qc/hs_metrics, normal_alignment_and_qc/per_target_coverage_metrics, normal_alignment_and_qc/per_target_hs_metrics, normal_alignment_and_qc/per_base_coverage_metrics, normal_alignment_and_qc/per_base_hs_metrics, normal_alignment_and_qc/flagstats, normal_alignment_and_qc/verify_bam_id_metrics, normal_alignment_and_qc/verify_bam_id_depth, detect_variants/mutect_unfiltered_vcf, detect_variants/mutect_filtered_vcf, detect_variants/strelka_unfiltered_vcf, detect_variants/strelka_filtered_vcf, detect_variants/varscan_unfiltered_vcf, detect_variants/varscan_filtered_vcf, detect_variants/pindel_unfiltered_vcf, detect_variants/pindel_filtered_vcf, detect_variants/docm_unfiltered_vcf, detect_variants/docm_filtered_vcf, detect_variants/final_vcf, detect_variants/final_filtered_vcf, detect_variants/final_tsv, detect_variants/vep_summary, detect_variants/tumor_bam_readcount_tsv, detect_variants/normal_bam_readcount_tsv]
+                valueFrom: ${
+                                function flatten(inArr, outArr) {
+                                    var arrLen = inArr.length;
+                                    for (var i = 0; i < arrLen; i++) {
+                                        if (Array.isArray(inArr[i])) {
+                                            flatten(inArr[i], outArr);
+                                        }
+                                        else {
+                                            outArr.push(inArr[i]);
+                                        }
+                                    }
+                                    return outArr;
+                                }
+                                return flatten(self, []);
+                            }
+        out: [gathered_files]

--- a/definitions/tools/gatherer.cwl
+++ b/definitions/tools/gatherer.cwl
@@ -1,0 +1,42 @@
+#! /usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: ['/bin/cp']
+
+requirements:
+    - class: ShellCommandRequirement
+    - class: DockerRequirement
+      dockerPull: "ubuntu:xenial"
+
+arguments: [
+    { shellQuote: false, valueFrom: "-t" }
+]
+
+inputs:
+    output_dir:
+        type: string
+        inputBinding:
+            position: 1
+    all_files:
+        type: File[] 
+        inputBinding:
+            position: 2
+outputs:
+    gathered_files:
+        type:
+            type: array
+            items: string
+        outputBinding:
+            outputEval: ${
+                            var file_paths = [];
+                            var new_path = inputs.output_dir;
+                            if (new_path.slice(-1) != "/") {
+                                new_path += "/";
+                            }
+                            var arrLen = inputs.all_files.length;
+                            for(var i = 0; i < arrLen; i++) {
+                                file_paths.push(new_path + inputs.all_files[i].basename);
+                            }
+                            return file_paths;
+                        }

--- a/definitions/tools/gatherer.cwl
+++ b/definitions/tools/gatherer.cwl
@@ -9,9 +9,7 @@ requirements:
     - class: DockerRequirement
       dockerPull: "ubuntu:xenial"
 
-arguments: [
-    { shellQuote: false, valueFrom: "-t" }
-]
+arguments: ["-t"]
 
 inputs:
     output_dir:


### PR DESCRIPTION
This PR contains a work-in-progress example workaround for several Cromwell bugs preventing final output files from being consolidated into a single directory. To use, add an `output_dir` string parameter to a workflow's inputs file, specifying an absolute path to the directory where final output files should be placed. Add in a step, which runs `/tools/gatherer.cwl`, taking in `output_dir` and `all_files`, an array of all files to be packaged together. A javascript expression is required to work around a bug and parse this input before actually sending it to the tool; see line 338 of `somatic_exome.cwl`. Finally, make sure to add the output of this step, a string array, to the outputs section.

Limitations:
~~Currently does not work with `secondaryFiles`- looking into fixing this~~
All output files to be gathered must be copy/pasted together into the gatherer.cwl input array, as seen on line 337; this may be improved upon if the Cromwell issues aren't officially fixed soon
Any file name collisions will cause the tool to error and the workflow to fail; this may be improved if the Cromwell issues aren't officially fixed soon

Cromwell bug reports will be filed soon and linked here