### PR TITLE
Set a default name for the final cram.

### DIFF
--- a/definitions/subworkflows/bam_to_bqsr.cwl
+++ b/definitions/subworkflows/bam_to_bqsr.cwl
@@ -22,6 +22,7 @@ inputs:
         secondaryFiles: [.tbi]
     final_name:
         type: string?
+        default: 'final.cram'
     mills:
         type: File
         secondaryFiles: [.tbi]


### PR DESCRIPTION
This property is required for the merge step, so making it optional here requires a default.

(This situation triggers warnings but not errors in `cwltool --validate`.)