### PR TITLE
Allow for some overhead between Java and job memory requests.

### DIFF
--- a/definitions/tools/bqsr.cwl
+++ b/definitions/tools/bqsr.cwl
@@ -13,7 +13,7 @@ arguments:
     "-nct", "4"]
 requirements:
     - class: ResourceRequirement
-      ramMin: 16000
+      ramMin: 18000
     - class: DockerRequirement
       dockerPull: "mgibio/gatk-cwl:3.6.0"
 inputs:

--- a/definitions/tools/collect_alignment_summary_metrics.cwl
+++ b/definitions/tools/collect_alignment_summary_metrics.cwl
@@ -8,7 +8,7 @@ arguments:
     ["OUTPUT=", { valueFrom: $(runtime.outdir)/$(inputs.cram.nameroot).AlignmentSummaryMetrics.txt }]
 requirements:
     - class: ResourceRequirement
-      ramMin: 16000
+      ramMin: 18000
     - class: DockerRequirement
       dockerPull: "mgibio/picard-cwl:2.18.1"
 inputs:

--- a/definitions/tools/collect_gc_bias_metrics.cwl
+++ b/definitions/tools/collect_gc_bias_metrics.cwl
@@ -10,7 +10,7 @@ arguments:
     "S=", { valueFrom: $(runtime.outdir)/GcBiasMetricsSummary.txt } ]
 requirements:
     - class: ResourceRequirement
-      ramMin: 16000
+      ramMin: 18000
     - class: DockerRequirement
       dockerPull: mgibio/cle
 inputs:

--- a/definitions/tools/collect_hs_metrics.cwl
+++ b/definitions/tools/collect_hs_metrics.cwl
@@ -8,7 +8,7 @@ arguments:
     ["O=", { valueFrom: $(runtime.outdir)/$(inputs.cram.nameroot).$(inputs.output_prefix)-HsMetrics.txt }]
 requirements:
     - class: ResourceRequirement
-      ramMin: 16000
+      ramMin: 18000
     - class: InlineJavascriptRequirement
     - class: DockerRequirement
       dockerPull: "mgibio/picard-cwl:2.18.1"

--- a/definitions/tools/collect_hs_metrics.cwl
+++ b/definitions/tools/collect_hs_metrics.cwl
@@ -3,12 +3,12 @@
 cwlVersion: v1.0
 class: CommandLineTool
 label: "collect HS metrics"
-baseCommand: ["/usr/bin/java", "-Xmx16g", "-jar", "/usr/picard/picard.jar", "CollectHsMetrics"]
+baseCommand: ["/usr/bin/java", "-Xmx32g", "-jar", "/usr/picard/picard.jar", "CollectHsMetrics"]
 arguments:
     ["O=", { valueFrom: $(runtime.outdir)/$(inputs.cram.nameroot).$(inputs.output_prefix)-HsMetrics.txt }]
 requirements:
     - class: ResourceRequirement
-      ramMin: 18000
+      ramMin: 36000
     - class: InlineJavascriptRequirement
     - class: DockerRequirement
       dockerPull: "mgibio/picard-cwl:2.18.1"

--- a/definitions/tools/collect_insert_size_metrics.cwl
+++ b/definitions/tools/collect_insert_size_metrics.cwl
@@ -9,7 +9,7 @@ arguments:
     "H=", { valueFrom: $(runtime.outdir)/$(inputs.cram.nameroot).InsertSizeHistogram.pdf }]
 requirements:
     - class: ResourceRequirement
-      ramMin: 16000
+      ramMin: 18000
     - class: DockerRequirement
       dockerPull: "mgibio/picard-cwl:2.18.1"
 inputs:

--- a/definitions/tools/collect_wgs_metrics.cwl
+++ b/definitions/tools/collect_wgs_metrics.cwl
@@ -8,7 +8,7 @@ arguments:
     ["O=", { valueFrom: $(runtime.outdir)/WgsMetrics.txt }]
 requirements:
     - class: ResourceRequirement
-      ramMin: 16000
+      ramMin: 18000
     - class: DockerRequirement
       dockerPull: mgibio/cle
 inputs:

--- a/definitions/tools/combine_variants.cwl
+++ b/definitions/tools/combine_variants.cwl
@@ -6,7 +6,7 @@ label: "CombineVariants (GATK 3.6)"
 baseCommand: ["/usr/bin/java", "-Xmx8g", "-jar", "/opt/GenomeAnalysisTK.jar", "-T", "CombineVariants"]
 requirements:
     - class: ResourceRequirement
-      ramMin: 8000
+      ramMin: 9000
       tmpdirMin: 25000
     - class: DockerRequirement
       dockerPull: mgibio/cle

--- a/definitions/tools/docm_gatk_haplotype_caller.cwl
+++ b/definitions/tools/docm_gatk_haplotype_caller.cwl
@@ -6,7 +6,7 @@ label: "HaplotypeCaller (GATK 3.6)"
 baseCommand: ["/usr/bin/java", "-Xmx8g", "-jar", "/opt/GenomeAnalysisTK.jar", "-T", "HaplotypeCaller"]
 requirements:
     - class: ResourceRequirement
-      ramMin: 8000
+      ramMin: 9000
     - class: DockerRequirement
       dockerPull: "mgibio/gatk-cwl:3.6.0"
 arguments:

--- a/definitions/tools/downsample.cwl
+++ b/definitions/tools/downsample.cwl
@@ -9,7 +9,7 @@ arguments:
     ["OUTPUT=", { valueFrom: $(runtime.outdir)/downsampled.bam }]
 requirements:
     - class: ResourceRequirement
-      ramMin: 16000
+      ramMin: 18000
     - class: DockerRequirement
       dockerPull: "mgibio/cle"
 inputs:

--- a/definitions/tools/gatk_genotypegvcfs.cwl
+++ b/definitions/tools/gatk_genotypegvcfs.cwl
@@ -6,7 +6,7 @@ label: "GATK HaplotypeCaller"
 baseCommand: ["/usr/bin/java", "-Xmx8g", "-jar", "/opt/GenomeAnalysisTK.jar", "-T", "GenotypeGVCFs"]
 requirements:
     - class: ResourceRequirement
-      ramMin: 8000
+      ramMin: 9000
     - class: InlineJavascriptRequirement
     - class: DockerRequirement
       dockerPull: "mgibio/gatk-cwl:3.5.0"

--- a/definitions/tools/germline_combine_variants.cwl
+++ b/definitions/tools/germline_combine_variants.cwl
@@ -6,7 +6,7 @@ label: "CombineVariants (GATK 3.6)"
 baseCommand: ["/usr/bin/java", "-Xmx8g", "-jar", "/opt/GenomeAnalysisTK.jar", "-T", "CombineVariants"]
 requirements:
     - class: ResourceRequirement
-      ramMin: 8000
+      ramMin: 9000
       tmpdirMin: 25000
     - class: DockerRequirement
       dockerPull: "mgibio/gatk-cwl:3.6.0"

--- a/definitions/tools/normalize_variants.cwl
+++ b/definitions/tools/normalize_variants.cwl
@@ -6,7 +6,7 @@ label: "Normalize variants"
 baseCommand: ["/usr/bin/java", "-Xmx8g", "-jar", "/opt/GenomeAnalysisTK.jar", "-T", "LeftAlignAndTrimVariants"]
 requirements:
     - class: ResourceRequirement
-      ramMin: 8000
+      ramMin: 9000
     - class: DockerRequirement
       dockerPull: "mgibio/gatk-cwl:3.6.0"
 arguments:

--- a/definitions/tools/pon_combine_variants.cwl
+++ b/definitions/tools/pon_combine_variants.cwl
@@ -6,7 +6,7 @@ label: "CombineVariants for Panel of Normals"
 baseCommand: ["/usr/bin/java", "-Xmx8g", "-jar", "/opt/GenomeAnalysisTK.jar", "-T", "CombineVariants"]
 requirements:
     - class: ResourceRequirement
-      ramMin: 8000
+      ramMin: 9000
       tmpdirMin: 25000
     - class: DockerRequirement
       dockerPull: mgibio/cle


### PR DESCRIPTION
Since 16000 MB < 16 GB, this was previously telling the JVM to use more memory than was available!