### PR TITLE
peg to versioned docker tag that has the needed software

### DIFF
--- a/definitions/tools/merge_bams.cwl
+++ b/definitions/tools/merge_bams.cwl
@@ -9,7 +9,7 @@ requirements:
       ramMin: 8000
       coresMin: 4
     - class: DockerRequirement
-      dockerPull: "mgibio/bisulfite"
+      dockerPull: "mgibio/bisulfite:v1.3"
 arguments: [
     "$(runtime.cores)",
     "$(runtime.outdir)/merged.bam"


### PR DESCRIPTION
quick fix because right now, `latest` no longer has samtools, which breaks this. Longer term, we should phase this out in favor of the samtools merge