### PR TITLE
Default value 'false' for Panel of Normals Mutect parameter.

### DIFF
--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -71,6 +71,7 @@ inputs:
         type: int
     mutect_artifact_detection_mode:
         type: boolean
+        default: false
     mutect_max_alt_allele_in_normal_fraction:
         type: float?
     mutect_max_alt_alleles_in_normal_count:


### PR DESCRIPTION
mutect_artifact_detection_mode is false unless otherwise defined at true. This parameter is only set to true when creating a panel of normals.