### PR TITLE
updating cellranger to 3.0.1

### DIFF
--- a/definitions/tools/cellranger_count.cwl
+++ b/definitions/tools/cellranger_count.cwl
@@ -4,11 +4,11 @@ cwlVersion: v1.0
 class: CommandLineTool
 label: "Run Cell Ranger Count"
 
-baseCommand: ["cellranger", "count", "--localmem=64", "--localcores=8", "--id=cellranger_output"]
+baseCommand: ["/opt/cellranger-3.0.1/cellranger", "count", "--localmem=64", "--localcores=8", "--id=cellranger_output"]
 
 requirements:
     - class: DockerRequirement
-      dockerPull: "registry.gsc.wustl.edu/ebelter/cellranger:2.2.0"
+      dockerPull: "registry.gsc.wustl.edu/mgi/cellranger:3.0.1"
     - class: ResourceRequirement
       ramMin: 64000
       coresMin: 8

--- a/definitions/tools/cellranger_mkfastq.cwl
+++ b/definitions/tools/cellranger_mkfastq.cwl
@@ -4,11 +4,11 @@ cwlVersion: v1.0
 class: CommandLineTool
 label: "Run Cell Ranger mkfastq"
 
-baseCommand: ["cellranger", "mkfastq", "--localmem=64", "--localcores=8", "--id=cellranger_output"]
+baseCommand: ["/opt/cellranger-3.0.1/cellranger", "mkfastq", "--localmem=64", "--localcores=8", "--id=cellranger_output"]
 
 requirements:
     - class: DockerRequirement
-      dockerPull: "registry.gsc.wustl.edu/ebelter/cellranger:2.2.0"
+      dockerPull: "registry.gsc.wustl.edu/mgi/cellranger:3.0.1"
     - class: ResourceRequirement
       ramMin: 64000
       coresMin: 8

--- a/definitions/tools/cellranger_vdj.cwl
+++ b/definitions/tools/cellranger_vdj.cwl
@@ -4,11 +4,11 @@ cwlVersion: v1.0
 class: CommandLineTool
 label: "Run Cell Ranger V(D)J"
 
-baseCommand: ["cellranger", "vdj", "--localmem=64", "--localcores=8", "--id=cellranger_output"]
+baseCommand: ["/opt/cellranger-3.0.1/cellranger", "vdj", "--localmem=64", "--localcores=8", "--id=cellranger_output"]
 
 requirements:
     - class: DockerRequirement
-      dockerPull: "registry.gsc.wustl.edu/ebelter/cellranger:2.2.0"
+      dockerPull: "registry.gsc.wustl.edu/mgi/cellranger:3.0.1"
     - class: ResourceRequirement
       ramMin: 64000
       coresMin: 8


### PR DESCRIPTION
updating to the latest version of cellranger. `cellranger` is not added to the path in the new images so have to specify the installation location