### PR TITLE
Added a subworkflow for cnvkit that returns a vcf

### DIFF
--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -66,10 +66,6 @@ inputs:
     custom_clinvar_vcf:
         type: File?
         secondaryFiles: [.tbi]
-    cnvkit_access: 
-        type: File?
-    cnvkit_bait_intervals:
-        type: File?
     cnvkit_diagram:
         type: boolean?
     cnvkit_drop_low_coverage: 
@@ -77,9 +73,13 @@ inputs:
     cnvkit_method:
         type: string? 
     cnvkit_reference_cnn: 
-        type: File?
+        type: File
     cnvkit_scatter_plot:
         type: boolean?
+    cnvkit_male_reference:
+        type: boolean?
+    cnvkit_vcf_name:
+        type: string?
     manta_call_regions:
         type: File?
     manta_non_wgs:
@@ -159,21 +159,6 @@ outputs:
         type: File[]
         outputSource: alignment_and_qc/summary_hs_metrics
 
-    intervals_antitarget:
-        type: File?
-        outputSource: variant_callers/intervals_antitarget
-    intervals_target:
-        type: File?
-        outputSource: variant_callers/intervals_target
-    normal_antitarget_coverage:
-        type: File?
-        outputSource: variant_callers/normal_antitarget_coverage
-    normal_target_coverage:
-        type: File?
-        outputSource: variant_callers/normal_target_coverage
-    reference_coverage:
-        type: File?
-        outputSource: variant_callers/reference_coverage
     cn_diagram:
         type: File?
         outputSource: variant_callers/cn_diagram
@@ -192,6 +177,9 @@ outputs:
     tumor_segmented_ratios:
         type: File
         outputSource: variant_callers/tumor_segmented_ratios
+    cnvkit_vcf:
+        type: File
+        outputSource: variant_callers/cnvkit_vcf
     manta_diploid_variants:
         type: File?
         outputSource: variant_callers/manta_diploid_variants
@@ -280,16 +268,16 @@ steps:
         in:
             cram: alignment_and_qc/cram
             reference: reference
-            cnvkit_access: cnvkit_access
-            cnvkit_bait_intervals: cnvkit_bait_intervals
             cnvkit_diagram: cnvkit_diagram
             cnvkit_drop_low_coverage: cnvkit_drop_low_coverage
             cnvkit_method: cnvkit_method
             cnvkit_reference_cnn: cnvkit_reference_cnn
             cnvkit_scatter_plot: cnvkit_scatter_plot
+            cnvkit_male_reference: cnvkit_male_reference
+            cnvkit_vcf_name: cnvkit_vcf_name
             manta_call_regions: manta_call_regions
             manta_non_wgs: manta_non_wgs
             manta_output_contigs: manta_output_contigs
             smoove_exclude_regions: smoove_exclude_regions
         out: 
-           [intervals_antitarget, intervals_target, normal_antitarget_coverage, normal_target_coverage, reference_coverage, cn_diagram, cn_scatter_plot, tumor_antitarget_coverage, tumor_target_coverage, tumor_bin_level_ratios, tumor_segmented_ratios, manta_diploid_variants, manta_somatic_variants, manta_all_candidates, manta_small_candidates, manta_tumor_only_variants, smoove_output_variants] 
+           [cn_diagram, cn_scatter_plot, tumor_antitarget_coverage, tumor_target_coverage, tumor_bin_level_ratios, tumor_segmented_ratios, cnvkit_vcf, manta_diploid_variants, manta_somatic_variants, manta_all_candidates, manta_small_candidates, manta_tumor_only_variants, smoove_output_variants] 

--- a/definitions/subworkflows/cnvkit_single_sample.cwl
+++ b/definitions/subworkflows/cnvkit_single_sample.cwl
@@ -22,6 +22,7 @@ inputs:
         type: File
     cnvkit_vcf_name:
         type: string?
+        default: $(inputs.tumor_bam.nameroot).cnvkit.vcf
 outputs:
     cn_diagram:
         type: File?

--- a/definitions/subworkflows/cnvkit_single_sample.cwl
+++ b/definitions/subworkflows/cnvkit_single_sample.cwl
@@ -1,0 +1,70 @@
+#! /usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+label: "Subworkflow that runs cnvkit in single sample mode and returns a vcf file"
+
+inputs:
+    tumor_bam:
+        type: File
+    method:
+        type: string?
+        default: "hybrid"
+    diagram:
+        type: boolean?
+    scatter_plot:
+        type: boolean?
+    drop_low_coverage:
+        type: boolean?
+    male_reference:
+        type: boolean?
+    reference_cnn:
+        type: File
+    cnvkit_vcf_name:
+        type: string?
+outputs:
+    cn_diagram:
+        type: File?
+        outputSource: cnvkit_main/cn_diagram
+    cn_scatter_plot:
+        type: File?
+        outputSource: cnvkit_main/cn_scatter_plot
+    tumor_antitarget_coverage:
+        type: File
+        outputSource: cnvkit_main/tumor_antitarget_coverage
+    tumor_target_coverage:
+        type: File
+        outputSource: cnvkit_main/tumor_target_coverage
+    tumor_bin_level_ratios:
+        type: File
+        outputSource: cnvkit_main/tumor_bin_level_ratios
+    tumor_segmented_ratios:
+        type: File
+        outputSource: cnvkit_main/tumor_segmented_ratios
+    cnvkit_vcf:
+        type: File
+        outputSource: cns_to_vcf/cnvkit_vcf
+
+steps:
+    cnvkit_main:
+        run: ../tools/cnvkit_batch.cwl
+        in: 
+            tumor_bam: tumor_bam
+            method: method
+            diagram: diagram
+            scatter_plot: scatter_plot
+            drop_low_coverage: drop_low_coverage
+            male_reference: male_reference
+            reference_cnn: reference_cnn
+        out:
+            [cn_diagram, cn_scatter_plot, tumor_antitarget_coverage, tumor_target_coverage, tumor_bin_level_ratios, tumor_segmented_ratios]            
+            
+    cns_to_vcf:
+        run: ../tools/cnvkit_vcf_export.cwl
+        in:
+            cns_file: cnvkit_main/tumor_segmented_ratios
+            male_reference: male_reference
+            cnr_file: cnvkit_main/tumor_bin_level_ratios
+            output_name: cnvkit_vcf_name
+        out:
+            [cnvkit_vcf]

--- a/definitions/subworkflows/single_sample_sv_callers.cwl
+++ b/definitions/subworkflows/single_sample_sv_callers.cwl
@@ -6,7 +6,7 @@ label: "Subworkflow to allow calling different SV callers which require bam file
 
 requirements:
     - class: MultipleInputFeatureRequirement
-
+    - class: SubworkflowFeatureRequirement
 inputs:
     cram:
         type: File

--- a/definitions/subworkflows/single_sample_sv_callers.cwl
+++ b/definitions/subworkflows/single_sample_sv_callers.cwl
@@ -13,10 +13,6 @@ inputs:
     reference:
         type: string
 
-    cnvkit_access:
-        type: File?
-    cnvkit_bait_intervals:
-        type: File?
     cnvkit_diagram:
         type: boolean?
     cnvkit_drop_low_coverage:
@@ -24,9 +20,13 @@ inputs:
     cnvkit_method:
         type: string?
     cnvkit_reference_cnn:
-        type: File?
+        type: File
     cnvkit_scatter_plot:
         type: boolean?
+    cnvkit_male_reference:
+        type: boolean?
+    cnvkit_vcf_name:
+        type: string?
 
     manta_call_regions:
         type: File?
@@ -39,21 +39,6 @@ inputs:
         type: File?
 
 outputs:
-    intervals_antitarget:
-        type: File?
-        outputSource: run_cnvkit/intervals_antitarget
-    intervals_target:
-        type: File?
-        outputSource: run_cnvkit/intervals_target
-    normal_antitarget_coverage:
-        type: File?
-        outputSource: run_cnvkit/normal_antitarget_coverage
-    normal_target_coverage:
-        type: File?
-        outputSource: run_cnvkit/normal_target_coverage
-    reference_coverage:
-        type: File?
-        outputSource: run_cnvkit/reference_coverage
     cn_diagram:
         type: File?
         outputSource: run_cnvkit/cn_diagram
@@ -72,6 +57,9 @@ outputs:
     tumor_segmented_ratios:
         type: File
         outputSource: run_cnvkit/tumor_segmented_ratios
+    cnvkit_vcf:
+        type: File
+        outputSource: run_cnvkit/cnvkit_vcf
     manta_diploid_variants:
         type: File?
         outputSource: run_manta/diploid_variants
@@ -106,18 +94,18 @@ steps:
         out:
             [indexed_bam]
     run_cnvkit:
-        run: ../tools/cnvkit_batch.cwl
+        run: cnvkit_single_sample.cwl
         in:
-            access: cnvkit_access
-            bait_intervals: cnvkit_bait_intervals
             diagram: cnvkit_diagram
             drop_low_coverage: cnvkit_drop_low_coverage
             method: cnvkit_method
             reference_cnn: cnvkit_reference_cnn
             tumor_bam: index_bam/indexed_bam
             scatter_plot: cnvkit_scatter_plot
+            male_reference: cnvkit_male_reference
+            cnvkit_vcf_name: cnvkit_vcf_name
         out:
-            [intervals_antitarget, intervals_target, normal_antitarget_coverage, normal_target_coverage, reference_coverage, cn_diagram, cn_scatter_plot, tumor_antitarget_coverage, tumor_target_coverage, tumor_bin_level_ratios, tumor_segmented_ratios]
+            [cn_diagram, cn_scatter_plot, tumor_antitarget_coverage, tumor_target_coverage, tumor_bin_level_ratios, tumor_segmented_ratios, cnvkit_vcf]
     run_manta:
         run: ../tools/manta_somatic.cwl
         in:

--- a/definitions/tools/cnvkit_vcf_export.cwl
+++ b/definitions/tools/cnvkit_vcf_export.cwl
@@ -1,0 +1,44 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: "Convert default cnvkit .cns output to standard vcf format"
+
+requirements:
+    - class: DockerRequirement
+      dockerPull: etal/cnvkit:0.9.5
+    - class: ShellCommandRequirement
+baseCommand: ["/usr/bin/python", "/usr/local/bin/cnvkit.py", "call"]
+arguments: [
+    { position: -1, valueFrom: $(inputs.male_reference), prefix: "-y" },
+    "-o", "adjusted.tumor.cns",
+    { shellQuote: false, valueFrom: "&&" },
+    "/usr/bin/python", "/usr/local/bin/cnvkit.py", "export", "vcf", "adjusted.tumor.cns"
+]
+inputs:
+    cns_file:
+        type: File
+        inputBinding:
+            position: -2
+    male_reference:
+        type: boolean
+        default: false
+        inputBinding:
+            position: 1
+            prefix: "-y"
+    cnr_file:
+        type: File?
+        inputBinding:
+            position: 2
+            prefix: "--cnr"
+    output_name:
+        type: string
+        default: "cnvkit_output.vcf"
+        inputBinding:
+            position: 3
+            prefix: "-o"
+outputs:
+    cnvkit_vcf:
+        type: File
+        outputBinding:
+            glob: $(inputs.output_name)


### PR DESCRIPTION
By default, cnvkit outputs results in a .cns file; this subworkflow runs cnvkit and converts the .cns file to a vcf. Additionally, since the base `cnvkit_batch.cwl` tool has different use cases with different requirements, almost all of its input parameters/outputs are optional. Since we know the exact use case of the `single_sample_sv_callers` subworkflow, irrelevant parameters and nonexistent outputs were removed in upstream steps, and a necessary parameter was updated (previously listed as optional).