### PR TITLE
Allow specifying names for CRAM files in somatic exome workflow.

### DIFF
--- a/definitions/pipelines/exome_alignment.cwl
+++ b/definitions/pipelines/exome_alignment.cwl
@@ -24,6 +24,8 @@ inputs:
         type: string[]?
     bait_intervals:
         type: File
+    final_name:
+        type: string?
     target_intervals:
         type: File
     per_target_intervals:
@@ -94,6 +96,7 @@ steps:
             known_indels: known_indels
             dbsnp_vcf: dbsnp_vcf
             bqsr_intervals: bqsr_intervals
+            final_name: final_name
         out: [final_cram,mark_duplicates_metrics_file]
     qc:
         run: ../subworkflows/qc_exome.cwl

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -11,10 +11,16 @@ inputs:
         type: File[]
     tumor_readgroups:
         type: string[]
+    tumor_cram_name:
+        type: string?
+        default: 'tumor.cram'
     normal_bams:
         type: File[]
     normal_readgroups:
         type: string[]
+    normal_cram_name:
+        type: string?
+        default: 'normal.cram'
     mills:
         type: File
         secondaryFiles: [.tbi]
@@ -264,6 +270,7 @@ steps:
             picard_metric_accumulation_level: picard_metric_accumulation_level   
             minimum_mapping_quality: qc_minimum_mapping_quality
             minimum_base_quality: qc_minimum_base_quality
+            final_name: tumor_cram_name
         out:
             [cram, mark_duplicates_metrics, insert_size_metrics, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]
     normal_alignment_and_qc:
@@ -286,6 +293,7 @@ steps:
             picard_metric_accumulation_level: picard_metric_accumulation_level   
             minimum_mapping_quality: qc_minimum_mapping_quality
             minimum_base_quality: qc_minimum_base_quality
+            final_name: normal_cram_name
         out:
             [cram, mark_duplicates_metrics, insert_size_metrics, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]
     detect_variants:

--- a/definitions/subworkflows/bam_to_bqsr.cwl
+++ b/definitions/subworkflows/bam_to_bqsr.cwl
@@ -20,6 +20,8 @@ inputs:
     dbsnp_vcf:
         type: File
         secondaryFiles: [.tbi]
+    final_name:
+        type: string?
     mills:
         type: File
         secondaryFiles: [.tbi]
@@ -85,6 +87,7 @@ steps:
         in:
             reference: reference
             bam: apply_bqsr/bqsr_bam
+            name: final_name
         out:
             [cram]
     index_cram:

--- a/definitions/tools/bam_to_cram.cwl
+++ b/definitions/tools/bam_to_cram.cwl
@@ -7,7 +7,7 @@ baseCommand: ["/opt/samtools/bin/samtools", "view", "-C"]
 requirements:
     - class: DockerRequirement
       dockerPull: "mgibio/samtools-cwl:1.0.0"
-stdout: "final.cram"
+stdout: $(inputs.name)
 inputs:
     reference:
         type: string
@@ -18,6 +18,9 @@ inputs:
         type: File
         inputBinding:
             position: 2
+    name:
+        type: string?
+        default: 'final.cram'
 outputs:
     cram:
         type: stdout


### PR DESCRIPTION
The old default of both CRAMs having the same name is confusing and problematic, so here's some slightly better defaults too.