### PR TITLE
Define the name input that we're using.

### DIFF
--- a/definitions/tools/merge_bams_samtools.cwl
+++ b/definitions/tools/merge_bams_samtools.cwl
@@ -16,6 +16,8 @@ inputs:
         type: File[]
         inputBinding:
             position: 1
+    name:
+        type: string
 outputs:
     merged_bam:
         type: File


### PR DESCRIPTION
The bam_to_bqsr subworkflow is passing this input, and it is being referenced.  CWL validation apparently doesn't require it to be defined to do these things, but running the workflow does.