### PR TITLE
Defer CRAM conversion to the end of workflows.

### DIFF
--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -8,12 +8,12 @@ requirements:
 inputs:
     reference:
         type: string
-    tumor_cram:
+    tumor_bam:
         type: File
-        secondaryFiles: [.crai,^.crai]
-    normal_cram:
+        secondaryFiles: [.bai,^.bai]
+    normal_bam:
         type: File
-        secondaryFiles: [.crai,^.crai]
+        secondaryFiles: [.bai,^.bai]
     interval_list:
         type: File
     dbsnp_vcf:
@@ -171,8 +171,8 @@ steps:
         run: ../subworkflows/mutect.cwl
         in:
             reference: reference
-            tumor_cram: tumor_cram
-            normal_cram: normal_cram
+            tumor_bam: tumor_bam
+            normal_bam: normal_bam
             interval_list: interval_list
             dbsnp_vcf: dbsnp_vcf
             cosmic_vcf: cosmic_vcf
@@ -187,8 +187,8 @@ steps:
         run: ../subworkflows/strelka_and_post_processing.cwl
         in:
             reference: reference
-            tumor_cram: tumor_cram
-            normal_cram: normal_cram
+            tumor_bam: tumor_bam
+            normal_bam: normal_bam
             interval_list: interval_list
             exome_mode: strelka_exome_mode
             cpu_reserved: strelka_cpu_reserved
@@ -198,8 +198,8 @@ steps:
         run: ../subworkflows/varscan_pre_and_post_processing.cwl
         in:
             reference: reference
-            tumor_cram: tumor_cram
-            normal_cram: normal_cram
+            tumor_bam: tumor_bam
+            normal_bam: normal_bam
             interval_list: interval_list
             strand_filter: varscan_strand_filter
             min_coverage: varscan_min_coverage
@@ -212,8 +212,8 @@ steps:
         run: ../subworkflows/pindel.cwl
         in:
             reference: reference
-            tumor_cram: tumor_cram
-            normal_cram: normal_cram
+            tumor_bam: tumor_bam
+            normal_bam: normal_bam
             interval_list: interval_list
             insert_size: pindel_insert_size
         out:
@@ -222,8 +222,8 @@ steps:
         run: ../subworkflows/docm_cle.cwl
         in:
             reference: reference
-            tumor_cram: tumor_cram
-            normal_cram: normal_cram
+            tumor_bam: tumor_bam
+            normal_bam: normal_bam
             docm_vcf: docm_vcf
             interval_list: interval_list
         out:
@@ -258,20 +258,6 @@ steps:
             custom_clivnar_vcf: custom_clinvar_vcf
         out:
             [annotated_vcf, vep_summary]
-    tumor_cram_to_bam:
-        run: ../subworkflows/cram_to_bam_and_index.cwl
-        in:
-            cram: tumor_cram
-            reference: reference
-        out:
-            [bam]
-    normal_cram_to_bam:
-        run: ../subworkflows/cram_to_bam_and_index.cwl
-        in:
-            cram: normal_cram
-            reference: reference
-        out:
-            [bam]
     tumor_bam_readcount:
         run: ../tools/bam_readcount.cwl
         in:
@@ -279,7 +265,7 @@ steps:
             sample:
                 default: 'TUMOR'
             reference_fasta: reference
-            bam: tumor_cram_to_bam/bam
+            bam: tumor_bam
             min_base_quality: readcount_minimum_base_quality
             min_mapping_quality: readcount_minimum_mapping_quality
         out:
@@ -291,7 +277,7 @@ steps:
             sample:
                 default: 'NORMAL'
             reference_fasta: reference
-            bam: normal_cram_to_bam/bam
+            bam: normal_bam
             min_base_quality: readcount_minimum_base_quality
             min_mapping_quality: readcount_minimum_mapping_quality
         out:
@@ -333,7 +319,7 @@ steps:
             filter_gnomADe_maximum_population_allele_frequency: filter_gnomADe_maximum_population_allele_frequency
             filter_mapq0_threshold: filter_mapq0_threshold
             filter_somatic_llr_threshold: filter_somatic_llr_threshold
-            tumor_bam: tumor_cram_to_bam/bam
+            tumor_bam: tumor_bam
             do_cle_vcf_filter: cle_vcf_filter
             reference: reference
         out: 

--- a/definitions/pipelines/exome.cwl
+++ b/definitions/pipelines/exome.cwl
@@ -98,7 +98,7 @@ inputs:
 outputs:
     cram:
         type: File
-        outputSource: alignment_and_qc/cram
+        outputSource: index_cram/indexed_cram
     mark_duplicates_metrics:
         type: File
         outputSource: alignment_and_qc/mark_duplicates_metrics
@@ -186,12 +186,12 @@ steps:
             qc_minimum_mapping_quality: qc_minimum_mapping_quality
             qc_minimum_base_quality: qc_minimum_base_quality
         out:
-            [cram, mark_duplicates_metrics, insert_size_metrics, insert_size_histogram, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, summary_hs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]
+            [bam, mark_duplicates_metrics, insert_size_metrics, insert_size_histogram, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, summary_hs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]
     detect_variants:
         run: tumor_only_detect_variants.cwl
         in:
             reference: reference
-            cram: alignment_and_qc/cram
+            bam: alignment_and_qc/bam
             interval_list: target_intervals
             varscan_strand_filter: varscan_strand_filter
             varscan_min_coverage: varscan_min_coverage
@@ -212,3 +212,16 @@ steps:
             readcount_minimum_base_quality: readcount_minimum_base_quality
         out:
             [varscan_vcf, docm_gatk_vcf, annotated_vcf, final_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv]
+    bam_to_cram:
+        run: ../tools/bam_to_cram.cwl
+        in:
+            bam: alignment_and_qc/bam
+            reference: reference
+        out:
+            [cram]
+    index_cram:
+         run: ../tools/index_cram.cwl
+         in:
+            cram: bam_to_cram/cram
+         out:
+            [indexed_cram]

--- a/definitions/pipelines/exome_alignment.cwl
+++ b/definitions/pipelines/exome_alignment.cwl
@@ -47,9 +47,9 @@ inputs:
     qc_minimum_base_quality:
         type: int?
 outputs:
-    cram:
+    bam:
         type: File
-        outputSource: alignment/final_cram
+        outputSource: alignment/final_bam
     mark_duplicates_metrics:
         type: File
         outputSource: alignment/mark_duplicates_metrics_file
@@ -101,11 +101,11 @@ steps:
             dbsnp_vcf: dbsnp_vcf
             bqsr_intervals: bqsr_intervals
             final_name: final_name
-        out: [final_cram,mark_duplicates_metrics_file]
+        out: [final_bam,mark_duplicates_metrics_file]
     qc:
         run: ../subworkflows/qc_exome.cwl
         in:
-            cram: alignment/final_cram
+            bam: alignment/final_bam
             reference: reference
             bait_intervals: bait_intervals
             target_intervals: target_intervals

--- a/definitions/pipelines/germline_exome.cwl
+++ b/definitions/pipelines/germline_exome.cwl
@@ -69,7 +69,7 @@ inputs:
 outputs:
     cram:
         type: File
-        outputSource: alignment_and_qc/cram
+        outputSource: index_cram/indexed_cram
     mark_duplicates_metrics:
         type: File
         outputSource: alignment_and_qc/mark_duplicates_metrics
@@ -148,7 +148,7 @@ steps:
             minimum_mapping_quality: qc_minimum_mapping_quality
             minimum_base_quality: qc_minimum_base_quality
         out:
-            [cram, mark_duplicates_metrics, insert_size_metrics, insert_size_histogram, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, summary_hs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]
+            [bam, mark_duplicates_metrics, insert_size_metrics, insert_size_histogram, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, summary_hs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]
     extract_freemix:
         in:
             verify_bam_id_metrics: alignment_and_qc/verify_bam_id_metrics
@@ -179,7 +179,7 @@ steps:
         run: ../subworkflows/germline_detect_variants.cwl
         in:
             reference: reference
-            cram: alignment_and_qc/cram
+            bam: alignment_and_qc/bam
             emit_reference_confidence: emit_reference_confidence
             gvcf_gq_bands: gvcf_gq_bands
             intervals: intervals
@@ -192,3 +192,16 @@ steps:
             custom_clinvar_vcf: custom_clinvar_vcf
         out:
             [gvcf, final_vcf, coding_vcf, limited_vcf, vep_summary]
+    bam_to_cram:
+        run: ../tools/bam_to_cram.cwl
+        in:
+            bam: alignment_and_qc/bam
+            reference: reference
+        out:
+            [cram]
+    index_cram:
+         run: ../tools/index_cram.cwl
+         in:
+            cram: bam_to_cram/cram
+         out:
+            [indexed_cram]

--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -92,7 +92,7 @@ inputs:
 outputs:
     cram:
         type: File
-        outputSource: alignment_and_qc/cram
+        outputSource: index_cram/indexed_cram
     mark_duplicates_metrics:
         type: File
         outputSource: alignment_and_qc/mark_duplicates_metrics
@@ -221,7 +221,7 @@ steps:
             per_target_intervals: per_target_intervals
             summary_intervals: summary_intervals
         out:
-            [cram, mark_duplicates_metrics, insert_size_metrics, insert_size_histogram, alignment_summary_metrics, gc_bias_metrics, gc_bias_metrics_chart, gc_bias_metrics_summary, wgs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth, per_base_coverage_metrics, per_base_hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, summary_hs_metrics, bamcoverage_bigwig]
+            [bam, mark_duplicates_metrics, insert_size_metrics, insert_size_histogram, alignment_summary_metrics, gc_bias_metrics, gc_bias_metrics_chart, gc_bias_metrics_summary, wgs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth, per_base_coverage_metrics, per_base_hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, summary_hs_metrics, bamcoverage_bigwig]
     extract_freemix:
         in:
             verify_bam_id_metrics: alignment_and_qc/verify_bam_id_metrics
@@ -252,7 +252,7 @@ steps:
         run: ../subworkflows/germline_detect_variants.cwl
         in:
             reference: reference
-            cram: alignment_and_qc/cram
+            bam: alignment_and_qc/bam
             emit_reference_confidence: emit_reference_confidence
             gvcf_gq_bands: gvcf_gq_bands
             intervals: intervals
@@ -268,7 +268,7 @@ steps:
     variant_callers:
         run: ../subworkflows/single_sample_sv_callers.cwl
         in:
-            cram: alignment_and_qc/cram
+            bam: alignment_and_qc/bam
             reference: reference
             cnvkit_diagram: cnvkit_diagram
             cnvkit_drop_low_coverage: cnvkit_drop_low_coverage
@@ -283,3 +283,16 @@ steps:
             smoove_exclude_regions: smoove_exclude_regions
         out: 
            [cn_diagram, cn_scatter_plot, tumor_antitarget_coverage, tumor_target_coverage, tumor_bin_level_ratios, tumor_segmented_ratios, cnvkit_vcf, manta_diploid_variants, manta_somatic_variants, manta_all_candidates, manta_small_candidates, manta_tumor_only_variants, smoove_output_variants] 
+    bam_to_cram:
+        run: ../tools/bam_to_cram.cwl
+        in:
+            bam: alignment_and_qc/bam
+            reference: reference
+        out:
+            [cram]
+    index_cram:
+         run: ../tools/index_cram.cwl
+         in:
+            cram: bam_to_cram/cram
+         out:
+            [indexed_cram]

--- a/definitions/pipelines/panel_of_normals.cwl
+++ b/definitions/pipelines/panel_of_normals.cwl
@@ -10,9 +10,9 @@ requirements:
 inputs:
     reference:
         type: string
-    normal_crams:
+    normal_bams:
         type: File[]
-        secondaryFiles: [^.crai]
+        secondaryFiles: [^.bai]
     interval_list:
         type: File
     scatter_count:
@@ -30,12 +30,12 @@ outputs:
         secondaryFiles: [.tbi]
 steps:
     mutect:
-        scatter: tumor_cram
+        scatter: tumor_bam
         run: ../subworkflows/mutect.cwl
         in:
             reference: reference
-            tumor_cram: normal_crams
-            normal_cram:
+            tumor_bam: normal_bams
+            normal_bam:
                 default: null
             interval_list: interval_list
             scatter_count: scatter_count

--- a/definitions/pipelines/tumor_only_detect_variants.cwl
+++ b/definitions/pipelines/tumor_only_detect_variants.cwl
@@ -10,9 +10,9 @@ requirements:
 inputs:
     reference:
         type: string
-    cram:
+    bam:
         type: File
-        secondaryFiles: [^.crai,.crai]
+        secondaryFiles: [^.bai,.bai]
     interval_list:
         type: File
     varscan_strand_filter:
@@ -99,7 +99,7 @@ steps:
         run: ../subworkflows/varscan_germline.cwl
         in:
             reference: reference
-            cram: cram
+            bam: bam
             interval_list: interval_list
             strand_filter: varscan_strand_filter
             min_coverage: varscan_min_coverage
@@ -113,7 +113,7 @@ steps:
         run: ../subworkflows/docm_germline.cwl
         in:
             reference: reference
-            cram: cram
+            bam: bam
             interval_list: interval_list
             docm_vcf: docm_vcf
         out:
@@ -144,20 +144,13 @@ steps:
             pick: vep_pick
         out:
             [annotated_vcf, vep_summary]
-    cram_to_bam:
-        run: ../subworkflows/cram_to_bam_and_index.cwl
-        in:
-            cram: cram
-            reference: reference
-        out:
-            [bam]
     bam_readcount:
         run: ../tools/bam_readcount.cwl
         in:
             vcf: annotate_variants/annotated_vcf
             sample: sample_name
             reference_fasta: reference
-            bam: cram_to_bam/bam
+            bam: bam
             min_mapping_quality: readcount_minimum_mapping_quality
             min_base_quality: readcount_minimum_base_quality
         out:

--- a/definitions/pipelines/umi_molecular_alignment.cwl
+++ b/definitions/pipelines/umi_molecular_alignment.cwl
@@ -29,7 +29,7 @@ outputs:
     aligned_cram:
         type: File
         secondaryFiles: [.crai, ^.crai]
-        outputSource: alignment_workflow/aligned_cram
+        outputSource: index_cram/indexed_cram
     adapter_histogram:
         type: File[]
         outputSource: alignment_workflow/adapter_histogram
@@ -59,4 +59,17 @@ steps:
             reference: reference
             target_intervals: target_intervals
         out:
-            [aligned_cram, adapter_histogram, duplex_seq_metrics]
+            [aligned_bam, adapter_histogram, duplex_seq_metrics]
+    bam_to_cram:
+        run: ../tools/bam_to_cram.cwl
+        in:
+            bam: alignment_workflow/aligned_bam
+            reference: reference
+        out:
+            [cram]
+    index_cram:
+         run: ../tools/index_cram.cwl
+         in:
+            cram: bam_to_cram/cram
+         out:
+            [indexed_cram]

--- a/definitions/pipelines/wgs.cwl
+++ b/definitions/pipelines/wgs.cwl
@@ -61,7 +61,7 @@ inputs:
 outputs:
     cram:
         type: File
-        outputSource: alignment_and_qc/cram
+        outputSource: index_cram/indexed_cram
     mark_duplicates_metrics:
         type: File
         outputSource: alignment_and_qc/mark_duplicates_metrics
@@ -159,12 +159,12 @@ steps:
             per_target_intervals: per_target_intervals
             summary_intervals: summary_intervals
         out:
-            [cram, mark_duplicates_metrics, insert_size_metrics, insert_size_histogram, alignment_summary_metrics, gc_bias_metrics, gc_bias_metrics_chart, gc_bias_metrics_summary, wgs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth, per_base_coverage_metrics, per_base_hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, summary_hs_metrics, bamcoverage_bigwig]
+            [bam, mark_duplicates_metrics, insert_size_metrics, insert_size_histogram, alignment_summary_metrics, gc_bias_metrics, gc_bias_metrics_chart, gc_bias_metrics_summary, wgs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth, per_base_coverage_metrics, per_base_hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, summary_hs_metrics, bamcoverage_bigwig]
     detect_variants:
         run: tumor_only_detect_variants.cwl
         in:
             reference: reference
-            cram: alignment_and_qc/cram
+            bam: alignment_and_qc/bam
             interval_list: variant_detection_intervals
             #varscan_strand_filter:
             #varscan_min_coverage:
@@ -185,3 +185,16 @@ steps:
             readcount_minimum_base_quality: readcount_minimum_base_quality
         out:
             [varscan_vcf, docm_gatk_vcf, annotated_vcf, final_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv]
+    bam_to_cram:
+        run: ../tools/bam_to_cram.cwl
+        in:
+            bam: alignment_and_qc/bam
+            reference: reference
+        out:
+            [cram]
+    index_cram:
+         run: ../tools/index_cram.cwl
+         in:
+            cram: bam_to_cram/cram
+         out:
+            [indexed_cram]

--- a/definitions/pipelines/wgs_alignment.cwl
+++ b/definitions/pipelines/wgs_alignment.cwl
@@ -43,9 +43,9 @@ inputs:
     summary_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
 outputs:
-    cram:
+    bam:
         type: File
-        outputSource: alignment/final_cram
+        outputSource: alignment/final_bam
     mark_duplicates_metrics:
         type: File
         outputSource: alignment/mark_duplicates_metrics_file
@@ -108,11 +108,11 @@ steps:
             known_indels: known_indels
             dbsnp_vcf: dbsnp_vcf
             bqsr_intervals: bqsr_intervals
-        out: [final_cram,mark_duplicates_metrics_file]
+        out: [final_bam,mark_duplicates_metrics_file]
     qc:
         run: ../subworkflows/qc_wgs.cwl
         in:
-            cram: alignment/final_cram
+            bam: alignment/final_bam
             reference: reference
             omni_vcf: omni_vcf
             intervals: intervals

--- a/definitions/subworkflows/bam_to_bqsr.cwl
+++ b/definitions/subworkflows/bam_to_bqsr.cwl
@@ -22,7 +22,7 @@ inputs:
         secondaryFiles: [.tbi]
     final_name:
         type: string?
-        default: 'final.cram'
+        default: 'final.bam'
     mills:
         type: File
         secondaryFiles: [.tbi]
@@ -30,10 +30,10 @@ inputs:
         type: File
         secondaryFiles: [.tbi]
 outputs:
-    final_cram:
+    final_bam:
         type: File
-        outputSource: index_cram/indexed_cram
-        secondaryFiles: [.crai, ^.crai]
+        outputSource: index_bam/indexed_bam
+        secondaryFiles: [.bai, ^.bai]
     mark_duplicates_metrics_file:
         type: File
         outputSource: mark_duplicates_and_sort/metrics_file
@@ -82,19 +82,12 @@ steps:
             reference: reference
             bam: mark_duplicates_and_sort/sorted_bam
             bqsr_table: bqsr/bqsr_table
+            output_name: final_name
         out:
             [bqsr_bam]
-    bam_to_cram:
-        run: ../tools/bam_to_cram.cwl
+    index_bam:
+        run: ../tools/index_bam.cwl
         in:
-            reference: reference
             bam: apply_bqsr/bqsr_bam
-            name: final_name
         out:
-            [cram]
-    index_cram:
-        run: ../tools/index_cram.cwl
-        in:
-            cram: bam_to_cram/cram
-        out:
-            [indexed_cram]
+            [indexed_bam]

--- a/definitions/subworkflows/docm_cle.cwl
+++ b/definitions/subworkflows/docm_cle.cwl
@@ -8,12 +8,12 @@ requirements:
 inputs:
     reference:
         type: string
-    tumor_cram:
+    tumor_bam:
         type: File
-        secondaryFiles: [^.crai]
-    normal_cram:
+        secondaryFiles: [^.bai]
+    normal_bam:
         type: File
-        secondaryFiles: [^.crai]
+        secondaryFiles: [^.bai]
     docm_vcf:
         type: File
         secondaryFiles: [.tbi]
@@ -32,8 +32,8 @@ steps:
         run: ../tools/docm_gatk_haplotype_caller.cwl
         in:
             reference: reference
-            cram: tumor_cram
-            normal_cram: normal_cram
+            bam: tumor_bam
+            normal_bam: normal_bam
             docm_vcf: docm_vcf
             interval_list: interval_list
         out:
@@ -42,8 +42,8 @@ steps:
         run: ../tools/somatic_docm_filter.cwl
         in:
             docm_out: GATK_haplotype_caller/docm_out
-            normal_cram: normal_cram
-            tumor_cram: tumor_cram
+            normal_bam: normal_bam
+            tumor_bam: tumor_bam
         out:
             [docm_filter_out]
     bgzip:

--- a/definitions/subworkflows/docm_germline.cwl
+++ b/definitions/subworkflows/docm_germline.cwl
@@ -8,9 +8,9 @@ requirements:
 inputs:
     reference:
         type: string
-    cram:
+    bam:
         type: File
-        secondaryFiles: [^.crai]
+        secondaryFiles: [^.bai]
     docm_vcf:
         type: File
         secondaryFiles: [.tbi]
@@ -29,7 +29,7 @@ steps:
         run: ../tools/docm_gatk_haplotype_caller.cwl
         in:
             reference: reference
-            cram: cram
+            bam: bam
             docm_vcf: docm_vcf
             interval_list: interval_list
         out:

--- a/definitions/subworkflows/downsampled_alignment.cwl
+++ b/definitions/subworkflows/downsampled_alignment.cwl
@@ -27,10 +27,10 @@ inputs:
     downsample_probability:
         type: float
 outputs:
-    cram:
+    bam:
         type: File
-        outputSource: align_workflow/final_cram
-        secondaryFiles: [.crai, ^.crai]
+        outputSource: align_workflow/final_bam
+        secondaryFiles: [.bai, ^.bai]
     mark_duplicates_metrics_file:
         type: File
         outputSource: align_workflow/mark_duplicates_metrics_file
@@ -55,4 +55,4 @@ steps:
             mills: mills
             known_indels: known_indels
         out:
-            [final_cram,mark_duplicates_metrics_file]
+            [final_bam,mark_duplicates_metrics_file]

--- a/definitions/subworkflows/fp_filter.cwl
+++ b/definitions/subworkflows/fp_filter.cwl
@@ -6,9 +6,9 @@ label: "fp_filter workflow"
 requirements:
     - class: SubworkflowFeatureRequirement
 inputs:
-    cram:
+    bam:
         type: File
-        secondaryFiles: [.crai,^.crai]
+        secondaryFiles: [.bai,^.bai]
     reference:
         type: string
     vcf:
@@ -30,13 +30,6 @@ outputs:
         outputSource: hard_filter/filtered_vcf
         secondaryFiles: [.tbi]
 steps:
-    cram_to_bam:
-        run: cram_to_bam_and_index.cwl
-        in:
-            cram: cram
-            reference: reference
-        out:
-            [bam]
     normalize_variants:
         run: ../tools/normalize_variants.cwl
         in:
@@ -60,7 +53,7 @@ steps:
         run: ../tools/fp_filter.cwl
         in:
             reference: reference
-            bam: cram_to_bam/bam
+            bam: bam
             vcf: index/indexed_vcf
             sample_name: sample_name
             min_var_freq: min_var_freq

--- a/definitions/subworkflows/gatk_haplotypecaller_iterator.cwl
+++ b/definitions/subworkflows/gatk_haplotypecaller_iterator.cwl
@@ -9,9 +9,9 @@ requirements:
 inputs:
     reference:
         type: string
-    cram:
+    bam:
         type: File
-        secondaryFiles: [^.crai]
+        secondaryFiles: [^.bai]
     emit_reference_confidence:
         type: string
     gvcf_gq_bands:
@@ -39,7 +39,7 @@ steps:
         run: ../tools/gatk_haplotype_caller.cwl
         in:
             reference: reference
-            cram: cram
+            bam: bam
             emit_reference_confidence: emit_reference_confidence
             gvcf_gq_bands: gvcf_gq_bands
             intervals: intervals

--- a/definitions/subworkflows/germline_detect_variants.cwl
+++ b/definitions/subworkflows/germline_detect_variants.cwl
@@ -8,7 +8,7 @@ requirements:
 inputs:
     reference:
         type: string
-    cram:
+    bam:
         type: File
     emit_reference_confidence:
         type: string
@@ -60,7 +60,7 @@ steps:
         run: gatk_haplotypecaller_iterator.cwl
         in:
             reference: reference
-            cram: cram
+            bam: bam
             emit_reference_confidence: emit_reference_confidence
             gvcf_gq_bands: gvcf_gq_bands
             intervals: intervals

--- a/definitions/subworkflows/hs_metrics.cwl
+++ b/definitions/subworkflows/hs_metrics.cwl
@@ -11,9 +11,9 @@ requirements:
     - class: StepInputExpressionRequirement
     - class: SubworkflowFeatureRequirement
 inputs:
-    cram:
+    bam:
         type: File
-        secondaryFiles: [^.crai]
+        secondaryFiles: [^.bai]
     minimum_mapping_quality:
         type: int?
     minimum_base_quality:
@@ -48,7 +48,7 @@ steps:
         scatter: [bait_intervals, target_intervals, output_prefix]
         scatterMethod: dotproduct
         in:
-            cram: cram
+            bam: bam
             reference: reference
             metric_accumulation_level:
                 valueFrom: "ALL_READS"
@@ -74,7 +74,7 @@ steps:
         scatter: [bait_intervals, target_intervals, output_prefix]
         scatterMethod: dotproduct
         in:
-            cram: cram
+            bam: bam
             reference: reference
             metric_accumulation_level:
                 valueFrom: "ALL_READS"
@@ -100,7 +100,7 @@ steps:
         scatter: [bait_intervals, target_intervals, output_prefix]
         scatterMethod: dotproduct
         in:
-            cram: cram
+            bam: bam
             reference: reference
             metric_accumulation_level:
                 valueFrom: "ALL_READS"

--- a/definitions/subworkflows/molecular_alignment.cwl
+++ b/definitions/subworkflows/molecular_alignment.cwl
@@ -18,10 +18,10 @@ inputs:
     target_intervals:
        type: File?
 outputs:
-    aligned_cram:
+    aligned_bam:
         type: File
-        secondaryFiles: [.crai, ^.crai]
-        outputSource: index_cram/indexed_cram
+        secondaryFiles: [.bai, ^.bai]
+        outputSource: index_bam/indexed_bam
     adapter_histogram:
         type: File[]
         outputSource: align/adapter_metrics
@@ -85,16 +85,9 @@ steps:
             description: sample_name
        out:
             [duplex_seq_metrics]
-    bam_to_cram:
-        run: ../tools/bam_to_cram.cwl
+    index_bam:
+        run: ../tools/index_bam.cwl
         in:
             bam: clip_overlap/clipped_bam
-            reference: reference
         out:
-            [cram]
-    index_cram:
-        run: ../tools/index_cram.cwl
-        in:
-            cram: bam_to_cram/cram
-        out:
-            [indexed_cram]
+            [indexed_bam]

--- a/definitions/subworkflows/molecular_qc.cwl
+++ b/definitions/subworkflows/molecular_qc.cwl
@@ -46,10 +46,10 @@ inputs:
     summary_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
 outputs:
-    aligned_cram:
+    aligned_bam:
         type: File
-        secondaryFiles: [.crai, ^.crai]
-        outputSource: alignment/aligned_cram
+        secondaryFiles: [.bai, ^.bai]
+        outputSource: alignment/aligned_bam
     adapter_histogram:
         type: File[]
         outputSource: alignment/adapter_histogram
@@ -102,11 +102,11 @@ steps:
             reference: reference
             target_intervals: target_intervals
         out:
-            [aligned_cram, adapter_histogram, duplex_seq_metrics]
+            [aligned_bam, adapter_histogram, duplex_seq_metrics]
     qc:
         run: qc_exome.cwl
         in:
-            cram: alignment/aligned_cram
+            bam: alignment/aligned_bam
             reference: reference
             bait_intervals: bait_intervals
             target_intervals: target_intervals

--- a/definitions/subworkflows/mutect.cwl
+++ b/definitions/subworkflows/mutect.cwl
@@ -11,12 +11,12 @@ requirements:
 inputs:
     reference:
         type: string
-    tumor_cram:
+    tumor_bam:
         type: File
-        secondaryFiles: [.crai]
-    normal_cram:
+        secondaryFiles: [.bai]
+    normal_bam:
         type: File?
-        secondaryFiles: [.crai]
+        secondaryFiles: [.bai]
     interval_list:
         type: File
     scatter_count:
@@ -57,8 +57,8 @@ steps:
         run: ../tools/mutect.cwl
         in:
             reference: reference
-            tumor_cram: tumor_cram
-            normal_cram: normal_cram
+            tumor_bam: tumor_bam
+            normal_bam: normal_bam
             interval_list: split_interval_list/split_interval_lists
             dbsnp_vcf: dbsnp_vcf
             cosmic_vcf: cosmic_vcf
@@ -84,7 +84,7 @@ steps:
         run: fp_filter.cwl
         in:
             reference: reference
-            cram: tumor_cram
+            bam: tumor_bam
             vcf: index/indexed_vcf
             variant_caller: 
                 valueFrom: "mutect"

--- a/definitions/subworkflows/pindel.cwl
+++ b/definitions/subworkflows/pindel.cwl
@@ -11,12 +11,12 @@ requirements:
 inputs:
     reference:
         type: string
-    tumor_cram:
+    tumor_bam:
         type: File
-        secondaryFiles: ["^.crai"]
-    normal_cram:
+        secondaryFiles: ["^.bai"]
+    normal_bam:
         type: File
-        secondaryFiles: ["^.crai"]
+        secondaryFiles: ["^.bai"]
     interval_list:
         type: File
     insert_size:
@@ -43,8 +43,8 @@ steps:
         run: pindel_cat.cwl
         in:
             reference: reference
-            tumor_cram: tumor_cram
-            normal_cram: normal_cram
+            tumor_bam: tumor_bam
+            normal_bam: normal_bam
             chromosome: get_chromosome_list/chromosome_list
             insert_size: insert_size
         out:
@@ -98,7 +98,7 @@ steps:
         run: fp_filter.cwl
         in:
             reference: reference
-            cram: tumor_cram
+            bam: tumor_bam
             vcf: reindex/indexed_vcf
             variant_caller: 
                 valueFrom: "pindel"

--- a/definitions/subworkflows/pindel_cat.cwl
+++ b/definitions/subworkflows/pindel_cat.cwl
@@ -9,12 +9,12 @@ requirements:
 inputs:
     reference:
         type: string
-    tumor_cram:
+    tumor_bam:
         type: File
-        secondaryFiles: ["^.crai"]
-    normal_cram:
+        secondaryFiles: ["^.bai"]
+    normal_bam:
         type: File
-        secondaryFiles: ["^.crai"]
+        secondaryFiles: ["^.bai"]
     chromosome:
         type: string
     insert_size:
@@ -29,8 +29,8 @@ steps:
         run: ../tools/pindel.cwl
         in:
             reference: reference
-            tumor_cram: tumor_cram
-            normal_cram: normal_cram
+            tumor_bam: tumor_bam
+            normal_bam: normal_bam
             insert_size: insert_size
             chromosome: chromosome
         out:

--- a/definitions/subworkflows/qc_exome.cwl
+++ b/definitions/subworkflows/qc_exome.cwl
@@ -9,9 +9,9 @@ requirements:
           - $import: ../types/labelled_file.yml
     - class: SubworkflowFeatureRequirement
 inputs:
-    cram:
+    bam:
         type: File
-        secondaryFiles: [^.crai]
+        secondaryFiles: [^.bai]
     reference:
         type: string
     bait_intervals:
@@ -75,7 +75,7 @@ steps:
     collect_insert_size_metrics:
         run: ../tools/collect_insert_size_metrics.cwl
         in:
-            cram: cram
+            bam: bam
             reference: reference
             metric_accumulation_level: picard_metric_accumulation_level
         out:
@@ -83,7 +83,7 @@ steps:
     collect_alignment_summary_metrics:
         run: ../tools/collect_alignment_summary_metrics.cwl
         in:
-            cram: cram
+            bam: bam
             reference: reference
             metric_accumulation_level: picard_metric_accumulation_level
         out:
@@ -91,7 +91,7 @@ steps:
     collect_roi_hs_metrics:
         run: ../tools/collect_hs_metrics.cwl
         in:
-            cram: cram
+            bam: bam
             reference: reference
             metric_accumulation_level:
                 valueFrom: "ALL_READS"
@@ -110,7 +110,7 @@ steps:
     collect_detailed_hs_metrics:
         run: hs_metrics.cwl
         in:
-            cram: cram
+            bam: bam
             minimum_mapping_quality: minimum_mapping_quality
             minimum_base_quality: minimum_base_quality
             per_base_intervals: per_base_intervals
@@ -122,7 +122,7 @@ steps:
     samtools_flagstat:
         run: ../tools/samtools_flagstat.cwl
         in:
-            cram: cram
+            bam: bam
         out: [flagstats]
     select_variants:
         run: ../tools/select_variants.cwl
@@ -132,17 +132,10 @@ steps:
             interval_list: target_intervals
         out:
             [filtered_vcf]
-    cram_to_bam:
-        run: cram_to_bam_and_index.cwl
-        in:
-          cram: cram
-          reference: reference
-        out:
-          [bam]
     verify_bam_id:
         run: ../tools/verify_bam_id.cwl
         in:
-            bam: cram_to_bam/bam
+            bam: bam
             vcf: select_variants/filtered_vcf
         out:
             [verify_bam_id_metrics, verify_bam_id_depth]

--- a/definitions/subworkflows/qc_wgs.cwl
+++ b/definitions/subworkflows/qc_wgs.cwl
@@ -9,9 +9,9 @@ requirements:
           - $import: ../types/labelled_file.yml
     - class: SubworkflowFeatureRequirement
 inputs:
-    cram:
+    bam:
         type: File
-        secondaryFiles: [^.crai]
+        secondaryFiles: [^.bai]
     reference:
         type: string
     intervals:
@@ -85,7 +85,7 @@ steps:
     collect_insert_size_metrics:
         run: ../tools/collect_insert_size_metrics.cwl
         in:
-            cram: cram
+            bam: bam
             reference: reference
             metric_accumulation_level: picard_metric_accumulation_level
         out:
@@ -93,7 +93,7 @@ steps:
     collect_alignment_summary_metrics:
         run: ../tools/collect_alignment_summary_metrics.cwl
         in:
-            cram: cram
+            bam: bam
             reference: reference
             metric_accumulation_level: picard_metric_accumulation_level
         out:
@@ -101,7 +101,7 @@ steps:
     collect_gc_bias_metrics:
         run: ../tools/collect_gc_bias_metrics.cwl
         in:
-            cram: cram
+            bam: bam
             reference: reference
             metric_accumulation_level: picard_metric_accumulation_level
         out:
@@ -109,7 +109,7 @@ steps:
     collect_wgs_metrics:
         run: ../tools/collect_wgs_metrics.cwl
         in:
-            cram: cram
+            bam: bam
             reference: reference
             intervals: intervals
         out:
@@ -117,26 +117,19 @@ steps:
     samtools_flagstat:
         run: ../tools/samtools_flagstat.cwl
         in:
-            cram: cram
+            bam: bam
         out: [flagstats]
-    cram_to_bam:
-        run: cram_to_bam_and_index.cwl
-        in:
-          cram: cram
-          reference: reference
-        out:
-          [bam]
     verify_bam_id:
         run: ../tools/verify_bam_id.cwl
         in:
-            bam: cram_to_bam/bam
+            bam: bam
             vcf: omni_vcf
         out:
             [verify_bam_id_metrics, verify_bam_id_depth]
     collect_hs_metrics:
         run: hs_metrics.cwl
         in:
-            cram: cram
+            bam: bam
             minimum_mapping_quality: minimum_mapping_quality
             minimum_base_quality: minimum_base_quality
             per_base_intervals: per_base_intervals
@@ -148,7 +141,7 @@ steps:
     deeptools_bamcoverage:
         run: ../tools/deeptools_bamcoverage.cwl
         in:
-            bam: cram
+            bam: bam
             min_mapping_quality: minimum_mapping_quality
         out:
             [outfile]

--- a/definitions/subworkflows/single_sample_sv_callers.cwl
+++ b/definitions/subworkflows/single_sample_sv_callers.cwl
@@ -8,8 +8,9 @@ requirements:
     - class: MultipleInputFeatureRequirement
     - class: SubworkflowFeatureRequirement
 inputs:
-    cram:
+    bam:
         type: File
+        secondaryFiles: [.bai,^.bai]
     reference:
         type: string
 
@@ -81,19 +82,6 @@ outputs:
         outputSource: run_smoove/output_vcf
 
 steps:
-    cram_to_bam:
-        run: ../tools/cram_to_bam.cwl
-        in:
-            cram: cram
-            reference: reference
-        out:
-            [bam]
-    index_bam:
-        run: ../tools/index_bam.cwl
-        in:
-            bam: cram_to_bam/bam
-        out:
-            [indexed_bam]
     run_cnvkit:
         run: cnvkit_single_sample.cwl
         in:
@@ -101,7 +89,7 @@ steps:
             drop_low_coverage: cnvkit_drop_low_coverage
             method: cnvkit_method
             reference_cnn: cnvkit_reference_cnn
-            tumor_bam: index_bam/indexed_bam
+            tumor_bam: bam
             scatter_plot: cnvkit_scatter_plot
             male_reference: cnvkit_male_reference
             cnvkit_vcf_name: cnvkit_vcf_name
@@ -114,14 +102,14 @@ steps:
             non_wgs: manta_non_wgs
             output_contigs: manta_output_contigs
             reference: reference
-            tumor_bam: index_bam/indexed_bam
+            tumor_bam: bam
         out: 
             [diploid_variants, somatic_variants, all_candidates, small_candidates, tumor_only_variants]
     run_smoove:
         run: ../tools/smoove.cwl
         in:
             bams:
-                source: [index_bam/indexed_bam]
+                source: [bam]
                 linkMerge: merge_flattened
             exclude_regions: smoove_exclude_regions
             reference: reference

--- a/definitions/subworkflows/strelka_and_post_processing.cwl
+++ b/definitions/subworkflows/strelka_and_post_processing.cwl
@@ -9,12 +9,12 @@ requirements:
     - class: MultipleInputFeatureRequirement
     - class: StepInputExpressionRequirement
 inputs:
-    tumor_cram:
+    tumor_bam:
         type: File
-        secondaryFiles: [.crai,^.crai]
-    normal_cram:
+        secondaryFiles: [.bai,^.bai]
+    normal_bam:
         type: File
-        secondaryFiles: [.crai,^.crai]
+        secondaryFiles: [.bai,^.bai]
     reference:
         type: string
     interval_list:
@@ -37,8 +37,8 @@ steps:
     strelka:
         run: ../tools/strelka.cwl
         in:
-            tumor_cram: tumor_cram
-            normal_cram: normal_cram
+            tumor_bam: tumor_bam
+            normal_bam: normal_bam
             reference: reference
             exome_mode: exome_mode
             cpu_reserved: cpu_reserved
@@ -75,7 +75,7 @@ steps:
         run: fp_filter.cwl
         in:
             reference: reference
-            cram: tumor_cram
+            bam: tumor_bam
             vcf: region_filter/filtered_vcf
             variant_caller: 
                 valueFrom: "strelka"

--- a/definitions/subworkflows/varscan.cwl
+++ b/definitions/subworkflows/varscan.cwl
@@ -6,12 +6,12 @@ label: "varscan somatic workflow"
 inputs:
     reference:
         type: string
-    tumor_cram:
+    tumor_bam:
         type: File
-        secondaryFiles: [^.crai]
-    normal_cram:
+        secondaryFiles: [^.bai]
+    normal_bam:
         type: File
-        secondaryFiles: [^.crai]
+        secondaryFiles: [^.bai]
     roi_bed:
         type: File?
     strand_filter:
@@ -72,8 +72,8 @@ steps:
         run: ../tools/varscan_somatic.cwl
         in:
             reference: reference
-            normal_cram: normal_cram
-            tumor_cram: tumor_cram
+            normal_bam: normal_bam
+            tumor_bam: tumor_bam
             roi_bed: roi_bed
             strand_filter: strand_filter
             min_coverage: min_coverage

--- a/definitions/subworkflows/varscan_germline.cwl
+++ b/definitions/subworkflows/varscan_germline.cwl
@@ -10,9 +10,9 @@ requirements:
 inputs:
     reference:
         type: string
-    cram:
+    bam:
         type: File
-        secondaryFiles: [^.crai]
+        secondaryFiles: [^.bai]
     interval_list:
         type: File
     strand_filter:
@@ -53,7 +53,7 @@ steps:
         run: ../tools/varscan_germline.cwl
         in:
             reference: reference
-            cram: cram
+            bam: bam
             roi_bed: intervals_to_bed/interval_bed
             strand_filter: strand_filter
             min_coverage: min_coverage
@@ -73,7 +73,7 @@ steps:
         run: fp_filter.cwl
         in:
             reference: reference
-            cram: cram
+            bam: bam
             vcf: bgzip_and_index/indexed_vcf
             variant_caller:
                 valueFrom: "varscan"

--- a/definitions/subworkflows/varscan_pre_and_post_processing.cwl
+++ b/definitions/subworkflows/varscan_pre_and_post_processing.cwl
@@ -10,12 +10,12 @@ requirements:
 inputs:
     reference:
         type: string
-    tumor_cram:
+    tumor_bam:
         type: File
-        secondaryFiles: [^.crai]
-    normal_cram:
+        secondaryFiles: [^.bai]
+    normal_bam:
         type: File
-        secondaryFiles: [^.crai]
+        secondaryFiles: [^.bai]
     interval_list:
         type: File
     strand_filter:
@@ -52,8 +52,8 @@ steps:
         run: varscan.cwl
         in:
             reference: reference
-            tumor_cram: tumor_cram
-            normal_cram: normal_cram
+            tumor_bam: tumor_bam
+            normal_bam: normal_bam
             roi_bed: intervals_to_bed/interval_bed
             strand_filter: strand_filter
             min_coverage: min_coverage
@@ -130,7 +130,7 @@ steps:
         run: fp_filter.cwl
         in:
             reference: reference
-            cram: tumor_cram
+            bam: tumor_bam
             vcf: index/indexed_vcf
             min_var_freq: min_var_freq
             variant_caller: 

--- a/definitions/tools/apply_bqsr.cwl
+++ b/definitions/tools/apply_bqsr.cwl
@@ -5,7 +5,7 @@ class: CommandLineTool
 label: 'apply BQSR'
 baseCommand: ["/usr/bin/java", "-Xmx16g", "-jar", "/opt/GenomeAnalysisTK.jar", "-T", "PrintReads"]
 arguments:
-    ["-o", { valueFrom: $(runtime.outdir)/Final.bam },
+    ["-o", { valueFrom: $(runtime.outdir)/$(inputs.output_name) },
     "-preserveQ", "6",
     "-SQQ", "10",
     "-SQQ", "20",
@@ -34,9 +34,12 @@ inputs:
         inputBinding:
             prefix: "-BQSR"
             position: 3
+    output_name:
+        type: string?
+        default: Final.bam
 outputs:
     bqsr_bam:
         type: File
         outputBinding:
-            glob: "Final.bam"
+            glob: $(inputs.output_name)
         secondaryFiles: [^.bai]

--- a/definitions/tools/bam_to_cram.cwl
+++ b/definitions/tools/bam_to_cram.cwl
@@ -9,7 +9,7 @@ requirements:
       dockerPull: "mgibio/samtools-cwl:1.0.0"
     - class: ResourceRequirement
       ramMin: 4000
-stdout: $(inputs.name)
+stdout: "$(inputs.bam.nameroot).cram"
 inputs:
     reference:
         type: string
@@ -20,9 +20,6 @@ inputs:
         type: File
         inputBinding:
             position: 2
-    name:
-        type: string?
-        default: 'final.cram'
 outputs:
     cram:
         type: stdout

--- a/definitions/tools/collect_alignment_summary_metrics.cwl
+++ b/definitions/tools/collect_alignment_summary_metrics.cwl
@@ -5,18 +5,18 @@ class: CommandLineTool
 label: "collect alignment summary metrics"
 baseCommand: ["/usr/bin/java", "-Xmx16g", "-jar", "/usr/picard/picard.jar", "CollectAlignmentSummaryMetrics"]
 arguments:
-    ["OUTPUT=", { valueFrom: $(runtime.outdir)/$(inputs.cram.nameroot).AlignmentSummaryMetrics.txt }]
+    ["OUTPUT=", { valueFrom: $(runtime.outdir)/$(inputs.bam.nameroot).AlignmentSummaryMetrics.txt }]
 requirements:
     - class: ResourceRequirement
       ramMin: 18000
     - class: DockerRequirement
       dockerPull: "mgibio/picard-cwl:2.18.1"
 inputs:
-    cram:
+    bam:
         type: File
         inputBinding:
             prefix: "INPUT="
-        secondaryFiles: [^.crai]
+        secondaryFiles: [^.bai]
     reference:
         type: string
         inputBinding:
@@ -29,4 +29,4 @@ outputs:
     alignment_summary_metrics:
         type: File
         outputBinding:
-            glob: "$(inputs.cram.nameroot).AlignmentSummaryMetrics.txt"
+            glob: "$(inputs.bam.nameroot).AlignmentSummaryMetrics.txt"

--- a/definitions/tools/collect_gc_bias_metrics.cwl
+++ b/definitions/tools/collect_gc_bias_metrics.cwl
@@ -14,11 +14,11 @@ requirements:
     - class: DockerRequirement
       dockerPull: mgibio/cle:v1.3.1
 inputs:
-    cram:
+    bam:
         type: File
         inputBinding:
             prefix: "I="
-        secondaryFiles: [^.crai]
+        secondaryFiles: [^.bai]
     reference:
         type: string
         inputBinding:

--- a/definitions/tools/collect_hs_metrics.cwl
+++ b/definitions/tools/collect_hs_metrics.cwl
@@ -5,7 +5,7 @@ class: CommandLineTool
 label: "collect HS metrics"
 baseCommand: ["/usr/bin/java", "-Xmx32g", "-jar", "/usr/picard/picard.jar", "CollectHsMetrics"]
 arguments:
-    ["O=", { valueFrom: $(runtime.outdir)/$(inputs.cram.nameroot).$(inputs.output_prefix)-HsMetrics.txt }]
+    ["O=", { valueFrom: $(runtime.outdir)/$(inputs.bam.nameroot).$(inputs.output_prefix)-HsMetrics.txt }]
 requirements:
     - class: ResourceRequirement
       ramMin: 36000
@@ -13,11 +13,11 @@ requirements:
     - class: DockerRequirement
       dockerPull: "mgibio/picard-cwl:2.18.1"
 inputs:
-    cram:
+    bam:
         type: File
         inputBinding:
             prefix: "I="
-        secondaryFiles: [^.crai]
+        secondaryFiles: [^.bai]
     reference:
         type: string
         inputBinding:
@@ -41,7 +41,7 @@ inputs:
             valueFrom: |
                         ${
                             if(self) {
-                                return inputs.cram.nameroot + "." + inputs.output_prefix + "-PerTargetCoverage.txt"
+                                return inputs.bam.nameroot + "." + inputs.output_prefix + "-PerTargetCoverage.txt"
                             } else {
                                 return false;
                             }
@@ -53,7 +53,7 @@ inputs:
             valueFrom: |
                         ${
                             if(self) {
-                                return inputs.cram.nameroot + "." + inputs.output_prefix + "-PerBaseCoverage.txt"
+                                return inputs.bam.nameroot + "." + inputs.output_prefix + "-PerBaseCoverage.txt"
                             } else {
                                 return false;
                             }
@@ -75,12 +75,12 @@ outputs:
     hs_metrics:
         type: File
         outputBinding:
-            glob: "$(inputs.cram.nameroot).$(inputs.output_prefix)-HsMetrics.txt"
+            glob: "$(inputs.bam.nameroot).$(inputs.output_prefix)-HsMetrics.txt"
     per_target_coverage_metrics:
         type: File?
         outputBinding:
-            glob: "$(inputs.cram.nameroot).$(inputs.output_prefix)-PerTargetCoverage.txt"
+            glob: "$(inputs.bam.nameroot).$(inputs.output_prefix)-PerTargetCoverage.txt"
     per_base_coverage_metrics:
         type: File?
         outputBinding:
-            glob: "$(inputs.cram.nameroot).$(inputs.output_prefix)-PerBaseCoverage.txt"
+            glob: "$(inputs.bam.nameroot).$(inputs.output_prefix)-PerBaseCoverage.txt"

--- a/definitions/tools/collect_insert_size_metrics.cwl
+++ b/definitions/tools/collect_insert_size_metrics.cwl
@@ -5,19 +5,19 @@ class: CommandLineTool
 label: "collect insert size metrics"
 baseCommand: ["/usr/bin/java", "-Xmx16g", "-jar", "/usr/picard/picard.jar", "CollectInsertSizeMetrics"]
 arguments:
-    ["O=", { valueFrom: $(runtime.outdir)/$(inputs.cram.nameroot).InsertSizeMetrics.txt },
-    "H=", { valueFrom: $(runtime.outdir)/$(inputs.cram.nameroot).InsertSizeHistogram.pdf }]
+    ["O=", { valueFrom: $(runtime.outdir)/$(inputs.bam.nameroot).InsertSizeMetrics.txt },
+    "H=", { valueFrom: $(runtime.outdir)/$(inputs.bam.nameroot).InsertSizeHistogram.pdf }]
 requirements:
     - class: ResourceRequirement
       ramMin: 18000
     - class: DockerRequirement
       dockerPull: "mgibio/picard-cwl:2.18.1"
 inputs:
-    cram:
+    bam:
         type: File
         inputBinding:
             prefix: "I="
-        secondaryFiles: [^.crai]
+        secondaryFiles: [^.bai]
     reference:
         type: string
         inputBinding:
@@ -30,8 +30,8 @@ outputs:
     insert_size_metrics:
         type: File
         outputBinding:
-            glob: "$(inputs.cram.nameroot).InsertSizeMetrics.txt"
+            glob: "$(inputs.bam.nameroot).InsertSizeMetrics.txt"
     insert_size_histogram:
         type: File
         outputBinding:
-            glob: "$(inputs.cram.nameroot).InsertSizeHistogram.pdf"
+            glob: "$(inputs.bam.nameroot).InsertSizeHistogram.pdf"

--- a/definitions/tools/collect_wgs_metrics.cwl
+++ b/definitions/tools/collect_wgs_metrics.cwl
@@ -12,11 +12,11 @@ requirements:
     - class: DockerRequirement
       dockerPull: mgibio/cle:v1.3.1
 inputs:
-    cram:
+    bam:
         type: File
         inputBinding:
             prefix: "I="
-        secondaryFiles: [^.crai]
+        secondaryFiles: [^.bai]
     reference:
         type: string
         inputBinding:

--- a/definitions/tools/docm_gatk_haplotype_caller.cwl
+++ b/definitions/tools/docm_gatk_haplotype_caller.cwl
@@ -18,18 +18,18 @@ inputs:
         inputBinding:
             prefix: "-R"
             position: 1
-    normal_cram:
+    normal_bam:
         type: File?
         inputBinding:
             prefix: "-I"
             position: 2
-        secondaryFiles: [^.crai]
-    cram:
+        secondaryFiles: [^.bai]
+    bam:
         type: File
         inputBinding:
             prefix: "-I"
             position: 3
-        secondaryFiles: [^.crai]
+        secondaryFiles: [^.bai]
     docm_vcf:
         type: File
         inputBinding:

--- a/definitions/tools/gatk_haplotype_caller.cwl
+++ b/definitions/tools/gatk_haplotype_caller.cwl
@@ -15,12 +15,12 @@ inputs:
         inputBinding:
             prefix: "-R"
             position: 1
-    cram:
+    bam:
         type: File
         inputBinding:
             prefix: "-I"
             position: 2
-        secondaryFiles: [^.crai]
+        secondaryFiles: [^.bai]
     emit_reference_confidence:
         type: string
         inputBinding:

--- a/definitions/tools/index_bam.cwl
+++ b/definitions/tools/index_bam.cwl
@@ -6,7 +6,9 @@ label: "samtools index"
 arguments: [
     "cp", $(inputs.bam.path), "$(runtime.outdir)/$(inputs.bam.basename)",
     { valueFrom: " && ", shellQuote: false },
-    "/opt/samtools/bin/samtools", "index", $(inputs.bam.path), "$(runtime.outdir)/$(inputs.bam.basename).bai"
+    "/opt/samtools/bin/samtools", "index", $(inputs.bam.path), "$(runtime.outdir)/$(inputs.bam.basename).bai",
+    { valueFrom: " && ", shellQuote: false },
+    "ln", "-s", "$(inputs.bam.basename).bai", "$(runtime.outdir)/$(inputs.bam.nameroot).bai"
 ]
 requirements:
     - class: ShellCommandRequirement
@@ -20,6 +22,6 @@ inputs:
 outputs:
     indexed_bam:
         type: File
-        secondaryFiles: [.bai]
+        secondaryFiles: [.bai, ^.bai]
         outputBinding:
             glob: $(inputs.bam.basename)

--- a/definitions/tools/mutect.cwl
+++ b/definitions/tools/mutect.cwl
@@ -18,18 +18,18 @@ inputs:
         inputBinding:
             prefix: "-R"
             position: 1
-    tumor_cram:
+    tumor_bam:
         type: File
         inputBinding:
             prefix: "-I:tumor"
             position: 2
-        secondaryFiles: [.crai]
-    normal_cram:
+        secondaryFiles: [.bai]
+    normal_bam:
         type: File?
         inputBinding:
             prefix: "-I:normal"
             position: 3
-        secondaryFiles: [.crai]
+        secondaryFiles: [.bai]
     interval_list:
         type: File
         inputBinding:

--- a/definitions/tools/pindel.cwl
+++ b/definitions/tools/pindel.cwl
@@ -5,7 +5,7 @@ class: CommandLineTool
 label: "pindel v0.2.5b8"
 arguments: [
     "/usr/bin/perl", "/usr/bin/pindel_helper.pl",
-    $(inputs.normal_cram.path), $(inputs.tumor_cram.path), $(inputs.insert_size)
+    $(inputs.normal_bam.path), $(inputs.tumor_bam.path), $(inputs.insert_size)
 ]
 requirements:
     - class: ResourceRequirement
@@ -14,12 +14,12 @@ requirements:
     - class: DockerRequirement
       dockerPull: "mgibio/cle:v1.3.1"
 inputs:
-    tumor_cram:
+    tumor_bam:
         type: File
-        secondaryFiles: ["^.crai"]
-    normal_cram:
+        secondaryFiles: ["^.bai"]
+    normal_bam:
         type: File
-        secondaryFiles: ["^.crai"]
+        secondaryFiles: ["^.bai"]
     reference:
         type: string
         inputBinding:

--- a/definitions/tools/samtools_flagstat.cwl
+++ b/definitions/tools/samtools_flagstat.cwl
@@ -9,13 +9,13 @@ requirements:
       ramMin: 4000
     - class: DockerRequirement
       dockerPull: "mgibio/samtools-cwl:1.0.0"
-stdout: "$(inputs.cram.basename).flagstat"
+stdout: "$(inputs.bam.basename).flagstat"
 inputs:
-    cram:
+    bam:
         type: File
         inputBinding:
             position: 1
-        secondaryFiles: [^.crai]
+        secondaryFiles: [^.bai]
 outputs:
     flagstats:
         type: stdout

--- a/definitions/tools/somatic_docm_filter.cwl
+++ b/definitions/tools/somatic_docm_filter.cwl
@@ -10,14 +10,14 @@ requirements:
     - class: ResourceRequirement
       ramMin: 4000
 arguments: [
-    $(inputs.docm_out.path), $(inputs.normal_cram.path), $(inputs.tumor_cram.path), $(runtime.outdir)
+    $(inputs.docm_out.path), $(inputs.normal_bam.path), $(inputs.tumor_bam.path), $(runtime.outdir)
 ]
 inputs:
     docm_out:
         type: File
-    normal_cram:
+    normal_bam:
         type: File
-    tumor_cram:
+    tumor_bam:
         type: File
 outputs:
     docm_filter_out:

--- a/definitions/tools/strelka.cwl
+++ b/definitions/tools/strelka.cwl
@@ -14,20 +14,20 @@ arguments:
     [ { valueFrom: $(inputs.cpu_reserved), position: 1 },
       { valueFrom: $(runtime.outdir), position: 2 }]
 inputs:
-    tumor_cram:
+    tumor_bam:
         type: File
         inputBinding:
             prefix: '--tumorBam='
             separate: false
             position: 3
-        secondaryFiles: [.crai,^.crai]
-    normal_cram:
+        secondaryFiles: [.bai,^.bai]
+    normal_bam:
         type: File
         inputBinding:
             prefix: '--normalBam='
             separate: false
             position: 4
-        secondaryFiles: [.crai,^.crai]
+        secondaryFiles: [.bai,^.bai]
     reference:
         type: string
         inputBinding:

--- a/definitions/tools/varscan_germline.cwl
+++ b/definitions/tools/varscan_germline.cwl
@@ -13,11 +13,11 @@ arguments:
     - position: 9
       valueFrom: "$(runtime.outdir)/output.vcf"
 inputs:
-    cram:
+    bam:
         type: File
         inputBinding:
             position: 1
-        secondaryFiles: [^.crai]
+        secondaryFiles: [^.bai]
     reference:
         type: string
         inputBinding:

--- a/definitions/tools/varscan_somatic.cwl
+++ b/definitions/tools/varscan_somatic.cwl
@@ -10,16 +10,16 @@ requirements:
     - class: DockerRequirement
       dockerPull: "mgibio/cle:v1.3.1"
 inputs:
-    tumor_cram:
+    tumor_bam:
         type: File
         inputBinding:
             position: 1
-        secondaryFiles: [^.crai]
-    normal_cram:
+        secondaryFiles: [^.bai]
+    normal_bam:
         type: File
         inputBinding:
             position: 2
-        secondaryFiles: [^.crai]
+        secondaryFiles: [^.bai]
     reference:
         type: string
         inputBinding:


### PR DESCRIPTION
This converts tools that previously accepted CRAM to instead accept BAM inputs.  Theoretically we could go with something like this to support both, instead:
https://github.com/genome/analysis-workflows/blob/64e10813d527c67ed7987697d5c47cdbbaadbebd/definitions/tools/manta_somatic.cwl#L29

It successfully runs on the `somatic_exome.yaml` example workflow, but I haven't tested it on anything else.