### PR TITLE
Hacked in default vcf name

### DIFF
--- a/definitions/subworkflows/cnvkit_single_sample.cwl
+++ b/definitions/subworkflows/cnvkit_single_sample.cwl
@@ -22,7 +22,6 @@ inputs:
         type: File
     cnvkit_vcf_name:
         type: string?
-        default: $(inputs.tumor_bam.nameroot).cnvkit.vcf
 outputs:
     cn_diagram:
         type: File?
@@ -67,5 +66,6 @@ steps:
             male_reference: male_reference
             cnr_file: cnvkit_main/tumor_bin_level_ratios
             output_name: cnvkit_vcf_name
+            tumor_bam: tumor_bam
         out:
             [cnvkit_vcf]

--- a/definitions/tools/cnvkit_vcf_export.cwl
+++ b/definitions/tools/cnvkit_vcf_export.cwl
@@ -10,6 +10,8 @@ requirements:
     - class: ShellCommandRequirement
     - class: ResourceRequirement
       ramMin: 4000
+    - class: StepInputExpressionRequirement
+    - class: InlineJavascriptRequirement
 baseCommand: ["/usr/bin/python", "/usr/local/bin/cnvkit.py", "call"]
 arguments: [
     { position: -1, valueFrom: $(inputs.male_reference), prefix: "-y" },
@@ -35,10 +37,22 @@ inputs:
             prefix: "--cnr"
     output_name:
         type: string
-        default: "cnvkit_output.vcf"
+        default: "default"
         inputBinding:
             position: 3
             prefix: "-o"
+            valueFrom: |
+                ${  
+                    if(inputs.output_name != "default") {
+                        return inputs.output_name;
+                    }   
+                    else {
+                        return inputs.tumor_bam.nameroot + ".cnvkit.vcf"
+                    }   
+                }   
+
+    tumor_bam:
+        type: File
 outputs:
     cnvkit_vcf:
         type: File


### PR DESCRIPTION
The `default` field does not seem to allow parameter references/Javascript, so I made a workaround using the `valueFrom` field instead