### PR TITLE
Adding survivor merge for sv vcfs

### DIFF
--- a/definitions/subworkflows/merge_svs.cwl
+++ b/definitions/subworkflows/merge_svs.cwl
@@ -1,0 +1,52 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+label: "merge and annotate svs with population allele freq"
+requirements:
+    - class: MultipleInputFeatureRequirement
+inputs:
+    vcfs:
+        type: File[]
+    max_distance_to_merge:
+        type: int
+    minimum_sv_calls:
+        type: int
+    same_type:
+        type: int
+    same_strand:
+        type: int
+    estimate_sv_distance:
+        type: int
+    minimum_sv_size:
+        type: int
+    cohort_name:
+        type: string?
+    sv_db:
+        type: File
+outputs:
+    merged_annotated_vcf:
+        type: File
+        outputSource: add_population_frequency/merged_annotated_vcf
+steps:
+    merge_vcfs:
+        run: ../tools/survivor.cwl
+        in: 
+            vcfs: vcfs
+            max_distance_to_merge: max_distance_to_merge
+            minimum_sv_calls: minimum_sv_calls
+            same_type: same_type
+            same_strand: same_strand
+            estimate_sv_distance: estimate_sv_distance
+            minimum_sv_size: minimum_sv_size
+            cohort_name: cohort_name
+        out:
+            [merged_vcf]
+    add_population_frequency:
+        run: ../tools/add_sv_population_frequency.cwl
+        in:
+            vcf: merge_vcfs/merged_vcf
+            sv_db: sv_db
+            cohort_name: cohort_name
+        out:
+            [merged_annotated_vcf]

--- a/definitions/subworkflows/single_sample_sv_callers.cwl
+++ b/definitions/subworkflows/single_sample_sv_callers.cwl
@@ -79,9 +79,6 @@ outputs:
     smoove_output_variants:
         type: File
         outputSource: run_smoove/output_vcf
-    merged_annotated_vcf:
-        type: File
-        outputSource: run_merge/merged_annotated_vcf
 steps:
     cram_to_bam:
         run: ../tools/cram_to_bam.cwl

--- a/definitions/subworkflows/single_sample_sv_callers.cwl
+++ b/definitions/subworkflows/single_sample_sv_callers.cwl
@@ -38,6 +38,20 @@ inputs:
     smoove_exclude_regions:
         type: File?
 
+    survivor_max_distance_to_merge:
+        type: int
+    survivor_minimum_sv_calls:
+        type: int
+    survivor_same_type:
+        type: int
+    survivor_estimate_sv_distance:
+        type: int
+    survivor_minimum_sv_size:
+        type: int
+
+    sv_pop_freq_db:
+        type: File
+
 outputs:
     cn_diagram:
         type: File?
@@ -78,7 +92,9 @@ outputs:
     smoove_output_variants:
         type: File
         outputSource: run_smoove/output_vcf
-
+    merged_annotated_vcf:
+        type: File
+        outputSource: run_merge/merged_annotated_vcf
 steps:
     cram_to_bam:
         run: ../tools/cram_to_bam.cwl
@@ -126,4 +142,18 @@ steps:
             reference: reference
         out:
             [output_vcf]
-
+    run_merge:
+        run: merge_svs.cwl
+        in:
+            vcfs:
+                source: [run_smoove/output_vcf, run_cnvkit/cnvkit_vcf, run_manta/tumor_only_variants]
+                linkMerge: merge_flattened
+            max_distance_to_merge: survivor_max_distance_to_merge
+            minimum_sv_calls: survivor_minimum_sv_calls
+            same_type: survivor_same_type
+            same_strand: survivor_same_type
+            estimate_sv_distance: survivor_estimate_sv_distance
+            minimum_sv_size: survivor_minimum_sv_size
+            sv_db: sv_pop_freq_db
+        out:
+            [merged_annotated_vcf]

--- a/definitions/subworkflows/single_sample_sv_callers.cwl
+++ b/definitions/subworkflows/single_sample_sv_callers.cwl
@@ -39,20 +39,6 @@ inputs:
     smoove_exclude_regions:
         type: File?
 
-    survivor_max_distance_to_merge:
-        type: int
-    survivor_minimum_sv_calls:
-        type: int
-    survivor_same_type:
-        type: int
-    survivor_estimate_sv_distance:
-        type: int
-    survivor_minimum_sv_size:
-        type: int
-
-    sv_pop_freq_db:
-        type: File
-
 outputs:
     cn_diagram:
         type: File?
@@ -143,18 +129,3 @@ steps:
             reference: reference
         out:
             [output_vcf]
-    run_merge:
-        run: merge_svs.cwl
-        in:
-            vcfs:
-                source: [run_smoove/output_vcf, run_cnvkit/cnvkit_vcf, run_manta/tumor_only_variants]
-                linkMerge: merge_flattened
-            max_distance_to_merge: survivor_max_distance_to_merge
-            minimum_sv_calls: survivor_minimum_sv_calls
-            same_type: survivor_same_type
-            same_strand: survivor_same_type
-            estimate_sv_distance: survivor_estimate_sv_distance
-            minimum_sv_size: survivor_minimum_sv_size
-            sv_db: sv_pop_freq_db
-        out:
-            [merged_annotated_vcf]

--- a/definitions/tools/add_sv_population_frequency.cwl
+++ b/definitions/tools/add_sv_population_frequency.cwl
@@ -19,7 +19,7 @@ requirements:
 inputs:
     vcf:
         type: File
-        doc: "vcf to add populationa allele frequence to"
+        doc: "vcf to add population allele frequencies to"
     sv_db:
         type: File
         doc: "bed file containing allele frequencies for a population"

--- a/definitions/tools/add_sv_population_frequency.cwl
+++ b/definitions/tools/add_sv_population_frequency.cwl
@@ -1,3 +1,5 @@
+#!/usr/bin/env cwl-runner
+
 cwlVersion: v1.0
 class: CommandLineTool
 label: "add population allele frequencies to a vcf"

--- a/definitions/tools/add_sv_population_frequency.cwl
+++ b/definitions/tools/add_sv_population_frequency.cwl
@@ -1,0 +1,32 @@
+cwlVersion: v1.0
+class: CommandLineTool
+label: "add population allele frequencies to a vcf"
+
+arguments: ["/opt/hall-lab/python-2.7.15/bin/svtools", "afreq", "$(inputs.vcf)", { shellQuote: false, valueFrom: "|" },
+    "/opt/hall-lab/python-2.7.15/bin/svtools", "vcftobedpe", "-i", "stdin", { shellQuote: false, valueFrom: "|" },
+    "/opt/hall-lab/python-2.7.15/bin/svtools", "varlookup", "-d", "200", "-c", "POPFREQ", "-a", "stdin", "-b", "$(inputs.sv_db)", { shellQuote: false, valueFrom: "|" },
+    "/opt/hall-lab/python-2.7.15/bin/svtools", "bedpetovcf"
+    ]
+stdout: "$(inputs.cohort_name)"
+requirements:
+    - class: ShellCommandRequirement
+    - class: DockerRequirement
+      dockerPull: "halllab/svtools:v0.4.0-2dc7f91" 
+    - class: ResourceRequirement
+      ramMin: 5000
+      coresMin: 1
+
+inputs:
+    vcf:
+        type: File
+        doc: "vcf to add populationa allele frequence to"
+    sv_db:
+        type: File
+        doc: "bed file containing allele frequencies for a population"
+    cohort_name:
+        type: string?
+        default: "merged_annotated.vcf"
+
+outputs:
+    merged_annotated_vcf:
+        type: stdout

--- a/definitions/tools/smoove.cwl
+++ b/definitions/tools/smoove.cwl
@@ -47,4 +47,4 @@ outputs:
         type: File
         outputBinding:
             glob: "$(inputs.cohort_name)-smoove.genotyped.vcf.gz"
-        secondaryFiles: [.tbi]
+        secondaryFiles: [.csi]

--- a/definitions/tools/survivor.cwl
+++ b/definitions/tools/survivor.cwl
@@ -44,7 +44,7 @@ inputs:
         type: int
         inputBinding:
             position: 6
-        doc: "Estimate distance based on the sixe of SV, 1=yes"
+        doc: "Estimate distance based on the size of SV, 1=yes"
     minimum_sv_size:
         type: int
         inputBinding:

--- a/definitions/tools/survivor.cwl
+++ b/definitions/tools/survivor.cwl
@@ -34,17 +34,17 @@ inputs:
         type: int
         inputBinding:
             position: 4
-        doc: "Require merged SVs to be of the same type, 1=yes"
+        doc: "Require merged SVs to be of the same type, 1=yes, 0=no"
     same_strand:
         type: int
         inputBinding:
             position: 5
-        doc: "Require merged SVs to be on the same strand, 1=yes"
+        doc: "Require merged SVs to be on the same strand, 1=yes, 0=no"
     estimate_sv_distance:
         type: int
         inputBinding:
             position: 6
-        doc: "Estimate distance based on the size of SV, 1=yes"
+        doc: "Estimate distance based on the size of SV, 1=yes, 0=no"
     minimum_sv_size:
         type: int
         inputBinding:

--- a/definitions/tools/survivor.cwl
+++ b/definitions/tools/survivor.cwl
@@ -1,0 +1,65 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: "Run SURVIVOR to merge SV calls"
+
+baseCommand: ["/bin/bash", "/usr/bin/survivor_merge_helper.sh"]
+
+requirements:
+    - class: DockerRequirement
+      dockerPull: "mgibio/survivor-cwl:1.0.6.1"
+    - class: ResourceRequirement
+      ramMin: 2000
+      coresMin: 1
+
+inputs:
+    vcfs:
+        type: File[]
+        inputBinding:
+            position: 1
+            itemSeparator: ","
+        doc: "Array of VCFs to merge SV calls of"
+    max_distance_to_merge:
+        type: int
+        inputBinding:
+            position: 2
+        doc: "Maximum distance of variants to consider for merging"
+    minimum_sv_calls:
+        type: int
+        inputBinding:
+            position: 3
+        doc: "Minimum number of sv calls needed to be merged"
+    same_type:
+        type: int
+        inputBinding:
+            position: 4
+        doc: "Require merged SVs to be of the same type, 1=yes"
+    same_strand:
+        type: int
+        inputBinding:
+            position: 5
+        doc: "Require merged SVs to be on the same strand, 1=yes"
+    estimate_sv_distance:
+        type: int
+        inputBinding:
+            position: 6
+        doc: "Estimate distance based on the sixe of SV, 1=yes"
+    minimum_sv_size:
+        type: int
+        inputBinding:
+            position: 7
+        doc: "Minimum size of SVs to merge"
+    cohort_name:
+        type: string?
+        inputBinding:
+            position: 8
+        default: "SURVIVOR-sv-merged.vcf"
+        doc: "Used to generate the output file name"
+
+outputs:
+  merged_vcf:
+    type: File
+    outputBinding:
+      glob: "$(inputs.cohort_name)"
+


### PR DESCRIPTION
this will allow us to merge the results from different sv callers together into a single vcf. And then annotate them with a population frequency of the sv calls.

I have it set up as a separate sub workflow to make it easier for people to run this manually. 

Open to suggestions on naming of files and input variables. 
