### PR TITLE
Add ignore_docm option

### DIFF
--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -62,6 +62,9 @@ inputs:
     docm_vcf:
         type: File
         secondaryFiles: [.tbi]
+    ignore_docm:
+        type: boolean?
+        default: true
     vep_cache_dir:
         type: string
     synonyms_file:
@@ -222,6 +225,7 @@ steps:
             tumor_cram: tumor_cram
             normal_cram: normal_cram
             docm_vcf: docm_vcf
+            ignore_docm: ignore_docm
             interval_list: interval_list
         out:
             [unfiltered_vcf, filtered_vcf]

--- a/definitions/pipelines/gathered_somatic_exome.cwl
+++ b/definitions/pipelines/gathered_somatic_exome.cwl
@@ -96,6 +96,9 @@ inputs:
     docm_vcf:
         type: File
         secondaryFiles: [.tbi]
+    ignore_docm:
+        type: boolean
+        default: true
     vep_cache_dir:
         type: string?
     synonyms_file:
@@ -169,6 +172,7 @@ steps:
             varscan_max_normal_freq: varscan_max_normal_freq
             pindel_insert_size: pindel_insert_size
             docm_vcf: docm_vcf
+            ignore_docm: ignore_docm
             vep_cache_dir: vep_cache_dir
             synonyms_file: synonyms_file
             annotate_coding_only: annotate_coding_only

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -97,6 +97,9 @@ inputs:
     docm_vcf:
         type: File
         secondaryFiles: [.tbi]
+    ignore_docm:
+        type: boolean
+        default: true
     vep_cache_dir:
         type: string
     synonyms_file:
@@ -372,6 +375,7 @@ steps:
             varscan_max_normal_freq: varscan_max_normal_freq
             pindel_insert_size: pindel_insert_size
             docm_vcf: docm_vcf
+            ignore_docm: ignore_docm
             vep_cache_dir: vep_cache_dir
             synonyms_file: synonyms_file
             annotate_coding_only: annotate_coding_only

--- a/definitions/subworkflows/docm_cle.cwl
+++ b/definitions/subworkflows/docm_cle.cwl
@@ -17,6 +17,8 @@ inputs:
     docm_vcf:
         type: File
         secondaryFiles: [.tbi]
+    ignore_docm:
+        type: boolean
     interval_list:
         type: File
 outputs:
@@ -44,6 +46,7 @@ steps:
             docm_out: GATK_haplotype_caller/docm_out
             normal_cram: normal_cram
             tumor_cram: tumor_cram
+            ignore_docm: ignore_docm
         out:
             [docm_filter_out]
     bgzip:

--- a/definitions/tools/somatic_docm_filter.cwl
+++ b/definitions/tools/somatic_docm_filter.cwl
@@ -17,6 +17,11 @@ inputs:
         type: File
     tumor_cram:
         type: File
+    ignore_docm:
+        type: boolean
+        inputBinding:
+            prefix: "ignoreDOCM"
+            position: 1
 outputs:
     docm_filter_out:
         type: File


### PR DESCRIPTION
For non-cle analysis, docm variants are not needed and this PR is to add ignore_docm option to CWL to filter out all docm variants.

This PR relies on https://github.com/genome/docker-cle/pull/86