### PR TITLE
fixes cp error with mark_duplicates

### DIFF
--- a/definitions/tools/mark_duplicates_and_sort.cwl
+++ b/definitions/tools/mark_duplicates_and_sort.cwl
@@ -10,7 +10,7 @@ requirements:
       coresMin: 8
       ramMin: 40000
     - class: DockerRequirement
-      dockerPull: "zlskidmore/mark_dups_test:latest"
+      dockerPull: "mgibio/mark_duplicates-cwl:1.0.1"
 arguments:
     - position: 2
       valueFrom: $(runtime.cores)

--- a/definitions/tools/mark_duplicates_and_sort.cwl
+++ b/definitions/tools/mark_duplicates_and_sort.cwl
@@ -10,12 +10,14 @@ requirements:
       coresMin: 8
       ramMin: 40000
     - class: DockerRequirement
-      dockerPull: "mgibio/mark_duplicates-cwl:1.0.0"
+      dockerPull: "zlskidmore/mark_dups_test:latest"
 arguments:
     - position: 2
       valueFrom: $(runtime.cores)
     - position: 3
       valueFrom: $(runtime.outdir)/MarkedSorted.bam
+    - position: 4
+      valueFrom: "$(inputs.bam.nameroot).mark_dups_metrics.txt"
 inputs:
     bam:
         type: File
@@ -30,4 +32,4 @@ outputs:
     metrics_file:
         type: File
         outputBinding:
-            glob: "mark_dups_metrics.txt"
+            glob: "$(inputs.bam.nameroot).mark_dups_metrics.txt"


### PR DESCRIPTION
Recently encountered an error message in my workflows:
` /bin/cp: will not overwrite just-created '/gscmnt/gc2547/griffithlab/ebarnell/GTB24/variant_calling/08-0075-1086/mark_dups_metrics.txt' with '/cromwell-executions/somatic_exome.cwl/3ded19a4-f74e-479f-957a-d9c243274e1d/call-gatherer/inputs/1282502474/mark_dups_metrics.txt'`

This should resolve that issue, however it requires modifying the mgibio docker image to accept a 4th argument, something like:

```#!/bin/bash

set -o pipefail
set -o errexit

declare MD_BARCODE_TAG
if [ ! -z "${5}" ]; then
    MD_BARCODE_TAG="BARCODE_TAG=${5}"
    /usr/bin/java -Xmx16g -jar /opt/picard/picard.jar MarkDuplicates I=$1 O=/dev/stdout ASSUME_SORT_ORDER=queryname METRICS_FILE=$4 QUIET=true COMPRESSION_LEVEL=0 VALIDATION_STRINGENCY=LENIENT "${MD_BARCODE_TAG}" | /usr/bin/sambamba sort -t $2 -m 18G -o $3 /dev/stdin
else
    /usr/bin/java -Xmx16g -jar /opt/picard/picard.jar MarkDuplicates I=$1 O=/dev/stdout ASSUME_SORT_ORDER=queryname METRICS_FILE=$4 QUIET=true COMPRESSION_LEVEL=0 VALIDATION_STRINGENCY=LENIENT | /usr/bin/sambamba sort -t $2 -m 18G -o $3 /dev/stdin
fi```