### PR TITLE
Fix some missed connection in workflows and add more secondaryFiles.

### DIFF
--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -278,7 +278,7 @@ steps:
             reference: reference
             custom_gnomad_vcf: custom_gnomad_vcf
             pick: vep_pick
-            custom_clivnar_vcf: custom_clinvar_vcf
+            custom_clinvar_vcf: custom_clinvar_vcf
             assembly: vep_assembly
             plugins: vep_plugins
         out:

--- a/definitions/pipelines/exome_alignment.cwl
+++ b/definitions/pipelines/exome_alignment.cwl
@@ -50,6 +50,7 @@ outputs:
     bam:
         type: File
         outputSource: alignment/final_bam
+        secondaryFiles: [.bai, ^.bai]
     mark_duplicates_metrics:
         type: File
         outputSource: alignment/mark_duplicates_metrics_file

--- a/definitions/pipelines/germline_exome.cwl
+++ b/definitions/pipelines/germline_exome.cwl
@@ -148,8 +148,8 @@ steps:
             summary_intervals: summary_intervals
             omni_vcf: omni_vcf
             picard_metric_accumulation_level: picard_metric_accumulation_level   
-            minimum_mapping_quality: qc_minimum_mapping_quality
-            minimum_base_quality: qc_minimum_base_quality
+            qc_minimum_mapping_quality: qc_minimum_mapping_quality
+            qc_minimum_base_quality: qc_minimum_base_quality
         out:
             [bam, mark_duplicates_metrics, insert_size_metrics, insert_size_histogram, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, summary_hs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]
     extract_freemix:
@@ -189,7 +189,7 @@ steps:
             contamination_fraction: extract_freemix/freemix_score
             vep_cache_dir: vep_cache_dir
             synonyms_file: synonyms_file
-            annotate_coding_only: annotate_coding_only
+            coding_only: annotate_coding_only
             custom_gnomad_vcf: custom_gnomad_vcf
             limit_variant_intervals: target_intervals
             custom_clinvar_vcf: custom_clinvar_vcf

--- a/definitions/pipelines/germline_exome.cwl
+++ b/definitions/pipelines/germline_exome.cwl
@@ -189,7 +189,7 @@ steps:
             contamination_fraction: extract_freemix/freemix_score
             vep_cache_dir: vep_cache_dir
             synonyms_file: synonyms_file
-            coding_only: annotate_coding_only
+            annotate_coding_only: annotate_coding_only
             custom_gnomad_vcf: custom_gnomad_vcf
             limit_variant_intervals: target_intervals
             custom_clinvar_vcf: custom_clinvar_vcf

--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -46,7 +46,7 @@ inputs:
         type: string
     synonyms_file:
         type: File?
-    coding_only:
+    annotate_coding_only:
         type: boolean?
     custom_gnomad_vcf:
         type: File?
@@ -279,7 +279,7 @@ steps:
             contamination_fraction: extract_freemix/freemix_score
             vep_cache_dir: vep_cache_dir
             synonyms_file: synonyms_file
-            coding_only: coding_only
+            annotate_coding_only: annotate_coding_only
             custom_gnomad_vcf: custom_gnomad_vcf
             limit_variant_intervals: variant_reporting_intervals
             custom_clinvar_vcf: custom_clinvar_vcf

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -360,8 +360,8 @@ steps:
             summary_intervals: summary_intervals
             omni_vcf: omni_vcf
             picard_metric_accumulation_level: picard_metric_accumulation_level   
-            minimum_mapping_quality: qc_minimum_mapping_quality
-            minimum_base_quality: qc_minimum_base_quality
+            qc_minimum_mapping_quality: qc_minimum_mapping_quality
+            qc_minimum_base_quality: qc_minimum_base_quality
             final_name:
                 source: tumor_name
                 valueFrom: "$(self).bam"
@@ -384,8 +384,8 @@ steps:
             summary_intervals: summary_intervals
             omni_vcf: omni_vcf
             picard_metric_accumulation_level: picard_metric_accumulation_level   
-            minimum_mapping_quality: qc_minimum_mapping_quality
-            minimum_base_quality: qc_minimum_base_quality
+            qc_minimum_mapping_quality: qc_minimum_mapping_quality
+            qc_minimum_base_quality: qc_minimum_base_quality
             final_name:
                 source: normal_name
                 valueFrom: "$(self).bam"

--- a/definitions/pipelines/tumor_only_detect_variants.cwl
+++ b/definitions/pipelines/tumor_only_detect_variants.cwl
@@ -37,7 +37,7 @@ inputs:
         type: string
     synonyms_file:
         type: File?
-    coding_only:
+    annotate_coding_only:
         type: boolean?
         default: true
     vep_pick:
@@ -144,7 +144,7 @@ steps:
             vcf: decompose/decomposed_vcf
             cache_dir: vep_cache_dir
             synonyms_file: synonyms_file
-            coding_only: coding_only
+            coding_only: annotate_coding_only
             reference: reference
             custom_gnomad_vcf: custom_gnomad_vcf
             pick: vep_pick

--- a/definitions/subworkflows/germline_detect_variants.cwl
+++ b/definitions/subworkflows/germline_detect_variants.cwl
@@ -29,7 +29,7 @@ inputs:
         default: [Downstream, Wildtype]
     synonyms_file:
         type: File?
-    coding_only:
+    annotate_coding_only:
         type: boolean?
     custom_gnomad_vcf:
         type: File?
@@ -85,7 +85,7 @@ steps:
             vcf: genotype_gvcfs/genotype_vcf
             cache_dir: vep_cache_dir
             synonyms_file: synonyms_file
-            coding_only: coding_only
+            coding_only: annotate_coding_only
             reference: reference
             custom_gnomad_vcf: custom_gnomad_vcf
             custom_clinvar_vcf: custom_clinvar_vcf

--- a/definitions/subworkflows/varscan_germline.cwl
+++ b/definitions/subworkflows/varscan_germline.cwl
@@ -12,7 +12,7 @@ inputs:
         type: string
     bam:
         type: File
-        secondaryFiles: [^.bai]
+        secondaryFiles: [.bai, ^.bai]
     interval_list:
         type: File
     strand_filter:
@@ -38,6 +38,7 @@ outputs:
     unfiltered_vcf:
         type: File
         outputSource: filter/unfiltered_vcf
+        secondaryFiles: [.tbi]
     filtered_vcf:
         type: File
         outputSource: filter/filtered_vcf


### PR DESCRIPTION
Specifying an input that does not exist is merely a warning.  Since we have a lot of optional inputs, this means no error is generated when things are mis-wired.

We should work to eliminate warnings from our CWL validation--we can then possibly make Travis CI fail if new warnings are generated.