### PR TITLE
New Filter Consensus Params for Single-Molecule

### DIFF
--- a/definitions/subworkflows/duplex_alignment.cwl
+++ b/definitions/subworkflows/duplex_alignment.cwl
@@ -17,6 +17,21 @@ inputs:
         type: string
     target_intervals:
        type: File?
+    min_reads:
+       type: int
+       default: [10, 5, 3]
+    max_read_error_rate:
+       type: float?
+       default: 0.05
+    max_base_error_rate:
+       type: float?
+       default: 0.1
+    min_base_quality:
+       type: int
+       default: 50
+    max_no_call_fraction:
+       type: float
+       default: 0.05
 outputs:
     aligned_bam:
         type: File
@@ -68,6 +83,11 @@ steps:
         in:
             bam: align_consensus/consensus_aligned_bam
             reference: reference
+            min_reads: min_reads
+            max_read_error_rate: max_read_error_rate
+            max_base_error_rate: max_base_error_rate
+            min_base_quality: min_base_quality
+            max_no_call_fraction: max_no_call_fraction
         out:
             [filtered_bam]
     clip_overlap:

--- a/definitions/subworkflows/duplex_alignment.cwl
+++ b/definitions/subworkflows/duplex_alignment.cwl
@@ -18,7 +18,7 @@ inputs:
     target_intervals:
        type: File?
     min_reads:
-       type: int
+       type: int[]
        default: [10, 5, 3]
     max_read_error_rate:
        type: float?

--- a/definitions/subworkflows/molecular_alignment.cwl
+++ b/definitions/subworkflows/molecular_alignment.cwl
@@ -18,8 +18,8 @@ inputs:
     target_intervals:
        type: File?
     min_reads:
-       type: int
-       default: 1
+       type: int[]
+       default: [1]
     max_read_error_rate:
        type: float?
        default: 0.05 

--- a/definitions/subworkflows/molecular_alignment.cwl
+++ b/definitions/subworkflows/molecular_alignment.cwl
@@ -17,6 +17,21 @@ inputs:
         type: string
     target_intervals:
        type: File?
+    min_reads:
+       type: int
+       default: 1
+    max_read_error_rate:
+       type: float?
+       default: 0.05 
+    max_base_error_rate:
+       type: float?
+       default: 0.1
+    min_base_quality:
+       type: int
+       default: 1
+    max_no_call_fraction:
+       type: float
+       default: 0.5
 outputs:
     aligned_cram:
         type: File
@@ -68,6 +83,11 @@ steps:
         in:
             bam: align_consensus/consensus_aligned_bam
             reference: reference
+            min_reads: min_reads
+            max_read_error_rate: max_read_error_rate
+            max_base_error_rate: max_base_error_rate
+            min_base_quality: min_base_quality
+            max_no_call_fraction: max_no_call_fraction
         out:
             [filtered_bam]
     clip_overlap:

--- a/definitions/subworkflows/molecular_qc.cwl
+++ b/definitions/subworkflows/molecular_qc.cwl
@@ -22,14 +22,6 @@ inputs:
         type: File
     bait_intervals:
         type: File
-    per_target_intervals:
-        type: File
-    per_target_bait_intervals:
-        type: File
-    per_base_intervals:
-        type: File
-    per_base_bait_intervals:
-        type: File
     omni_vcf:
         type: File
         secondaryFiles: [.tbi]

--- a/definitions/tools/filter_consensus.cwl
+++ b/definitions/tools/filter_consensus.cwl
@@ -24,7 +24,6 @@ inputs:
     min_reads:
         type: int[]
         inputBinding:
-            itemSeparator: ' '
             prefix: "--min-reads"
     max_read_error_rate:
         type: float?

--- a/definitions/tools/filter_consensus.cwl
+++ b/definitions/tools/filter_consensus.cwl
@@ -5,10 +5,7 @@ class: CommandLineTool
 label: 'filter consensus reads'
 baseCommand: ["/usr/bin/java", "-Xmx4g", "-jar", "/opt/fgbio-0.5.0.jar", "FilterConsensusReads"]
 arguments:
-    ["--min-reads", "10", "5", "3", "--max-read-error-rate", "0.05",
-    "--max-base-error-rate", "0.1", "--min-base-quality", "50",
-    "--max-no-call-fraction", "0.05",
-    "--output", { valueFrom: "$(runtime.outdir)/consensus_filtered.bam"} ]
+    [ "--output", { valueFrom: "$(runtime.outdir)/consensus_filtered.bam"} ]
 requirements:
     - class: ResourceRequirement
       ramMin: 6000
@@ -24,6 +21,27 @@ inputs:
         type: string
         inputBinding:
             prefix: "--ref"
+    min_reads:
+        type: int[]
+        inputBinding:
+            itemSeparator: ' '
+            prefix: "--min-reads"
+    max_read_error_rate:
+        type: float?
+        inputBinding:
+            prefix: "--max-read-error-rate"
+    max_base_error_rate:
+        type: float?
+        inputBinding:
+            prefix: "--max-base-error-rate"
+    min_base_quality:
+        type: int
+        inputBinding:
+            prefix: "--min-base-quality"
+    max_no_call_fraction:
+        type: float?
+        inputBinding:
+            prefix: "--max-no-call-fraction"
 outputs:
     filtered_bam:
         type: File


### PR DESCRIPTION
The duplex parameters are way too strict for single-molecule consensus calling. Most of the UMI sequencing we do is not designed for consensus calling at all. Rather than ignore the UMIs, make single-molecule consensus reads but relax the parameters to allow nearly all consensus reads of reasonable quality pass.

This should replace PR #599 since the raw alignments are not really needed. 

NOTE: keeping the original alignments is not the right approach unless we implemented UMI-aware duplicate marking. The net effect is similar to this single-molecule consensus calling with relaxed params.