### PR TITLE
Vep everything flag

### DIFF
--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -63,7 +63,7 @@ inputs:
         type: File
         secondaryFiles: [.tbi]
     vep_cache_dir:
-        type: string?
+        type: string
     synonyms_file:
         type: File?
     annotate_coding_only:

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -94,9 +94,6 @@ inputs:
     custom_gnomad_vcf:
         type: File?
         secondaryFiles: [.tbi]
-    vep_everything_flag:
-        type: boolean?
-        default: true
 outputs:
     mutect_unfiltered_vcf:
         type: File
@@ -240,7 +237,6 @@ steps:
             reference: reference
             custom_gnomad_vcf: custom_gnomad_vcf
             pick: vep_pick
-            everything: vep_everything_flag
         out:
             [annotated_vcf, vep_summary]
     tumor_cram_to_bam:

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -68,8 +68,6 @@ inputs:
         type: File?
     annotate_coding_only:
         type: boolean?
-    hgvs_annotation:
-        type: boolean?
     vep_pick:
         type:
             - "null"
@@ -96,6 +94,9 @@ inputs:
     custom_gnomad_vcf:
         type: File?
         secondaryFiles: [.tbi]
+    vep_everything_flag:
+        type: boolean?
+        default: true
 outputs:
     mutect_unfiltered_vcf:
         type: File
@@ -236,10 +237,10 @@ steps:
             cache_dir: vep_cache_dir
             synonyms_file: synonyms_file
             coding_only: annotate_coding_only
-            hgvs: hgvs_annotation
             reference: reference
             custom_gnomad_vcf: custom_gnomad_vcf
             pick: vep_pick
+            everything: vep_everything_flag
         out:
             [annotated_vcf, vep_summary]
     tumor_cram_to_bam:

--- a/definitions/pipelines/exome.cwl
+++ b/definitions/pipelines/exome.cwl
@@ -65,9 +65,6 @@ inputs:
     annotate_coding_only:
         type: boolean?
         default: true
-    vep_everything_flag:
-        type: boolean?
-        default: true
     vep_pick:
         type:
             - "null"
@@ -207,7 +204,6 @@ steps:
             vep_to_table_fields: vep_to_table_fields
             sample_name: sample_name
             docm_vcf: docm_vcf
-            vep_everything_flag: vep_everything_flag
             custom_gnomad_vcf: custom_gnomad_vcf
             readcount_minimum_mapping_quality: readcount_minimum_mapping_quality
             readcount_minimum_base_quality: readcount_minimum_base_quality

--- a/definitions/pipelines/exome.cwl
+++ b/definitions/pipelines/exome.cwl
@@ -59,13 +59,13 @@ inputs:
         type: float?
         default: 0.001
     vep_cache_dir:
-        type: string?
+        type: string
     synonyms_file:
         type: File?
     annotate_coding_only:
         type: boolean?
         default: true
-    hgvs_annotation:
+    vep_everything_flag:
         type: boolean?
         default: true
     vep_pick:
@@ -207,7 +207,7 @@ steps:
             vep_to_table_fields: vep_to_table_fields
             sample_name: sample_name
             docm_vcf: docm_vcf
-            hgvs_annotation: hgvs_annotation
+            vep_everything_flag: vep_everything_flag
             custom_gnomad_vcf: custom_gnomad_vcf
             readcount_minimum_mapping_quality: readcount_minimum_mapping_quality
             readcount_minimum_base_quality: readcount_minimum_base_quality

--- a/definitions/pipelines/germline_exome.cwl
+++ b/definitions/pipelines/germline_exome.cwl
@@ -51,12 +51,10 @@ inputs:
                 type: array
                 items: string
     vep_cache_dir:
-        type: string?
+        type: string
     synonyms_file:
         type: File?
     annotate_coding_only:
-        type: boolean?
-    hgvs_annotation:
         type: boolean?
     custom_gnomad_vcf:
         type: File?
@@ -68,6 +66,9 @@ inputs:
     custom_clinvar_vcf:
         type: File?
         secondaryFiles: [.tbi]
+    vep_everything_flag:
+        type: boolean?
+        default: true
 outputs:
     cram:
         type: File
@@ -189,9 +190,9 @@ steps:
             vep_cache_dir: vep_cache_dir
             synonyms_file: synonyms_file
             annotate_coding_only: annotate_coding_only
-            hgvs: hgvs_annotation
             custom_gnomad_vcf: custom_gnomad_vcf
             limit_variant_intervals: target_intervals
             custom_clinvar_vcf: custom_clinvar_vcf
+            vep_everything_flag: vep_everything_flag
         out:
             [gvcf, final_vcf, coding_vcf, limited_vcf, vep_summary]

--- a/definitions/pipelines/germline_exome.cwl
+++ b/definitions/pipelines/germline_exome.cwl
@@ -66,9 +66,6 @@ inputs:
     custom_clinvar_vcf:
         type: File?
         secondaryFiles: [.tbi]
-    vep_everything_flag:
-        type: boolean?
-        default: true
 outputs:
     cram:
         type: File
@@ -193,6 +190,5 @@ steps:
             custom_gnomad_vcf: custom_gnomad_vcf
             limit_variant_intervals: target_intervals
             custom_clinvar_vcf: custom_clinvar_vcf
-            vep_everything_flag: vep_everything_flag
         out:
             [gvcf, final_vcf, coding_vcf, limited_vcf, vep_summary]

--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -270,7 +270,7 @@ steps:
             gvcf_gq_bands: gvcf_gq_bands
             intervals: intervals
             contamination_fraction: extract_freemix/freemix_score
-            cache_dir: vep_cache_dir
+            vep_cache_dir: vep_cache_dir
             synonyms_file: synonyms_file
             coding_only: coding_only
             custom_gnomad_vcf: custom_gnomad_vcf

--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -88,9 +88,6 @@ inputs:
         type: boolean?
     smoove_exclude_regions:
         type: File?
-    vep_everything_flag:
-        type: boolean?
-        default: true
 outputs:
     cram:
         type: File
@@ -276,7 +273,6 @@ steps:
             custom_gnomad_vcf: custom_gnomad_vcf
             limit_variant_intervals: variant_reporting_intervals
             custom_clinvar_vcf: custom_clinvar_vcf
-            vep_everything_flag: vep_everything_flag
         out:
             [gvcf, final_vcf, coding_vcf, limited_vcf, vep_summary]
     variant_callers:

--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -43,12 +43,10 @@ inputs:
     variant_reporting_intervals:
         type: File
     vep_cache_dir:
-        type: string?
+        type: string
     synonyms_file:
         type: File?
     coding_only:
-        type: boolean?
-    hgvs_annotation:
         type: boolean?
     custom_gnomad_vcf:
         type: File?
@@ -90,6 +88,9 @@ inputs:
         type: boolean?
     smoove_exclude_regions:
         type: File?
+    vep_everything_flag:
+        type: boolean?
+        default: true
 outputs:
     cram:
         type: File
@@ -272,10 +273,10 @@ steps:
             cache_dir: vep_cache_dir
             synonyms_file: synonyms_file
             coding_only: coding_only
-            hgvs: hgvs_annotation
             custom_gnomad_vcf: custom_gnomad_vcf
             limit_variant_intervals: variant_reporting_intervals
             custom_clinvar_vcf: custom_clinvar_vcf
+            vep_everything_flag: vep_everything_flag
         out:
             [gvcf, final_vcf, coding_vcf, limited_vcf, vep_summary]
     variant_callers:

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -98,12 +98,10 @@ inputs:
         type: File
         secondaryFiles: [.tbi]
     vep_cache_dir:
-        type: string?
+        type: string
     synonyms_file:
         type: File?
     annotate_coding_only:
-        type: boolean?
-    hgvs_annotation:
         type: boolean?
     vep_pick:
         type:
@@ -125,6 +123,9 @@ inputs:
     custom_gnomad_vcf:
         type: File?
         secondaryFiles: [.tbi]
+    vep_everything_flag:
+        type: boolean?
+        default: true
 outputs:
     tumor_cram:
         type: File
@@ -368,13 +369,13 @@ steps:
             vep_cache_dir: vep_cache_dir
             synonyms_file: synonyms_file
             annotate_coding_only: annotate_coding_only
-            hgvs_annotation: hgvs_annotation
             vep_pick: vep_pick
             cle_vcf_filter: cle_vcf_filter
             variants_to_table_fields: variants_to_table_fields
             variants_to_table_genotype_fields: variants_to_table_genotype_fields
             vep_to_table_fields: vep_to_table_fields
             custom_gnomad_vcf: custom_gnomad_vcf
+            vep_everything_flag: vep_everything_flag
         out:
             [mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, docm_unfiltered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_bam_readcount_tsv, normal_bam_readcount_tsv]
     cnvkit:

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -123,9 +123,6 @@ inputs:
     custom_gnomad_vcf:
         type: File?
         secondaryFiles: [.tbi]
-    vep_everything_flag:
-        type: boolean?
-        default: true
 outputs:
     tumor_cram:
         type: File
@@ -375,7 +372,6 @@ steps:
             variants_to_table_genotype_fields: variants_to_table_genotype_fields
             vep_to_table_fields: vep_to_table_fields
             custom_gnomad_vcf: custom_gnomad_vcf
-            vep_everything_flag: vep_everything_flag
         out:
             [mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, docm_unfiltered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_bam_readcount_tsv, normal_bam_readcount_tsv]
     cnvkit:

--- a/definitions/pipelines/tumor_only_detect_variants.cwl
+++ b/definitions/pipelines/tumor_only_detect_variants.cwl
@@ -34,7 +34,7 @@ inputs:
         type: float?
         default: 0.001
     vep_cache_dir:
-        type: string?
+        type: string
     synonyms_file:
         type: File?
     coding_only:

--- a/definitions/pipelines/tumor_only_detect_variants.cwl
+++ b/definitions/pipelines/tumor_only_detect_variants.cwl
@@ -66,9 +66,6 @@ inputs:
         type: int?
     readcount_minimum_base_quality:
         type: int?
-    vep_everything_flag:
-        type: boolean?
-        default: true
 outputs:
     varscan_vcf:
         type: File
@@ -136,7 +133,6 @@ steps:
             reference: reference
             custom_gnomad_vcf: custom_gnomad_vcf
             pick: vep_pick
-            everything: vep_everything_flag
         out:
             [annotated_vcf, vep_summary]
     cram_to_bam:

--- a/definitions/pipelines/tumor_only_detect_variants.cwl
+++ b/definitions/pipelines/tumor_only_detect_variants.cwl
@@ -40,9 +40,6 @@ inputs:
     coding_only:
         type: boolean?
         default: true
-    hgvs_annotation:
-        type: boolean?
-        default: true
     vep_pick:
         type:
             - "null"
@@ -69,6 +66,9 @@ inputs:
         type: int?
     readcount_minimum_base_quality:
         type: int?
+    vep_everything_flag:
+        type: boolean?
+        default: true
 outputs:
     varscan_vcf:
         type: File
@@ -133,10 +133,10 @@ steps:
             cache_dir: vep_cache_dir
             synonyms_file: synonyms_file
             coding_only: coding_only
-            hgvs: hgvs_annotation
             reference: reference
             custom_gnomad_vcf: custom_gnomad_vcf
             pick: vep_pick
+            everything: vep_everything_flag
         out:
             [annotated_vcf, vep_summary]
     cram_to_bam:

--- a/definitions/pipelines/wgs.cwl
+++ b/definitions/pipelines/wgs.cwl
@@ -33,7 +33,7 @@ inputs:
     variant_detection_intervals:
         type: File
     vep_cache_dir:
-        type: string?
+        type: string
     synonyms_file:
         type: File?
     vep_pick:
@@ -58,6 +58,9 @@ inputs:
         type: ../types/labelled_file.yml#labelled_file[]
     summary_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
+    vep_everything_flag:
+        type: boolean?
+        default: true
 outputs:
     cram:
         type: File
@@ -177,5 +180,6 @@ steps:
             custom_gnomad_vcf: custom_gnomad_vcf
             readcount_minimum_mapping_quality: readcount_minimum_mapping_quality
             readcount_minimum_base_quality: readcount_minimum_base_quality
+            vep_everything_flag: vep_everything_flag
         out:
             [varscan_vcf, docm_gatk_vcf, annotated_vcf, final_vcf, final_tsv, vep_summary, tumor_bam_readcount_tsv]

--- a/definitions/pipelines/wgs.cwl
+++ b/definitions/pipelines/wgs.cwl
@@ -58,9 +58,6 @@ inputs:
         type: ../types/labelled_file.yml#labelled_file[]
     summary_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
-    vep_everything_flag:
-        type: boolean?
-        default: true
 outputs:
     cram:
         type: File
@@ -180,6 +177,5 @@ steps:
             custom_gnomad_vcf: custom_gnomad_vcf
             readcount_minimum_mapping_quality: readcount_minimum_mapping_quality
             readcount_minimum_base_quality: readcount_minimum_base_quality
-            vep_everything_flag: vep_everything_flag
         out:
             [varscan_vcf, docm_gatk_vcf, annotated_vcf, final_vcf, final_tsv, vep_summary, tumor_bam_readcount_tsv]

--- a/definitions/subworkflows/germline_detect_variants.cwl
+++ b/definitions/subworkflows/germline_detect_variants.cwl
@@ -23,7 +23,7 @@ inputs:
     contamination_fraction:
         type: string?
     vep_cache_dir:
-        type: string?
+        type: string
     synonyms_file:
         type: File?
     coding_only:

--- a/definitions/subworkflows/germline_detect_variants.cwl
+++ b/definitions/subworkflows/germline_detect_variants.cwl
@@ -36,9 +36,6 @@ inputs:
     custom_clinvar_vcf:
         type: File?
         secondaryFiles: [.tbi]
-    vep_everything_flag:
-        type: boolean?
-        default: true
 outputs:
     gvcf:
         type: File[]
@@ -87,7 +84,6 @@ steps:
             reference: reference
             custom_gnomad_vcf: custom_gnomad_vcf
             custom_clinvar_vcf: custom_clinvar_vcf
-            everything: vep_everything_flag
         out:
             [annotated_vcf, vep_summary]
     bgzip_annotated_vcf:

--- a/definitions/subworkflows/germline_detect_variants.cwl
+++ b/definitions/subworkflows/germline_detect_variants.cwl
@@ -28,8 +28,6 @@ inputs:
         type: File?
     coding_only:
         type: boolean?
-    hgvs_annotation:
-        type: boolean?
     custom_gnomad_vcf:
         type: File?
         secondaryFiles: [.tbi]
@@ -38,6 +36,9 @@ inputs:
     custom_clinvar_vcf:
         type: File?
         secondaryFiles: [.tbi]
+    vep_everything_flag:
+        type: boolean?
+        default: true
 outputs:
     gvcf:
         type: File[]
@@ -83,10 +84,10 @@ steps:
             cache_dir: vep_cache_dir
             synonyms_file: synonyms_file
             coding_only: coding_only
-            hgvs: hgvs_annotation
             reference: reference
             custom_gnomad_vcf: custom_gnomad_vcf
             custom_clinvar_vcf: custom_clinvar_vcf
+            everything: vep_everything_flag
         out:
             [annotated_vcf, vep_summary]
     bgzip_annotated_vcf:

--- a/definitions/tools/vep.cwl
+++ b/definitions/tools/vep.cwl
@@ -16,10 +16,9 @@ arguments:
     "--vcf",
     "--plugin", "Downstream",
     "--plugin", "Wildtype",
-    "--symbol",
     "--term", "SO",
     "--transcript_version",
-    "--tsl",
+    "--everything", 
     "-o", { valueFrom: $(runtime.outdir)/annotated.vcf }]
 inputs:
     vcf:
@@ -28,16 +27,11 @@ inputs:
             prefix: "-i"
             position: 1
     cache_dir:
-        type: string?
+        type: string
         inputBinding:
             valueFrom: |
                 ${
-                    if (inputs.cache_dir) {
-                        return ["--offline", "--cache", "--dir", inputs.cache_dir ]
-                    }
-                    else {
-                        return "--database"
-                    }
+                    return ["--offline", "--cache", "--dir", inputs.cache_dir ]
                 }
             position: 4
     synonyms_file:
@@ -68,15 +62,10 @@ inputs:
             valueFrom: |
                 ${
                     if (inputs.custom_gnomad_vcf) {
-                        return ['--check_existing', '--custom', inputs.custom_gnomad_vcf.path + ',gnomADe,vcf,exact,0,AF,AF_AFR,AF_AMR,AF_ASJ,AF_EAS,AF_FIN,AF_NFE,AF_OTH,AF_SAS']
+                        return ['--check_existing', '--custom', inputs.custom_gnomad_vcf.path + ',custom_gnomAD,vcf,exact,0,AF,AF_AFR,AF_AMR,AF_ASJ,AF_EAS,AF_FIN,AF_NFE,AF_OTH,AF_SAS']
                     }
                     else {
-                        if (inputs.cache_dir) {
-                            return ['--max_af', '--af_gnomad', '--af_1kg']
-                        }
-                        else {
-                            return []
-                        }
+                        return []
                     }
                 }
             position: 6
@@ -87,7 +76,7 @@ inputs:
             valueFrom: |
                 ${
                     if (inputs.custom_clinvar_vcf) {
-                        return ["--custom", inputs.custom_clinvar_vcf.path + ",clinvar,vcf,exact,0,CLINSIGN,PHENOTYPE,SCORE,RCVACC,TESTEDINGTR,PHENOTYPELIST,NUMSUBMIT,GUIDELINES"]
+                        return ["--custom", inputs.custom_clinvar_vcf.path + ",custom_clinvar,vcf,exact,0,CLINSIGN,PHENOTYPE,SCORE,RCVACC,TESTEDINGTR,PHENOTYPELIST,NUMSUBMIT,GUIDELINES"]
 
                     }
                     else {
@@ -95,26 +84,12 @@ inputs:
                     }
                 }
             position: 7
-    hgvs:
-        type: boolean?
-        inputBinding:
-            valueFrom: |
-                ${
-                    if (inputs.hgvs) {
-                        if (inputs.cache_dir) {
-                            return ["--hgvs", "--fasta", inputs.reference]
-                        }
-                        else {
-                            return ["--hgvs"]
-                        }
-                    }
-                    else {
-                        return []
-                    }
-                }
-            position: 5
     reference:
         type: string?
+        inputBinding:
+            prefix: "--fasta" 
+            position: 8
+            
 outputs:
     annotated_vcf:
         type: File

--- a/definitions/tools/vep.cwl
+++ b/definitions/tools/vep.cwl
@@ -18,7 +18,6 @@ arguments:
     "--plugin", "Wildtype",
     "--term", "SO",
     "--transcript_version",
-    "--everything", 
     "-o", { valueFrom: $(runtime.outdir)/annotated.vcf }]
 inputs:
     vcf:
@@ -89,7 +88,12 @@ inputs:
         inputBinding:
             prefix: "--fasta" 
             position: 8
-            
+    everything:
+        type: boolean?
+        default: true
+        inputBinding:
+            prefix: "--everything" 
+            position: 9
 outputs:
     annotated_vcf:
         type: File

--- a/definitions/tools/vep.cwl
+++ b/definitions/tools/vep.cwl
@@ -20,6 +20,7 @@ arguments:
     "--transcript_version",
     "--offline",
     "--cache",
+    "--everything",
     "-o", { valueFrom: $(runtime.outdir)/annotated.vcf }]
 inputs:
     vcf:
@@ -87,12 +88,6 @@ inputs:
         inputBinding:
             prefix: "--fasta" 
             position: 8
-    everything:
-        type: boolean?
-        default: true
-        inputBinding:
-            prefix: "--everything" 
-            position: 9
 outputs:
     annotated_vcf:
         type: File

--- a/definitions/tools/vep.cwl
+++ b/definitions/tools/vep.cwl
@@ -18,6 +18,8 @@ arguments:
     "--plugin", "Wildtype",
     "--term", "SO",
     "--transcript_version",
+    "--offline",
+    "--cache",
     "-o", { valueFrom: $(runtime.outdir)/annotated.vcf }]
 inputs:
     vcf:
@@ -28,10 +30,7 @@ inputs:
     cache_dir:
         type: string
         inputBinding:
-            valueFrom: |
-                ${
-                    return ["--offline", "--cache", "--dir", inputs.cache_dir ]
-                }
+            prefix: "--dir"
             position: 4
     synonyms_file:
         type: File?
@@ -61,7 +60,7 @@ inputs:
             valueFrom: |
                 ${
                     if (inputs.custom_gnomad_vcf) {
-                        return ['--check_existing', '--custom', inputs.custom_gnomad_vcf.path + ',custom_gnomAD,vcf,exact,0,AF,AF_AFR,AF_AMR,AF_ASJ,AF_EAS,AF_FIN,AF_NFE,AF_OTH,AF_SAS']
+                        return ['--check_existing', '--custom', inputs.custom_gnomad_vcf.path + ',gnomADe,vcf,exact,0,AF,AF_AFR,AF_AMR,AF_ASJ,AF_EAS,AF_FIN,AF_NFE,AF_OTH,AF_SAS']
                     }
                     else {
                         return []
@@ -75,7 +74,7 @@ inputs:
             valueFrom: |
                 ${
                     if (inputs.custom_clinvar_vcf) {
-                        return ["--custom", inputs.custom_clinvar_vcf.path + ",custom_clinvar,vcf,exact,0,CLINSIGN,PHENOTYPE,SCORE,RCVACC,TESTEDINGTR,PHENOTYPELIST,NUMSUBMIT,GUIDELINES"]
+                        return ["--custom", inputs.custom_clinvar_vcf.path + ",clinvar,vcf,exact,0,CLINSIGN,PHENOTYPE,SCORE,RCVACC,TESTEDINGTR,PHENOTYPELIST,NUMSUBMIT,GUIDELINES"]
 
                     }
                     else {


### PR DESCRIPTION
This PR adds the --everything flag as a default argument to vep. Some of the flags it turns on require a cache to be present, so it's now a required parameter in vep.cwl and all upstream files. This also simplifies some of the argument construction logic within vep.cwl. The new flag also includes some AF flags that were previously only added if there was no custom gnomad vcf; since these are now always present, in order to avoid naming collisions within the vcf fields, fields added from the custom file are prefixed with "custom_gnomad"