### PR TITLE
adding survivor to single_sample_sv_caller.cwl

### DIFF
--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -89,6 +89,20 @@ inputs:
         type: boolean?
     smoove_exclude_regions:
         type: File?
+    merge_max_distance:
+        type: int
+    merge_min_svs:
+        type: int
+    merge_same_type:
+        type: boolean
+    merge_same_strand:
+        type: boolean
+    merge_estimate_sv_distance:
+        type: boolean
+    merge_min_sv_size:
+        type: int
+    merge_sv_pop_freq_db:
+        type: File
 outputs:
     cram:
         type: File
@@ -201,6 +215,9 @@ outputs:
     smoove_output_variants:
         type: File
         outputSource: variant_callers/smoove_output_variants
+    merged_annotated_svs:
+        type: File
+        outputSource: variant_callers/merged_annotated_svs
 steps:
     alignment_and_qc:
         run: wgs_alignment.cwl
@@ -281,8 +298,15 @@ steps:
             manta_non_wgs: manta_non_wgs
             manta_output_contigs: manta_output_contigs
             smoove_exclude_regions: smoove_exclude_regions
+            merge_max_distance: merge_max_distance
+            merge_min_svs: merge_min_svs
+            merge_same_type: merge_same_type
+            merge_same_strand: merge_same_strand
+            merge_estimate_sv_distance: merge_estimate_sv_distance
+            merge_min_sv_size: merge_min_sv_size
+            merge_sv_pop_freq_db: merge_sv_pop_freq_db
         out: 
-           [cn_diagram, cn_scatter_plot, tumor_antitarget_coverage, tumor_target_coverage, tumor_bin_level_ratios, tumor_segmented_ratios, cnvkit_vcf, manta_diploid_variants, manta_somatic_variants, manta_all_candidates, manta_small_candidates, manta_tumor_only_variants, smoove_output_variants] 
+           [cn_diagram, cn_scatter_plot, tumor_antitarget_coverage, tumor_target_coverage, tumor_bin_level_ratios, tumor_segmented_ratios, cnvkit_vcf, manta_diploid_variants, manta_somatic_variants, manta_all_candidates, manta_small_candidates, manta_tumor_only_variants, smoove_output_variants, merged_annotated_svs]
     bam_to_cram:
         run: ../tools/bam_to_cram.cwl
         in:

--- a/definitions/subworkflows/merge_svs.cwl
+++ b/definitions/subworkflows/merge_svs.cwl
@@ -13,11 +13,11 @@ inputs:
     minimum_sv_calls:
         type: int
     same_type:
-        type: int
+        type: boolean
     same_strand:
-        type: int
+        type: boolean
     estimate_sv_distance:
-        type: int
+        type: boolean
     minimum_sv_size:
         type: int
     cohort_name:

--- a/definitions/subworkflows/single_sample_sv_callers.cwl
+++ b/definitions/subworkflows/single_sample_sv_callers.cwl
@@ -37,6 +37,21 @@ inputs:
     manta_output_contigs:
         type: boolean?
 
+    merge_max_distance:
+        type: int
+    merge_min_svs:
+        type: int
+    merge_same_type:
+        type: boolean
+    merge_same_strand:
+        type: boolean
+    merge_estimate_sv_distance:
+        type: boolean
+    merge_min_sv_size:
+        type: int
+    merge_sv_pop_freq_db:
+        type: File
+
     smoove_exclude_regions:
         type: File?
 
@@ -80,6 +95,9 @@ outputs:
     smoove_output_variants:
         type: File
         outputSource: run_smoove/output_vcf
+    merged_annotated_svs:
+        type: File
+        outputSource: run_merge/merged_annotated_vcf
 steps:
     run_cnvkit:
         run: cnvkit_single_sample.cwl
@@ -114,3 +132,18 @@ steps:
             reference: reference
         out:
             [output_vcf]
+    run_merge:
+        run: merge_svs.cwl
+        in:
+            vcfs:
+                source: [run_cnvkit/cnvkit_vcf, run_manta/tumor_only_variants, run_smoove/output_vcf]
+                linkMerge: merge_flattened
+            max_distance_to_merge: merge_max_distance
+            minimum_sv_calls: merge_min_svs
+            same_type: merge_same_type
+            same_strand: merge_same_strand
+            estimate_sv_distance: merge_estimate_sv_distance
+            minimum_sv_size: merge_min_sv_size
+            sv_db: merge_sv_pop_freq_db
+        out:
+            [merged_annotated_vcf]

--- a/definitions/tools/survivor.cwl
+++ b/definitions/tools/survivor.cwl
@@ -7,6 +7,7 @@ label: "Run SURVIVOR to merge SV calls"
 baseCommand: ["/bin/bash", "/usr/bin/survivor_merge_helper.sh"]
 
 requirements:
+    - class: InlineJavascriptRequirement
     - class: DockerRequirement
       dockerPull: "mgibio/survivor-cwl:1.0.6.1"
     - class: ResourceRequirement
@@ -31,20 +32,44 @@ inputs:
             position: 3
         doc: "Minimum number of sv calls needed to be merged"
     same_type:
-        type: int
+        type: boolean
         inputBinding:
             position: 4
-        doc: "Require merged SVs to be of the same type, 1=yes, 0=no"
+            valueFrom: |
+                ${
+                  if(inputs.same_type){
+                    return "1";
+                  } else {
+                    return "0";
+                  }
+                }
+        doc: "Require merged SVs to be of the same type"
     same_strand:
-        type: int
+        type: boolean
         inputBinding:
             position: 5
-        doc: "Require merged SVs to be on the same strand, 1=yes, 0=no"
+            valueFrom: |
+                ${
+                  if(inputs.same_strand){
+                    return "1";
+                  } else {
+                    return "0";
+                  }
+                }
+        doc: "Require merged SVs to be on the same strand"
     estimate_sv_distance:
-        type: int
+        type: boolean
         inputBinding:
             position: 6
-        doc: "Estimate distance based on the size of SV, 1=yes, 0=no"
+            valueFrom: |
+                ${
+                  if(inputs.estimate_sv_distance){
+                    return "1";
+                  } else {
+                    return "0";
+                  }
+                }
+        doc: "Estimate distance based on the size of SV"
     minimum_sv_size:
         type: int
         inputBinding:


### PR DESCRIPTION
This pr does a few things first I added javascript expressions to handle boolean values for inputs into survivor(thanks to @tmooney for the suggestion). That should make it easier to use and understand the survivor parameters in the pipeline.
Second added the `merge_svs.cwl` subworkflow into the `single_sample_sv_caller.cwl` subworkflow.
Third updated the `germline_wgs.cwl` pipeline to pass down the newly required inputs.

Confirmed that the updated `single_sample_sv_caller.cwl` works with a small test bam.