### PR TITLE
Use the final_name to distinguish intermediate processes, too.

### DIFF
--- a/definitions/subworkflows/bam_to_bqsr.cwl
+++ b/definitions/subworkflows/bam_to_bqsr.cwl
@@ -51,6 +51,7 @@ steps:
         run: ../tools/merge_bams_samtools.cwl
         in:
             bams: align/tagged_bam
+            name: final_name
         out:
             [merged_bam]
     name_sort:

--- a/definitions/tools/merge_bams_samtools.cwl
+++ b/definitions/tools/merge_bams_samtools.cwl
@@ -10,7 +10,7 @@ requirements:
       coresMin: 4
     - class: DockerRequirement
       dockerPull: "mgibio/samtools-cwl:1.0.0"
-arguments: ["merged.bam"]
+arguments: ["$(inputs.name).merged.bam"]
 inputs:
     bams:
         type: File[]
@@ -20,5 +20,5 @@ outputs:
     merged_bam:
         type: File
         outputBinding:
-            glob: "merged.bam"
+            glob: "$(inputs.name).merged.bam"
 

--- a/definitions/tools/name_sort.cwl
+++ b/definitions/tools/name_sort.cwl
@@ -8,7 +8,7 @@ arguments:
     ["-t", { valueFrom: $(runtime.cores) },
     "-m", "12G",
     "-n",
-    "-o", { valueFrom: $(runtime.outdir)/NameSorted.bam }]
+    "-o", { valueFrom: "$(inputs.bam.nameroot).NameSorted.bam" }]
 requirements:
     - class: ResourceRequirement
       ramMin: 13000
@@ -24,4 +24,4 @@ outputs:
     name_sorted_bam:
         type: File
         outputBinding:
-            glob: "NameSorted.bam"
+            glob: "$(inputs.bam.nameroot).NameSorted.bam"


### PR DESCRIPTION
Since the mark duplicate metrics are saved, we'll want to make sure the files have unique names in cases where multiple alignments are run in a single workflow.

This takes #516 one step further.