### PR TITLE
Upgrade pVACtools CWLs to latest version 1.1.5

### DIFF
--- a/definitions/pipelines/pvacseq.cwl
+++ b/definitions/pipelines/pvacseq.cwl
@@ -61,7 +61,7 @@ inputs:
         type: string?
     exclude_nas:
         type: boolean?
-    phased_proximal_variants_file:
+    phased_proximal_variants_vcf:
         type: File?
         secondaryFiles: ['.tbi']
     maximum_transcript_support_level:
@@ -180,7 +180,7 @@ steps:
             fasta_size: fasta_size
             downstream_sequence_length: downstream_sequence_length
             exclude_nas: exclude_nas
-            phased_proximal_variants_vcf: phased_proximal_variants_file
+            phased_proximal_variants_vcf: phased_proximal_variants_vcf
             maximum_transcript_support_level: maximum_transcript_support_level
             normal_cov: normal_cov
             tdna_cov: tdna_cov

--- a/definitions/pipelines/pvacseq.cwl
+++ b/definitions/pipelines/pvacseq.cwl
@@ -180,7 +180,7 @@ steps:
             fasta_size: fasta_size
             downstream_sequence_length: downstream_sequence_length
             exclude_nas: exclude_nas
-            phased_proximal_variants_file: phased_proximal_variants_file
+            phased_proximal_variants_vcf: phased_proximal_variants_file
             maximum_transcript_support_level: maximum_transcript_support_level
             normal_cov: normal_cov
             tdna_cov: tdna_cov

--- a/definitions/tools/pvacfuse.cwl
+++ b/definitions/tools/pvacfuse.cwl
@@ -10,7 +10,7 @@ baseCommand: [
 ]
 requirements:
     - class: DockerRequirement
-      dockerPull: "griffithlab/pvactools:1.1.4"
+      dockerPull: "griffithlab/pvactools:1.1.5"
 arguments:
     - position: 5
       valueFrom: $(runtime.outdir)

--- a/definitions/tools/pvacseq.cwl
+++ b/definitions/tools/pvacseq.cwl
@@ -7,7 +7,7 @@ label: "run pVACseq"
 baseCommand: ["pvacseq", "run"]
 requirements:
     - class: DockerRequirement
-      dockerPull: "griffithlab/pvactools:1.1.4"
+      dockerPull: "griffithlab/pvactools:1.1.5"
 arguments:
     - position: 5
       valueFrom: $(runtime.outdir)

--- a/definitions/tools/pvacvector.cwl
+++ b/definitions/tools/pvacvector.cwl
@@ -10,7 +10,7 @@ baseCommand: [
 ]
 requirements:
     - class: DockerRequirement
-      dockerPull: "griffithlab/pvactools:1.1.4"
+      dockerPull: "griffithlab/pvactools:1.1.5"
 arguments:
     - position: 5
       valueFrom: $(runtime.outdir)


### PR DESCRIPTION
This also fixes an incorrect reference to an input to pvacseq.cwl that I discovered buried in the travis-ci warnings. 