### PR TITLE
adding max population frequency filtering

### DIFF
--- a/definitions/tools/filter_vcf_max_sv_pop_freq.cwl
+++ b/definitions/tools/filter_vcf_max_sv_pop_freq.cwl
@@ -12,7 +12,7 @@ requirements:
       ramMin: 4000
 arguments:
     [{ valueFrom: $(inputs.vcf.path) },
-    { valueFrom: $(runtime.outdir)/annotated.af_filtered.vcf },
+    { valueFrom: $(runtime.outdir)/annotated.max_sv_pf_filtered.vcf },
     "/usr/bin/perl", "/opt/vep/src/ensembl-vep/filter_vep",
     "--format", "vcf",
     "--vcf_info_field", "tmp",

--- a/definitions/tools/filter_vcf_max_sv_pop_freq.cwl
+++ b/definitions/tools/filter_vcf_max_sv_pop_freq.cwl
@@ -1,0 +1,44 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: "POPFREQ_AF filter"
+baseCommand: ["/usr/bin/perl", "/usr/bin/vcf_check.pl"]
+requirements:
+    - class: InlineJavascriptRequirement
+    - class: DockerRequirement
+      dockerPull: "mgibio/vep_helper-cwl:1.0.1"
+    - class: ResourceRequirement
+      ramMin: 4000
+arguments:
+    [{ valueFrom: $(inputs.vcf.path) },
+    { valueFrom: $(runtime.outdir)/annotated.af_filtered.vcf },
+    "/usr/bin/perl", "/opt/vep/src/ensembl-vep/filter_vep",
+    "--format", "vcf",
+    "--vcf_info_field", "tmp",
+    "-o", { valueFrom: $(runtime.outdir)/annotated.max_sv_pf_filtered.vcf }]
+inputs:
+    vcf:
+        type: File
+        inputBinding:
+            prefix: "-i"
+            position: 1
+    maximum_sv_population_frequency:
+        type: float
+        inputBinding:
+            valueFrom: |
+                ${
+                    return [
+                        "--filter",
+                        [
+                            "POPFREQ_AF", "<", inputs.maximum_sv_population_frequency,
+                            "or not", "POPFREQ_AF"
+                        ].join(" ")
+                    ]
+                }
+            position: 2
+outputs:
+    filtered_vcf:
+        type: File
+        outputBinding:
+            glob: "annotated.max_sv_pf_filtered.vcf"


### PR DESCRIPTION
This tool adds the option to do filtering on the sv population frequency which has been added using the `add_sv_population_frequency.cwl`.
I originally tried running this in a similar fashion to the `filter_vcf_gnomADe_allele_freq.cwl` tool but continued running into memory issues. Had the max requested RAM to 64gb which is the same amount used to annotate the variants in `vep.cwl`. That still had issues and there is no forking option in filter_vep to help. I start taking subsets of the vcf I was using and figured out that the issue is caused by large svs that have a lot of information stored in the consquence tag created by VEP. Using the `--vcf_info_field` I can trick filter_vep to not load the true consequence tag and can filter the svs without issue.  

Not sure if this is the best solution or if I should try using a different tool. Open to any suggestions. This was tested with a VEP annotated wgs sv vcf that had been merged using survivor with calls from cnvkit, manta and smoove. input vcf was 3.1gb 