### PR TITLE
adding markdups, fixing pileup

### DIFF
--- a/definitions/subworkflows/bam_to_trimmed_fastq_and_biscuit_alignments.cwl
+++ b/definitions/subworkflows/bam_to_trimmed_fastq_and_biscuit_alignments.cwl
@@ -25,7 +25,7 @@ inputs:
 outputs:
     aligned_bam:
         type: File
-        outputSource: biscuit_align/aligned_bam
+        outputSource: biscuit_markdup/markdup_bam
 steps:
     bam_to_fastq:
         run: ../tools/bam_to_fastq.cwl
@@ -54,3 +54,15 @@ steps:
             read_group_id: read_group_id
         out:
             [aligned_bam]
+    index_bam:
+        run: ../tools/index_bam.cwl
+        in:
+            bam: biscuit_align/aligned_bam
+        out:
+            [indexed_bam]
+    biscuit_markdup:
+        run: ../tools/biscuit_markdup.cwl
+        in:
+           bam: index_bam/indexed_bam
+        out:
+            [markdup_bam]

--- a/definitions/tools/biscuit_align.cwl
+++ b/definitions/tools/biscuit_align.cwl
@@ -10,7 +10,7 @@ requirements:
       ramMin: 32000
       coresMin: 12
     - class: DockerRequirement
-      dockerPull: "mgibio/bisulfite"
+      dockerPull: "mgibio/bisulfite:v1.3"
 arguments: [
     { valueFrom: "-t", position: -10 },
     { valueFrom: $(runtime.cores), position: -9 },

--- a/definitions/tools/biscuit_markdup.cwl
+++ b/definitions/tools/biscuit_markdup.cwl
@@ -1,0 +1,28 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: "Biscuit dedup"
+baseCommand: ["/usr/bin/biscuit", "markdup"]
+requirements:
+    - class: ShellCommandRequirement
+    - class: ResourceRequirement
+      ramMin: 16000
+    - class: DockerRequirement
+      dockerPull: "mgibio/bisulfite"
+
+arguments:
+    ["/dev/stdout",
+    { shellQuote: false, valueFrom: "|" },
+    "/usr/bin/sambamba", "sort", "-t", $(runtime.cores), "-m", "8G", "-o", "$(runtime.outdir)/markdup.bam", "/dev/stdin"
+    ]
+inputs:
+    bam:
+        type: File
+        inputBinding:
+            position: -1
+outputs:
+    markdup_bam:
+        type: File
+        outputBinding:
+            glob: "markdup.bam"

--- a/definitions/tools/biscuit_markdup.cwl
+++ b/definitions/tools/biscuit_markdup.cwl
@@ -8,13 +8,14 @@ requirements:
     - class: ShellCommandRequirement
     - class: ResourceRequirement
       ramMin: 16000
+      coresMin: 4
     - class: DockerRequirement
-      dockerPull: "mgibio/bisulfite"
+      dockerPull: "mgibio/bisulfite:v1.3"
 
 arguments:
     ["/dev/stdout",
     { shellQuote: false, valueFrom: "|" },
-    "/usr/bin/sambamba", "sort", "-t", $(runtime.cores), "-m", "8G", "-o", "$(runtime.outdir)/markdup.bam", "/dev/stdin"
+    "/usr/bin/sambamba", "sort", "-t", $(runtime.cores), "-m", "15G", "-o", "$(runtime.outdir)/markdup.bam", "/dev/stdin"
     ]
 inputs:
     bam:

--- a/definitions/tools/biscuit_pileup.cwl
+++ b/definitions/tools/biscuit_pileup.cwl
@@ -11,7 +11,7 @@ requirements:
       ramMin: 16000
       coresMin: 4
     - class: DockerRequirement
-      dockerPull: "mgibio/bisulfite"
+      dockerPull: "mgibio/bisulfite:v1.3"
 arguments: [
     { valueFrom: "-q", position: -10 },
     { valueFrom: $(runtime.cores), position: -9 },

--- a/definitions/tools/biscuit_pileup.cwl
+++ b/definitions/tools/biscuit_pileup.cwl
@@ -24,13 +24,11 @@ inputs:
     bam:
         type: File
         inputBinding:
-            prefix: "-i"
-            position: -2
+            position: -1
     reference: 
         type: string
         inputBinding:
-            prefix: "-r"
-            position: -1
+            position: -2
 outputs:
     vcf:
         type: stdout

--- a/definitions/tools/bisulfite_vcf2bed.cwl
+++ b/definitions/tools/bisulfite_vcf2bed.cwl
@@ -9,7 +9,7 @@ requirements:
       ramMin: 16000
       coresMin: 2
     - class: DockerRequirement
-      dockerPull: "mgibio/bisulfite"
+      dockerPull: "mgibio/bisulfite:v1.3"
 #Creates a gzipped bed and a bedgraph that leaves out MT, random, GL contigs, etc
 arguments: [
     "$(runtime.outdir)/cpgs.bed.gz",


### PR DESCRIPTION
This PR: 
- adds a bisulfite-strand aware duplicate marking procedure
- fixes the pileup script to reflect the changed params in the newer version of biscuit
- explicitly specifies the v1.3 tag since older versions of the container will not work with this cwl