### PR TITLE
Use latest version of the vcf_annotation_tools-cwl docker image

### DIFF
--- a/definitions/tools/vcf_expression_annotator.cwl
+++ b/definitions/tools/vcf_expression_annotator.cwl
@@ -7,7 +7,7 @@ label: "add expression info to vcf"
 baseCommand: ["vcf-expression-annotator"]
 requirements:
     - class: DockerRequirement
-      dockerPull: "mgibio/vcf_annotation_tools-cwl:1.4.4"
+      dockerPull: "mgibio/vcf_annotation_tools-cwl:1.4.5"
 arguments:
     ["-o", { valueFrom: $(runtime.outdir)/annotated.expression.vcf.gz }]
 inputs:

--- a/definitions/tools/vcf_readcount_annotator.cwl
+++ b/definitions/tools/vcf_readcount_annotator.cwl
@@ -7,7 +7,7 @@ label: "add bam_readcount info to vcf"
 baseCommand: ["vcf-readcount-annotator"]
 requirements:
     - class: DockerRequirement
-      dockerPull: "mgibio/vcf_annotation_tools-cwl:1.4.4"
+      dockerPull: "mgibio/vcf_annotation_tools-cwl:1.4.5"
 arguments:
     ["-o", { valueFrom: $(runtime.outdir)/annotated.bam_readcount.vcf.gz }]
 inputs:


### PR DESCRIPTION
This version of the vcf-annotation-tools package adds a new fatal error to guard against an edge case where the combined bam-readcount output from snvs and indels might contains two entries for the same position (one from the snvs and one from the indels file). After we merge this in, we might encounter workflows where this situation occurs that would subsequently fail where they didn't fail before. If we encounter this situation I would like to change this fatal error to actually handle this case.

@jasonwalker80 given the above information, should we wait to merge this until after I get back from vacation? I would hate for workflows to fail for this reason while I'm not around to add handling for this case.