### PR TITLE
adding the Cell Ranger analysis cwls

### DIFF
--- a/definitions/subworkflows/cellranger_mkfastq_and_count.cwl
+++ b/definitions/subworkflows/cellranger_mkfastq_and_count.cwl
@@ -6,15 +6,15 @@ label: "running cellranger mkfastq and count"
 
 inputs:
     bcl_directory:
-        type: string
+        type: Directory
     chemistry:
         type: string?
     reference:
-        type: string
+        type: Directory
     sample_name:
         type: string
     simple_sample_csv:
-        type: string
+        type: File
 
 steps:
     mkfastq:

--- a/definitions/subworkflows/cellranger_mkfastq_and_count.cwl
+++ b/definitions/subworkflows/cellranger_mkfastq_and_count.cwl
@@ -1,0 +1,48 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+label: "running cellranger mkfastq and count"
+
+inputs:
+    bcl_directory:
+        type: string
+    chemistry:
+        type: string
+    reference:
+        type: string
+    sample_name:
+        type: string
+    simple_sample_csv:
+        type: string
+    unique_id:
+        type: string
+
+steps:
+    mkfastq:
+        run: ../tools/cellranger_mkfastq.cwl
+        in:
+            bcl_directory: bcl_directory
+            simple_sample_csv: simple_sample_csv
+            unique_id: unique_id
+        out: [samplesheet_csv, fastq_dir]
+    count:
+        run: ../tools/cellranger_count.cwl
+        in: 
+            chemistry: chemistry
+            fastq_directory: mkfastq/fastq_dir
+            reference: reference
+            sample_name: sample_name
+            unique_id: unique_id
+        out: [out_dir]
+
+outputs:
+    counts_out_dir:
+        type: Directory
+        outputSource: count/out_dir
+    fastqs:
+        type: Directory
+        outputSource: mkfastq/fastq_dir
+    samplesheet:
+        type: File
+        outputSource: mkfastq/samplesheet_csv

--- a/definitions/subworkflows/cellranger_mkfastq_and_count.cwl
+++ b/definitions/subworkflows/cellranger_mkfastq_and_count.cwl
@@ -15,8 +15,6 @@ inputs:
         type: string
     simple_sample_csv:
         type: string
-    unique_id:
-        type: string
 
 steps:
     mkfastq:
@@ -24,7 +22,6 @@ steps:
         in:
             bcl_directory: bcl_directory
             simple_sample_csv: simple_sample_csv
-            unique_id: unique_id
         out: [samplesheet_csv, fastq_dir]
     count:
         run: ../tools/cellranger_count.cwl
@@ -33,7 +30,6 @@ steps:
             fastq_directory: mkfastq/fastq_dir
             reference: reference
             sample_name: sample_name
-            unique_id: unique_id
         out: [out_dir]
 
 outputs:

--- a/definitions/subworkflows/cellranger_mkfastq_and_count.cwl
+++ b/definitions/subworkflows/cellranger_mkfastq_and_count.cwl
@@ -8,7 +8,7 @@ inputs:
     bcl_directory:
         type: string
     chemistry:
-        type: string
+        type: string?
     reference:
         type: string
     sample_name:

--- a/definitions/tools/cellranger_count.cwl
+++ b/definitions/tools/cellranger_count.cwl
@@ -47,4 +47,4 @@ outputs:
     out_dir:
         type: Directory
         outputBinding:
-            glob: "$(inputs.unique_id)/outs/"
+            glob: "cellranger_output/outs/"

--- a/definitions/tools/cellranger_count.cwl
+++ b/definitions/tools/cellranger_count.cwl
@@ -4,7 +4,7 @@ cwlVersion: v1.0
 class: CommandLineTool
 label: "Run Cell Ranger Count"
 
-baseCommand: ["cellranger", "count", "--localmem=64", "--localcores=8"]
+baseCommand: ["cellranger", "count", "--localmem=64", "--localcores=8", "--id=cellranger_output"]
 
 requirements:
     - class: DockerRequirement
@@ -43,13 +43,6 @@ inputs:
             position: 4
             separate: false
         doc: "Sample name, must be same as name specified in sample sheet in previous mkfastq step"
-    unique_id:
-        type: string
-        inputBinding:
-           prefix: --id=
-           position: 5
-           separate: false
-        doc: "Unique name for the run"
 outputs:
     out_dir:
         type: Directory

--- a/definitions/tools/cellranger_count.cwl
+++ b/definitions/tools/cellranger_count.cwl
@@ -1,0 +1,57 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: "Run Cell Ranger Count"
+
+baseCommand: ["cellranger", "count", "--localmem=64", "--localcores=8"]
+
+requirements:
+    - class: DockerRequirement
+      dockerPull: "registry.gsc.wustl.edu/ebelter/cellranger:2.2.0"
+    - class: ResourceRequirement
+      ramMin: 64000
+      coresMin: 8
+
+inputs:
+    chemistry:
+        type: string?
+        inputBinding:
+            prefix: --chemistry=
+            position: 1
+            separate: false
+        default: "auto"
+        doc: "Assay configuration used, default 'auto' should usually work without issue"
+    fastq_directory:
+        type: Directory
+        inputBinding:
+           prefix: --fastqs=
+           position: 2
+           separate: false
+        doc: "Directory containing fastq files"
+    reference:
+        type: string
+        inputBinding:
+            prefix: --transcriptome=
+            position: 3
+            separate: false
+        doc: "Transcriptome reference compatible with input species and Cell Ranger"
+    sample_name:
+        type: string
+        inputBinding:
+            prefix: --sample=
+            position: 4
+            separate: false
+        doc: "Sample name, must be same as name specified in sample sheet in previous mkfastq step"
+    unique_id:
+        type: string
+        inputBinding:
+           prefix: --id=
+           position: 5
+           separate: false
+        doc: "Unique name for the run"
+outputs:
+    out_dir:
+        type: Directory
+        outputBinding:
+            glob: "$(inputs.unique_id)/outs/"

--- a/definitions/tools/cellranger_count.cwl
+++ b/definitions/tools/cellranger_count.cwl
@@ -30,7 +30,7 @@ inputs:
            separate: false
         doc: "Directory containing fastq files"
     reference:
-        type: string
+        type: Directory
         inputBinding:
             prefix: --transcriptome=
             position: 3

--- a/definitions/tools/cellranger_mkfastq.cwl
+++ b/definitions/tools/cellranger_mkfastq.cwl
@@ -1,0 +1,47 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: "Run Cell Ranger mkfastq"
+
+baseCommand: ["cellranger", "mkfastq", "--localmem=64", "--localcores=8"]
+
+requirements:
+    - class: DockerRequirement
+      dockerPull: "registry.gsc.wustl.edu/ebelter/cellranger:2.2.0"
+    - class: ResourceRequirement
+      ramMin: 64000
+      coresMin: 8
+
+inputs:
+    bcl_directory:
+        type: string
+        inputBinding:
+            prefix: --run=
+            position: 1
+            separate: false
+        doc: "Directory of the Illumina BCL run"
+    unique_id:
+        type: string
+        inputBinding:
+            prefix: --id=
+            position: 2
+            separate: false
+        doc: "Unique name for the run"
+    simple_sample_csv:  
+        type: string
+        inputBinding:
+            prefix: --simple-csv=
+            position: 3
+            separate: false
+        doc: "input simple sample CSV used to describe the way to demultiplex the flowcell"
+
+outputs:
+    samplesheet_csv:
+        type: File
+        outputBinding:
+            glob: "$(inputs.unique_id)/outs/input_samplesheet.csv"
+    fastq_dir:
+        type: Directory
+        outputBinding:
+            glob: "$(inputs.unique_id)/outs/fastq_path/"

--- a/definitions/tools/cellranger_mkfastq.cwl
+++ b/definitions/tools/cellranger_mkfastq.cwl
@@ -33,8 +33,8 @@ outputs:
     samplesheet_csv:
         type: File
         outputBinding:
-            glob: "$(inputs.unique_id)/outs/input_samplesheet.csv"
+            glob: "cellranger_output/outs/input_samplesheet.csv"
     fastq_dir:
         type: Directory
         outputBinding:
-            glob: "$(inputs.unique_id)/outs/fastq_path/"
+            glob: "cellranger_output/outs/fastq_path/"

--- a/definitions/tools/cellranger_mkfastq.cwl
+++ b/definitions/tools/cellranger_mkfastq.cwl
@@ -15,14 +15,14 @@ requirements:
 
 inputs:
     bcl_directory:
-        type: string
+        type: Directory
         inputBinding:
             prefix: --run=
             position: 1
             separate: false
         doc: "Directory of the Illumina BCL run"
     simple_sample_csv:  
-        type: string
+        type: File
         inputBinding:
             prefix: --simple-csv=
             position: 3

--- a/definitions/tools/cellranger_mkfastq.cwl
+++ b/definitions/tools/cellranger_mkfastq.cwl
@@ -4,7 +4,7 @@ cwlVersion: v1.0
 class: CommandLineTool
 label: "Run Cell Ranger mkfastq"
 
-baseCommand: ["cellranger", "mkfastq", "--localmem=64", "--localcores=8"]
+baseCommand: ["cellranger", "mkfastq", "--localmem=64", "--localcores=8", "--id=cellranger_output"]
 
 requirements:
     - class: DockerRequirement
@@ -21,13 +21,6 @@ inputs:
             position: 1
             separate: false
         doc: "Directory of the Illumina BCL run"
-    unique_id:
-        type: string
-        inputBinding:
-            prefix: --id=
-            position: 2
-            separate: false
-        doc: "Unique name for the run"
     simple_sample_csv:  
         type: string
         inputBinding:

--- a/definitions/tools/cellranger_vdj.cwl
+++ b/definitions/tools/cellranger_vdj.cwl
@@ -45,4 +45,5 @@ inputs:
 outputs:
     out_dir:
         type: Directory
-        glob: "$(inputs.unique_id)/outs/"
+        outputBinding:
+            glob: "$(inputs.unique_id)/outs/"

--- a/definitions/tools/cellranger_vdj.cwl
+++ b/definitions/tools/cellranger_vdj.cwl
@@ -40,7 +40,7 @@ inputs:
         inputBinding:
             prefix: --id=
             position: 4
-            separate: falsei
+            separate: false
         doc: "Unique name for the run"
 outputs:
     out_dir:

--- a/definitions/tools/cellranger_vdj.cwl
+++ b/definitions/tools/cellranger_vdj.cwl
@@ -45,4 +45,4 @@ inputs:
 outputs:
     out_dir:
         type: Directory
-        glob: "$(inputs.unique_id)/outs/"]
+        glob: "$(inputs.unique_id)/outs/"

--- a/definitions/tools/cellranger_vdj.cwl
+++ b/definitions/tools/cellranger_vdj.cwl
@@ -1,0 +1,48 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: "Run Cell Ranger V(D)J"
+
+baseCommand: ["cellranger", "vdj", "--localmem=64", "--localcores=8"]
+
+requirements:
+    - class: DockerRequirement
+      dockerPull: "registry.gsc.wustl.edu/ebelter/cellranger:2.2.0"
+    - class: ResourceRequirement
+      ramMin: 64000
+      coresMin: 8
+
+inputs:
+    fastq_directory:
+        type: Directory
+        inputBinding:
+            prefix: --fastqs=
+            position: 1
+            separate: false
+        doc: "Directory containing fastq files"
+    reference:
+        type: string
+        inputBinding:
+            prefix: --reference=
+            position: 2
+            separate: false
+        doc: "Transcriptome reference compatible with input species and Cell Ranger VDJ"
+    sample_name:
+        type: string
+        inputBinding:
+            prefix: --sample=
+            position: 3
+            separate: false
+        doc: "Sample name, must be same as name specified in sample sheet in previous mkfastq step" 
+    unique_id:
+        type: string
+        inputBinding:
+            prefix: --id=
+            position: 4
+            separate: falsei
+        doc: "Unique name for the run"
+outputs:
+    out_dir:
+        type: Directory
+        glob: "$(inputs.unique_id)/outs/"]

--- a/definitions/tools/cellranger_vdj.cwl
+++ b/definitions/tools/cellranger_vdj.cwl
@@ -22,7 +22,7 @@ inputs:
             separate: false
         doc: "Directory containing fastq files"
     reference:
-        type: string
+        type: Directory
         inputBinding:
             prefix: --reference=
             position: 2

--- a/definitions/tools/cellranger_vdj.cwl
+++ b/definitions/tools/cellranger_vdj.cwl
@@ -39,4 +39,4 @@ outputs:
     out_dir:
         type: Directory
         outputBinding:
-            glob: "$(inputs.unique_id)/outs/"
+            glob: "cellranger_output/outs/"

--- a/definitions/tools/cellranger_vdj.cwl
+++ b/definitions/tools/cellranger_vdj.cwl
@@ -4,7 +4,7 @@ cwlVersion: v1.0
 class: CommandLineTool
 label: "Run Cell Ranger V(D)J"
 
-baseCommand: ["cellranger", "vdj", "--localmem=64", "--localcores=8"]
+baseCommand: ["cellranger", "vdj", "--localmem=64", "--localcores=8", "--id=cellranger_output"]
 
 requirements:
     - class: DockerRequirement
@@ -35,13 +35,6 @@ inputs:
             position: 3
             separate: false
         doc: "Sample name, must be same as name specified in sample sheet in previous mkfastq step" 
-    unique_id:
-        type: string
-        inputBinding:
-            prefix: --id=
-            position: 4
-            separate: false
-        doc: "Unique name for the run"
 outputs:
     out_dir:
         type: Directory


### PR DESCRIPTION
I have the different CWLs I have been using to run different single cell cell ranger analysis. For `cellranger mkfastq`, `cellranger count`, `cellranger vdj`. This is currently using Eddie’s docker image for cellranger v2.2.0 which is hosted on the local private registry.

I also created a subworkflow that currently runs the `mkfastq` and `count` steps for a single sample. I have ran it using the tiny-bcl test data that can be downloaded from 10x Genomics website in about 15 minutes.
