### PR TITLE
adding bedtools_intersect.cwl

### DIFF
--- a/definitions/tools/bedtools_intersect.cwl
+++ b/definitions/tools/bedtools_intersect.cwl
@@ -1,0 +1,55 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+
+baseCommand: ["/opt/ccdg/bedtools-2.27.1/bin/bedtools", "intersect"]
+
+requirements:
+    - class: DockerRequirement
+      dockerPull: "ernfrid/bedtools:v2.27.1"
+    - class: ResourceRequirement
+      ramMin: 4000
+
+stdout: "$(inputs.output_name)"
+
+inputs:
+    file_a:
+        type: File
+        inputBinding:
+            position: 1
+            prefix: "-a"
+        doc: "BAM/BED/GFF/VCF file to compare to file b"
+    file_b:
+        type: File
+        inputBinding:
+            position: 2
+            prefix: "-b"
+        doc: "BAM/BED/GFF/VCF file to compare to file a"
+    output_file_a:
+        type: boolean?
+        default: true
+        inputBinding:
+            position: 3
+            prefix: "-wa"
+        doc: "Write the original entry in A for each overlap, default to true"
+    output_header:
+        type: boolean?
+        default: true
+        inputBinding:
+            position: 4
+            prefix: "-header"
+        doc: "Print the header from the A file prior to results, default to true"
+    output_name:
+        type: string
+    unique_result:
+        type: boolean?
+        default: true
+        inputBinding:
+            position: 5
+            prefix: "-u"
+        doc: "Write original A entry once if any overlaps found in B, default to true"
+
+outputs:
+    intersect_result:
+        type: stdout


### PR DESCRIPTION
We use GATK select variants for limiting snp/indel variants with an interval list. Select variants does not properly handle SV variants, Bedtools can. Will require calling `intervals_to_bed.cwl` to convert the interval list file to a bed file.

Tried to allow some flexibility with the tool but there are a bunch of options. (https://github.com/arq5x/bedtools2/blob/v2.27.1/docs/content/tools/intersect.rst)

Not sure if it would be useful to have a default output name. As the output file format could be a few different things I thought it would be best for the subworklow that calls `bedtools.cwl` to also provide an output file name. preferably using labelled file type.