### PR TITLE
use sample name as run id

### DIFF
--- a/definitions/tools/cellranger_count.cwl
+++ b/definitions/tools/cellranger_count.cwl
@@ -4,7 +4,8 @@ cwlVersion: v1.0
 class: CommandLineTool
 label: "Run Cell Ranger Count"
 
-baseCommand: ["/opt/cellranger-3.0.1/cellranger", "count", "--localmem=64", "--localcores=8", "--id=cellranger_output"]
+baseCommand: ["/opt/cellranger-3.0.1/cellranger", "count", "--localmem=64", "--localcores=8"]
+arguments: ["--id=$(inputs.sample_name)"]
 
 requirements:
     - class: DockerRequirement
@@ -43,8 +44,9 @@ inputs:
             position: 4
             separate: false
         doc: "Sample name, must be same as name specified in sample sheet in previous mkfastq step"
+
 outputs:
     out_dir:
         type: Directory
         outputBinding:
-            glob: "cellranger_output/outs/"
+            glob: "$(inputs.sample_name)/outs/"

--- a/definitions/tools/cellranger_vdj.cwl
+++ b/definitions/tools/cellranger_vdj.cwl
@@ -4,7 +4,8 @@ cwlVersion: v1.0
 class: CommandLineTool
 label: "Run Cell Ranger V(D)J"
 
-baseCommand: ["/opt/cellranger-3.0.1/cellranger", "vdj", "--localmem=64", "--localcores=8", "--id=cellranger_output"]
+baseCommand: ["/opt/cellranger-3.0.1/cellranger", "vdj", "--localmem=64", "--localcores=8"]
+arguments: ["--id=$(inputs.sample_name)"]
 
 requirements:
     - class: DockerRequirement
@@ -35,8 +36,9 @@ inputs:
             position: 3
             separate: false
         doc: "Sample name, must be same as name specified in sample sheet in previous mkfastq step" 
+
 outputs:
     out_dir:
         type: Directory
         outputBinding:
-            glob: "cellranger_output/outs/"
+            glob: "$(inputs.sample_name)/outs/"


### PR DESCRIPTION
Cellranger has an input option for a run id which is used to generate the running directory and is used as an identifier in some of the output files. Initially we had a generic `cellranger_ouput` id to simplify parsing  and consistency across runs. That makes it difficult to easily determine the sample from the result files. This PR helps to fix that. 
