### PR TITLE
passing ref param to bsvcf2bed

### DIFF
--- a/definitions/pipelines/bisulfite.cwl
+++ b/definitions/pipelines/bisulfite.cwl
@@ -75,6 +75,7 @@ steps:
         run: ../tools/bisulfite_vcf2bed.cwl
         in:
             vcf: pileup/vcf
+            reference: reference_index
         out:
             [cpgs,cpg_bedgraph]
     bedgraph_to_bigwig:

--- a/definitions/tools/bisulfite_vcf2bed.cwl
+++ b/definitions/tools/bisulfite_vcf2bed.cwl
@@ -19,6 +19,10 @@ inputs:
     vcf:
         type: File
         inputBinding:
+            position: -2
+    reference:
+        type: string
+        inputBinding:
             position: -1
 outputs:
     cpgs:


### PR DESCRIPTION
With ditching the perl script in favor of the built-in utility, we now have to pass the reference fasta to this tool.