### PR TITLE
Bump up ram to get around errors

### DIFF
--- a/definitions/tools/pindel.cwl
+++ b/definitions/tools/pindel.cwl
@@ -9,7 +9,7 @@ arguments: [
 ]
 requirements:
     - class: ResourceRequirement
-      ramMin: 32000
+      ramMin: 64000
       tmpdirMin: 100000
     - class: DockerRequirement
       dockerPull: "mgibio/cle:v1.3.1"


### PR DESCRIPTION
We continue to see pindel jobs dying due to memory errors. Increasing requested memory again to 64 gb; there may be better solutions worth investigating, but for now, this seems to fix the issues.