### PR TITLE
Use a `long` for the genome size instead of an `int`.

### DIFF
--- a/definitions/tools/deeptools_bamcoverage.cwl
+++ b/definitions/tools/deeptools_bamcoverage.cwl
@@ -53,7 +53,7 @@ inputs:
         inputBinding:
             prefix: '-v'
     effective_genome_size:
-        type: int?
+        type: long?
         inputBinding:
             prefix: '--effectiveGenomeSize'
         default: 2451960000


### PR DESCRIPTION
Genome sizes exceed 32-bit integers. They don't seem *that* long 😄

Guess we've been spoiled by friendlier languages that don't cap their integers.  It's all really a string anyway.