### PR TITLE
Updating germline exome workflow to work with cromwell

### DIFF
--- a/definitions/pipelines/germline_exome.cwl
+++ b/definitions/pipelines/germline_exome.cwl
@@ -180,7 +180,7 @@ steps:
             gvcf_gq_bands: gvcf_gq_bands
             intervals: intervals
             contamination_fraction: extract_freemix/freemix_score
-            cache_dir: vep_cache_dir
+            vep_cache_dir: vep_cache_dir
             synonyms_file: synonyms_file
             annotate_coding_only: annotate_coding_only
             hgvs: hgvs_annotation

--- a/definitions/subworkflows/gatk_haplotypecaller_iterator.cwl
+++ b/definitions/subworkflows/gatk_haplotypecaller_iterator.cwl
@@ -4,6 +4,7 @@ cwlVersion: v1.0
 class: Workflow
 label: "scatter GATK HaplotypeCaller over intervals"
 requirements:
+    - class: InlineJavascriptRequirement
     - class: ScatterFeatureRequirement
 inputs:
     reference:

--- a/definitions/subworkflows/gatk_haplotypecaller_iterator.cwl
+++ b/definitions/subworkflows/gatk_haplotypecaller_iterator.cwl
@@ -44,5 +44,13 @@ steps:
             intervals: intervals
             dbsnp_vcf: dbsnp_vcf
             contamination_fraction: contamination_fraction
+            output_file_name:
+                valueFrom: '${
+                    if (inputs.intervals.length == 1 && inputs.intervals[0].match(/^[0-9A-Za-z]+$/)) {
+                        return inputs.intervals[0] + ".g.vcf.gz";
+                    } else {
+                        return "output.g.vcf.gz";
+                    }
+                }'
         out:
             [gvcf]

--- a/definitions/tools/gatk_genotypegvcfs.cwl
+++ b/definitions/tools/gatk_genotypegvcfs.cwl
@@ -9,7 +9,7 @@ requirements:
       ramMin: 8000
     - class: InlineJavascriptRequirement
     - class: DockerRequirement
-      dockerPull: "mgibio/gatk-cwl:3.6.0"
+      dockerPull: "mgibio/gatk-cwl:3.5.0"
 arguments:
     ["-o", 'genotype.vcf.gz']
 inputs:

--- a/definitions/tools/gatk_genotypegvcfs.cwl
+++ b/definitions/tools/gatk_genotypegvcfs.cwl
@@ -3,13 +3,13 @@
 cwlVersion: v1.0
 class: CommandLineTool
 label: "GATK HaplotypeCaller"
-baseCommand: ["/usr/bin/java", "-Xmx8g", "-jar", "/opt/GenomeAnalysisTK-3.5.jar", "-T", "GenotypeGVCFs"]
+baseCommand: ["/usr/bin/java", "-Xmx8g", "-jar", "/opt/GenomeAnalysisTK.jar", "-T", "GenotypeGVCFs"]
 requirements:
     - class: ResourceRequirement
       ramMin: 8000
     - class: InlineJavascriptRequirement
     - class: DockerRequirement
-      dockerPull: mgibio/cle
+      dockerPull: "mgibio/gatk-cwl:3.6.0"
 arguments:
     ["-o", 'genotype.vcf.gz']
 inputs:

--- a/definitions/tools/gatk_haplotype_caller.cwl
+++ b/definitions/tools/gatk_haplotype_caller.cwl
@@ -10,15 +10,6 @@ requirements:
     - class: InlineJavascriptRequirement
     - class: DockerRequirement
       dockerPull: mgibio/cle
-arguments:
-    ["-o", { valueFrom: '${
-            if (inputs.intervals.length == 1 && inputs.intervals[0].match(/^[0-9A-Za-z]+$/)) {
-                return inputs.intervals[0] + ".g.vcf.gz";
-            } else {
-                return "output.g.vcf.gz";
-            }
-        }'
-    }]
 inputs:
     reference:
         type: string
@@ -63,9 +54,15 @@ inputs:
         inputBinding:
             prefix: "-contamination"
             position: 7
+    output_file_name:
+        type: string
+        default: "output.g.vcf.gz"
+        inputBinding:
+            prefix: "-o"
+            position: 8
 outputs:
     gvcf:
         type: File
         outputBinding:
-            glob: "*.g.vcf.gz"
+            glob: $(inputs.output_file_name)
         secondaryFiles: [.tbi]

--- a/definitions/tools/gatk_haplotype_caller.cwl
+++ b/definitions/tools/gatk_haplotype_caller.cwl
@@ -8,7 +8,7 @@ requirements:
     - class: ResourceRequirement
       ramMin: 8000
     - class: DockerRequirement
-      dockerPull: "mgibio/gatk-cwl:3.6.0"
+      dockerPull: "mgibio/gatk-cwl:3.5.0"
 inputs:
     reference:
         type: string

--- a/definitions/tools/gatk_haplotype_caller.cwl
+++ b/definitions/tools/gatk_haplotype_caller.cwl
@@ -3,13 +3,13 @@
 cwlVersion: v1.0
 class: CommandLineTool
 label: "GATK HaplotypeCaller"
-baseCommand: ["/usr/bin/java", "-Xmx8g", "-jar", "/opt/GenomeAnalysisTK-3.5.jar", "-T", "HaplotypeCaller"]
+baseCommand: ["/usr/bin/java", "-Xmx8g", "-jar", "/opt/GenomeAnalysisTK.jar", "-T", "HaplotypeCaller"]
 requirements:
     - class: ResourceRequirement
       ramMin: 8000
     - class: InlineJavascriptRequirement
     - class: DockerRequirement
-      dockerPull: mgibio/cle
+      dockerPull: "mgibio/gatk-cwl:3.6.0"
 inputs:
     reference:
         type: string

--- a/definitions/tools/gatk_haplotype_caller.cwl
+++ b/definitions/tools/gatk_haplotype_caller.cwl
@@ -7,7 +7,6 @@ baseCommand: ["/usr/bin/java", "-Xmx8g", "-jar", "/opt/GenomeAnalysisTK.jar", "-
 requirements:
     - class: ResourceRequirement
       ramMin: 8000
-    - class: InlineJavascriptRequirement
     - class: DockerRequirement
       dockerPull: "mgibio/gatk-cwl:3.6.0"
 inputs:


### PR DESCRIPTION
Original CWL workflow was unable to successfully complete. Was an issue with finding the output file in the `definitions/tools/gatk_haplotype_caller.cwl` step. Unsure what the root cause was but with the help of @tmooney was able to find a workaround. 

Added an input for a `output_file_name` and moved the javascript expression to generate the name based on the input interval up to the `definitions/subworkflows/gatk_haplotypecaller_iterator.cwl` step.

 Also added small docker images. 


