### PR TITLE
Base QC filenames on the CRAM filename.

### DIFF
--- a/definitions/tools/collect_alignment_summary_metrics.cwl
+++ b/definitions/tools/collect_alignment_summary_metrics.cwl
@@ -5,7 +5,7 @@ class: CommandLineTool
 label: "collect alignment summary metrics"
 baseCommand: ["/usr/bin/java", "-Xmx16g", "-jar", "/usr/picard/picard.jar", "CollectAlignmentSummaryMetrics"]
 arguments:
-    ["OUTPUT=", { valueFrom: $(runtime.outdir)/AlignmentSummaryMetrics.txt }]
+    ["OUTPUT=", { valueFrom: $(runtime.outdir)/$(inputs.cram.nameroot).AlignmentSummaryMetrics.txt }]
 requirements:
     - class: ResourceRequirement
       ramMin: 16000
@@ -29,4 +29,4 @@ outputs:
     alignment_summary_metrics:
         type: File
         outputBinding:
-            glob: "AlignmentSummaryMetrics.txt"
+            glob: "$(inputs.cram.nameroot).AlignmentSummaryMetrics.txt"

--- a/definitions/tools/collect_hs_metrics.cwl
+++ b/definitions/tools/collect_hs_metrics.cwl
@@ -5,7 +5,7 @@ class: CommandLineTool
 label: "collect HS metrics"
 baseCommand: ["/usr/bin/java", "-Xmx16g", "-jar", "/usr/picard/picard.jar", "CollectHsMetrics"]
 arguments:
-    ["O=", { valueFrom: $(runtime.outdir)/$(inputs.output_prefix)-HsMetrics.txt }]
+    ["O=", { valueFrom: $(runtime.outdir)/$(inputs.cram.nameroot).$(inputs.output_prefix)-HsMetrics.txt }]
 requirements:
     - class: ResourceRequirement
       ramMin: 16000
@@ -41,7 +41,7 @@ inputs:
             valueFrom: |
                         ${
                             if(self) {
-                                return inputs.output_prefix + "-PerTargetCoverage.txt"
+                                return inputs.cram.nameroot + "." + inputs.output_prefix + "-PerTargetCoverage.txt"
                             } else {
                                 return false;
                             }
@@ -53,7 +53,7 @@ inputs:
             valueFrom: |
                         ${
                             if(self) {
-                                return inputs.output_prefix + "-PerBaseCoverage.txt"
+                                return inputs.cram.nameroot + "." + inputs.output_prefix + "-PerBaseCoverage.txt"
                             } else {
                                 return false;
                             }
@@ -75,12 +75,12 @@ outputs:
     hs_metrics:
         type: File
         outputBinding:
-            glob: "$(inputs.output_prefix)-HsMetrics.txt"
+            glob: "$(inputs.cram.nameroot).$(inputs.output_prefix)-HsMetrics.txt"
     per_target_coverage_metrics:
         type: File?
         outputBinding:
-            glob: "$(inputs.output_prefix)-PerTargetCoverage.txt"
+            glob: "$(inputs.cram.nameroot).$(inputs.output_prefix)-PerTargetCoverage.txt"
     per_base_coverage_metrics:
         type: File?
         outputBinding:
-            glob: "$(inputs.output_prefix)-PerBaseCoverage.txt"
+            glob: "$(inputs.cram.nameroot).$(inputs.output_prefix)-PerBaseCoverage.txt"

--- a/definitions/tools/collect_insert_size_metrics.cwl
+++ b/definitions/tools/collect_insert_size_metrics.cwl
@@ -5,8 +5,8 @@ class: CommandLineTool
 label: "collect insert size metrics"
 baseCommand: ["/usr/bin/java", "-Xmx16g", "-jar", "/usr/picard/picard.jar", "CollectInsertSizeMetrics"]
 arguments:
-    ["O=", { valueFrom: $(runtime.outdir)/InsertSizeMetrics.txt },
-    "H=", { valueFrom: $(runtime.outdir)/InsertSizeHistogram.pdf }]
+    ["O=", { valueFrom: $(runtime.outdir)/$(inputs.cram.nameroot).InsertSizeMetrics.txt },
+    "H=", { valueFrom: $(runtime.outdir)/$(inputs.cram.nameroot).InsertSizeHistogram.pdf }]
 requirements:
     - class: ResourceRequirement
       ramMin: 16000
@@ -30,8 +30,8 @@ outputs:
     insert_size_metrics:
         type: File
         outputBinding:
-            glob: "InsertSizeMetrics.txt"
+            glob: "$(inputs.cram.nameroot).InsertSizeMetrics.txt"
     insert_size_histogram:
         type: File
         outputBinding:
-            glob: "InsertSizeHistogram.pdf"
+            glob: "$(inputs.cram.nameroot).InsertSizeHistogram.pdf"

--- a/definitions/tools/cram_to_bam.cwl
+++ b/definitions/tools/cram_to_bam.cwl
@@ -10,7 +10,7 @@ requirements:
     - class: DockerRequirement
       dockerPull: "mgibio/samtools-cwl:1.0.0"
 arguments:
-        ["-o", { valueFrom: $(runtime.outdir)/output.bam }]
+        ["-o", { valueFrom: $(runtime.outdir)/$(inputs.cram.nameroot).bam }]
 inputs:
     reference:
         type: string
@@ -26,4 +26,4 @@ outputs:
     bam:
         type: File
         outputBinding:
-            glob: "output.bam"
+            glob: "$(inputs.cram.nameroot).bam"

--- a/definitions/tools/samtools_flagstat.cwl
+++ b/definitions/tools/samtools_flagstat.cwl
@@ -9,7 +9,7 @@ requirements:
       ramMin: 4000
     - class: DockerRequirement
       dockerPull: "mgibio/samtools-cwl:1.0.0"
-stdout: flagstat.out
+stdout: "$(inputs.cram.basename).flagstat"
 inputs:
     cram:
         type: File

--- a/definitions/tools/verify_bam_id.cwl
+++ b/definitions/tools/verify_bam_id.cwl
@@ -5,7 +5,7 @@ class: CommandLineTool
 label: "verify BAM ID"
 baseCommand: "/usr/local/bin/verifyBamID"
 arguments:
-    ["--out", { valueFrom: $(runtime.outdir)/VerifyBamId }]
+    ["--out", { valueFrom: $(runtime.outdir)/$(inputs.bam.nameroot).VerifyBamId }]
 requirements:
     - class: ResourceRequirement
       ramMin: 4000
@@ -24,9 +24,9 @@ outputs:
     verify_bam_id_metrics:
         type: File
         outputBinding:
-            glob: "VerifyBamId.selfSM"
+            glob: "$(inputs.bam.nameroot).VerifyBamId.selfSM"
     verify_bam_id_depth:
         type: File
         outputBinding:
-            glob: "VerifyBamId.depthSM"
+            glob: "$(inputs.bam.nameroot).VerifyBamId.depthSM"
 


### PR DESCRIPTION
This should help distinguish which QC matches which alignments, especially in cases where more than one CRAM is present (e.g. somatic pipelines).