### PR TITLE
Add cle_somatic_exome.cwl for CLE IDT somatic exome assay that will be implemented by LIMS

### DIFF
--- a/definitions/pipelines/cle_somatic_exome.cwl
+++ b/definitions/pipelines/cle_somatic_exome.cwl
@@ -1,0 +1,402 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+label: "exome alignment and somatic variant detection for cle purpose"
+requirements:
+    - class: SchemaDefRequirement
+      types:
+          - $import: ../types/labelled_file.yml
+    - class: SubworkflowFeatureRequirement
+    - class: StepInputExpressionRequirement
+inputs:
+    reference: string
+    tumor_bams:
+        type: File[]
+    tumor_readgroups:
+        type: string[]
+    tumor_name:
+        type: string?
+        default: 'tumor'
+    normal_bams:
+        type: File[]
+    normal_readgroups:
+        type: string[]
+    normal_name:
+        type: string?
+        default: 'normal'
+    mills:
+        type: File
+        secondaryFiles: [.tbi]
+    known_indels:
+        type: File
+        secondaryFiles: [.tbi]
+    dbsnp_vcf:
+        type: File
+        secondaryFiles: [.tbi]
+    bqsr_intervals:
+        type: string[]
+    bait_intervals:
+        type: File
+    target_intervals:
+        type: File
+    per_base_intervals:
+        type: ../types/labelled_file.yml#labelled_file[]
+    per_target_intervals:
+        type: ../types/labelled_file.yml#labelled_file[]
+    summary_intervals:
+        type: ../types/labelled_file.yml#labelled_file[]
+    omni_vcf:
+        type: File
+        secondaryFiles: [.tbi]
+    picard_metric_accumulation_level:
+        type: string
+    qc_minimum_mapping_quality:
+        type: int?
+        default: 0
+    qc_minimum_base_quality:
+        type: int?
+        default: 0
+    interval_list:
+        type: File
+    cosmic_vcf:
+        type: File?
+        secondaryFiles: [.tbi]
+    panel_of_normals_vcf:
+        type: File?
+        secondaryFiles: [.tbi]
+    strelka_cpu_reserved:
+        type: int?
+        default: 8
+    mutect_scatter_count:
+        type: int
+    mutect_artifact_detection_mode:
+        type: boolean
+        default: false
+    mutect_max_alt_allele_in_normal_fraction:
+        type: float?
+    mutect_max_alt_alleles_in_normal_count:
+        type: int?
+    varscan_strand_filter:
+        type: int?
+        default: 0
+    varscan_min_coverage:
+        type: int?
+        default: 8
+    varscan_min_var_freq:
+        type: float?
+        default: 0.05
+    varscan_p_value:
+        type: float?
+        default: 0.99
+    varscan_max_normal_freq:
+        type: float?
+    pindel_insert_size:
+        type: int
+        default: 400
+    docm_vcf:
+        type: File
+        secondaryFiles: [.tbi]
+    filter_docm_variants:
+        type: boolean?
+        default: true
+    vep_cache_dir:
+        type: string
+    synonyms_file:
+        type: File?
+    annotate_coding_only:
+        type: boolean?
+    vep_pick:
+        type:
+            - "null"
+            - type: enum
+              symbols: ["pick", "flag_pick", "pick_allele", "per_gene", "pick_allele_gene", "flag_pick_allele", "flag_pick_allele_gene"]
+    cle_vcf_filter:
+        type: boolean
+        default: false
+    variants_to_table_fields:
+        type: string[]
+        default: [CHROM,POS,ID,REF,ALT,set,AC,AF]
+    variants_to_table_genotype_fields:
+        type: string[]
+        default: [GT,AD]
+    vep_to_table_fields:
+        type: string[]
+        default: [HGVSc,HGVSp]
+    custom_gnomad_vcf:
+        type: File?
+        secondaryFiles: [.tbi]
+    custom_clinvar_vcf:
+        type: File?
+        secondaryFiles: [.tbi]
+    somalier_vcf:
+        type: File
+outputs:
+    tumor_cram:
+        type: File
+        outputSource: tumor_index_cram/indexed_cram
+    tumor_mark_duplicates_metrics:
+        type: File
+        outputSource: tumor_alignment_and_qc/mark_duplicates_metrics
+    tumor_insert_size_metrics:
+        type: File
+        outputSource: tumor_alignment_and_qc/insert_size_metrics
+    tumor_alignment_summary_metrics:
+        type: File
+        outputSource: tumor_alignment_and_qc/alignment_summary_metrics
+    tumor_hs_metrics:
+        type: File
+        outputSource: tumor_alignment_and_qc/hs_metrics
+    tumor_per_target_coverage_metrics:
+        type: File[]
+        outputSource: tumor_alignment_and_qc/per_target_coverage_metrics
+    tumor_per_target_hs_metrics:
+        type: File[]
+        outputSource: tumor_alignment_and_qc/per_target_hs_metrics
+    tumor_per_base_coverage_metrics:
+        type: File[]
+        outputSource: tumor_alignment_and_qc/per_base_coverage_metrics
+    tumor_per_base_hs_metrics:
+        type: File[]
+        outputSource: tumor_alignment_and_qc/per_base_hs_metrics
+    tumor_summary_hs_metrics:
+        type: File[]
+        outputSource: tumor_alignment_and_qc/summary_hs_metrics
+    tumor_flagstats:
+        type: File
+        outputSource: tumor_alignment_and_qc/flagstats
+    tumor_verify_bam_id_metrics:
+        type: File
+        outputSource: tumor_alignment_and_qc/verify_bam_id_metrics
+    tumor_verify_bam_id_depth:
+        type: File
+        outputSource: tumor_alignment_and_qc/verify_bam_id_depth
+    normal_cram:
+        type: File
+        outputSource: normal_index_cram/indexed_cram
+    normal_mark_duplicates_metrics:
+        type: File
+        outputSource: normal_alignment_and_qc/mark_duplicates_metrics
+    normal_insert_size_metrics:
+        type: File
+        outputSource: normal_alignment_and_qc/insert_size_metrics
+    normal_alignment_summary_metrics:
+        type: File
+        outputSource: normal_alignment_and_qc/alignment_summary_metrics
+    normal_hs_metrics:
+        type: File
+        outputSource: normal_alignment_and_qc/hs_metrics
+    normal_per_target_coverage_metrics:
+        type: File[]
+        outputSource: normal_alignment_and_qc/per_target_coverage_metrics
+    normal_per_target_hs_metrics:
+        type: File[]
+        outputSource: normal_alignment_and_qc/per_target_hs_metrics
+    normal_per_base_coverage_metrics:
+        type: File[]
+        outputSource: normal_alignment_and_qc/per_base_coverage_metrics
+    normal_per_base_hs_metrics:
+        type: File[]
+        outputSource: normal_alignment_and_qc/per_base_hs_metrics
+    normal_summary_hs_metrics:
+        type: File[]
+        outputSource: normal_alignment_and_qc/summary_hs_metrics
+    normal_flagstats:
+        type: File
+        outputSource: normal_alignment_and_qc/flagstats
+    normal_verify_bam_id_metrics:
+        type: File
+        outputSource: normal_alignment_and_qc/verify_bam_id_metrics
+    normal_verify_bam_id_depth:
+        type: File
+        outputSource: normal_alignment_and_qc/verify_bam_id_depth
+    mutect_unfiltered_vcf:
+        type: File
+        outputSource: detect_variants/mutect_unfiltered_vcf
+        secondaryFiles: [.tbi]
+    mutect_filtered_vcf:
+        type: File
+        outputSource: detect_variants/mutect_filtered_vcf
+        secondaryFiles: [.tbi]
+    strelka_unfiltered_vcf:
+        type: File
+        outputSource: detect_variants/strelka_unfiltered_vcf
+        secondaryFiles: [.tbi]
+    strelka_filtered_vcf:
+        type: File
+        outputSource: detect_variants/strelka_filtered_vcf
+        secondaryFiles: [.tbi]
+    varscan_unfiltered_vcf:
+        type: File
+        outputSource: detect_variants/varscan_unfiltered_vcf
+        secondaryFiles: [.tbi]
+    varscan_filtered_vcf:
+        type: File
+        outputSource: detect_variants/varscan_filtered_vcf
+        secondaryFiles: [.tbi]
+    pindel_unfiltered_vcf:
+        type: File
+        outputSource: detect_variants/pindel_unfiltered_vcf
+        secondaryFiles: [.tbi]
+    pindel_filtered_vcf:
+        type: File
+        outputSource: detect_variants/pindel_filtered_vcf
+        secondaryFiles: [.tbi]
+    docm_filtered_vcf:
+        type: File
+        outputSource: detect_variants/docm_filtered_vcf
+        secondaryFiles: [.tbi]
+    final_vcf:
+        type: File
+        outputSource: detect_variants/final_vcf
+        secondaryFiles: [.tbi]
+    final_filtered_vcf:
+        type: File
+        outputSource: detect_variants/final_filtered_vcf
+        secondaryFiles: [.tbi]
+    final_tsv:
+        type: File
+        outputSource: detect_variants/final_tsv
+    vep_summary:
+        type: File
+        outputSource: detect_variants/vep_summary
+    tumor_snv_bam_readcount_tsv:
+        type: File
+        outputSource: detect_variants/tumor_snv_bam_readcount_tsv
+    tumor_indel_bam_readcount_tsv:
+        type: File
+        outputSource: detect_variants/tumor_indel_bam_readcount_tsv
+    normal_snv_bam_readcount_tsv:
+        type: File
+        outputSource: detect_variants/normal_snv_bam_readcount_tsv
+    normal_indel_bam_readcount_tsv:
+        type: File
+        outputSource: detect_variants/normal_indel_bam_readcount_tsv
+    somalier_concordance_metrics:
+        type: File
+        outputSource: concordance/somalier_pairs
+    somalier_concordance_statistics:
+        type: File
+        outputSource: concordance/somalier_samples
+steps:
+    tumor_alignment_and_qc:
+        run: exome_alignment.cwl
+        in:
+            reference: reference
+            bams: tumor_bams
+            readgroups: tumor_readgroups
+            mills: mills
+            known_indels: known_indels
+            dbsnp_vcf: dbsnp_vcf
+            bqsr_intervals: bqsr_intervals
+            bait_intervals: bait_intervals
+            target_intervals: target_intervals
+            per_base_intervals: per_base_intervals
+            per_target_intervals: per_target_intervals
+            summary_intervals: summary_intervals
+            omni_vcf: omni_vcf
+            picard_metric_accumulation_level: picard_metric_accumulation_level   
+            minimum_mapping_quality: qc_minimum_mapping_quality
+            minimum_base_quality: qc_minimum_base_quality
+            final_name:
+                source: tumor_name
+                valueFrom: "$(self).bam"
+        out:
+            [bam, mark_duplicates_metrics, insert_size_metrics, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, summary_hs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]
+    normal_alignment_and_qc:
+        run: exome_alignment.cwl
+        in:
+            reference: reference
+            bams: normal_bams
+            readgroups: normal_readgroups
+            mills: mills
+            known_indels: known_indels
+            dbsnp_vcf: dbsnp_vcf
+            bqsr_intervals: bqsr_intervals
+            bait_intervals: bait_intervals
+            target_intervals: target_intervals
+            per_base_intervals: per_base_intervals
+            per_target_intervals: per_target_intervals
+            summary_intervals: summary_intervals
+            omni_vcf: omni_vcf
+            picard_metric_accumulation_level: picard_metric_accumulation_level   
+            minimum_mapping_quality: qc_minimum_mapping_quality
+            minimum_base_quality: qc_minimum_base_quality
+            final_name:
+                source: normal_name
+                valueFrom: "$(self).bam"
+        out:
+            [bam, mark_duplicates_metrics, insert_size_metrics, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, summary_hs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]
+    concordance:
+        run: ../tools/concordance.cwl
+        in:
+            reference: reference
+            bam_1: tumor_alignment_and_qc/bam
+            bam_2: normal_alignment_and_qc/bam
+            vcf: somalier_vcf
+        out:
+            [somalier_pairs, somalier_samples]
+    detect_variants:
+        run: detect_variants.cwl
+        in:
+            reference: reference
+            tumor_bam: tumor_alignment_and_qc/bam
+            normal_bam: normal_alignment_and_qc/bam
+            interval_list: interval_list
+            dbsnp_vcf: dbsnp_vcf
+            cosmic_vcf: cosmic_vcf
+            panel_of_normals_vcf: panel_of_normals_vcf
+            strelka_exome_mode:
+                default: true
+            strelka_cpu_reserved: strelka_cpu_reserved
+            mutect_scatter_count: mutect_scatter_count
+            mutect_artifact_detection_mode: mutect_artifact_detection_mode
+            mutect_max_alt_allele_in_normal_fraction: mutect_max_alt_allele_in_normal_fraction
+            mutect_max_alt_alleles_in_normal_count: mutect_max_alt_alleles_in_normal_count
+            varscan_strand_filter: varscan_strand_filter
+            varscan_min_coverage: varscan_min_coverage
+            varscan_min_var_freq: varscan_min_var_freq
+            varscan_p_value: varscan_p_value
+            varscan_max_normal_freq: varscan_max_normal_freq
+            pindel_insert_size: pindel_insert_size
+            docm_vcf: docm_vcf
+            filter_docm_variants: filter_docm_variants
+            vep_cache_dir: vep_cache_dir
+            synonyms_file: synonyms_file
+            annotate_coding_only: annotate_coding_only
+            vep_pick: vep_pick
+            cle_vcf_filter: cle_vcf_filter
+            variants_to_table_fields: variants_to_table_fields
+            variants_to_table_genotype_fields: variants_to_table_genotype_fields
+            vep_to_table_fields: vep_to_table_fields
+            custom_gnomad_vcf: custom_gnomad_vcf
+            custom_clinvar_vcf: custom_clinvar_vcf
+        out:
+            [mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv]
+    tumor_bam_to_cram:
+        run: ../tools/bam_to_cram.cwl
+        in:
+            bam: tumor_alignment_and_qc/bam
+            reference: reference
+        out:
+            [cram]
+    tumor_index_cram:
+         run: ../tools/index_cram.cwl
+         in:
+            cram: tumor_bam_to_cram/cram
+         out:
+            [indexed_cram]
+    normal_bam_to_cram:
+        run: ../tools/bam_to_cram.cwl
+        in:
+            bam: normal_alignment_and_qc/bam
+            reference: reference
+        out:
+            [cram]
+    normal_index_cram:
+         run: ../tools/index_cram.cwl
+         in:
+            cram: normal_bam_to_cram/cram
+         out:
+            [indexed_cram]
+

--- a/definitions/pipelines/gathered_cle_somatic_exome.cwl
+++ b/definitions/pipelines/gathered_cle_somatic_exome.cwl
@@ -180,6 +180,7 @@ steps:
             hgvs_annotation: hgvs_annotation
             vep_pick: vep_pick
             cle_vcf_filter: cle_vcf_filter
+            filter_docm_variants: filter_docm_variants
             variants_to_table_fields: variants_to_table_fields
             variants_to_table_genotype_fields: variants_to_table_genotype_fields
             vep_to_table_fields: vep_to_table_fields

--- a/definitions/pipelines/gathered_cle_somatic_exome.cwl
+++ b/definitions/pipelines/gathered_cle_somatic_exome.cwl
@@ -1,0 +1,221 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+label: "gathered exome alignment and somatic variant detection for cle purpose"
+requirements:
+    - class: SchemaDefRequirement
+      types:
+          - $import: ../types/labelled_file.yml
+    - class: SubworkflowFeatureRequirement
+    - class: StepInputExpressionRequirement
+inputs:
+    reference: string
+    tumor_bams:
+        type: File[]
+    tumor_readgroups:
+        type: string[]
+    tumor_cram_name:
+        type: string?
+        default: 'tumor.cram'
+    normal_bams:
+        type: File[]
+    normal_readgroups:
+        type: string[]
+    normal_cram_name:
+        type: string?
+        default: 'normal.cram'
+    mills:
+        type: File
+        secondaryFiles: [.tbi]
+    known_indels:
+        type: File
+        secondaryFiles: [.tbi]
+    dbsnp_vcf:
+        type: File
+        secondaryFiles: [.tbi]
+    bqsr_intervals:
+        type: string[]
+    bait_intervals:
+        type: File
+    target_intervals:
+        type: File
+    per_base_intervals:
+        type: ../types/labelled_file.yml#labelled_file[]
+    per_target_intervals:
+        type: ../types/labelled_file.yml#labelled_file[]
+    summary_intervals:
+        type: ../types/labelled_file.yml#labelled_file[]
+    omni_vcf:
+        type: File
+        secondaryFiles: [.tbi]
+    picard_metric_accumulation_level:
+        type: string
+    qc_minimum_mapping_quality:
+        type: int?
+        default: 0
+    qc_minimum_base_quality:
+        type: int?
+        default: 0
+    interval_list:
+        type: File
+    cosmic_vcf:
+        type: File?
+        secondaryFiles: [.tbi]
+    panel_of_normals_vcf:
+        type: File?
+        secondaryFiles: [.tbi]
+    strelka_cpu_reserved:
+        type: int?
+        default: 8
+    mutect_scatter_count:
+        type: int
+    mutect_artifact_detection_mode:
+        type: boolean
+    mutect_max_alt_allele_in_normal_fraction:
+        type: float?
+    mutect_max_alt_alleles_in_normal_count:
+        type: int?
+    varscan_strand_filter:
+        type: int?
+        default: 0
+    varscan_min_coverage:
+        type: int?
+        default: 8
+    varscan_min_var_freq:
+        type: float?
+        default: 0.05
+    varscan_p_value:
+        type: float?
+        default: 0.99
+    varscan_max_normal_freq:
+        type: float?
+    pindel_insert_size:
+        type: int
+        default: 400
+    docm_vcf:
+        type: File
+        secondaryFiles: [.tbi]
+    filter_docm_variants:
+        type: boolean?
+        default: true
+    vep_cache_dir:
+        type: string?
+    synonyms_file:
+        type: File?
+    annotate_coding_only:
+        type: boolean?
+    hgvs_annotation:
+        type: boolean?
+    vep_pick:
+        type:
+            - "null"
+            - type: enum
+              symbols: ["pick", "flag_pick", "pick_allele", "per_gene", "pick_allele_gene", "flag_pick_allele", "flag_pick_allele_gene"]
+    cle_vcf_filter:
+        type: boolean
+        default: false
+    variants_to_table_fields:
+        type: string[]
+        default: [CHROM,POS,ID,REF,ALT,set,AC,AF]
+    variants_to_table_genotype_fields:
+        type: string[]
+        default: [GT,AD]
+    vep_to_table_fields:
+        type: string[]
+        default: [HGVSc,HGVSp]
+    custom_gnomad_vcf:
+        type: File?
+        secondaryFiles: [.tbi]
+    output_dir: 
+        type: string
+    somalier_vcf:
+        type: File
+outputs:
+    final_outputs:
+        type: string[]
+        outputSource: gatherer/gathered_files
+steps:
+    somatic_exome:
+        run: cle_somatic_exome.cwl
+        in:
+            reference: reference
+            tumor_bams: tumor_bams
+            tumor_readgroups: tumor_readgroups
+            tumor_cram_name: tumor_cram_name
+            normal_bams: normal_bams
+            normal_readgroups: normal_readgroups
+            normal_cram_name: normal_cram_name
+            mills: mills
+            known_indels: known_indels
+            dbsnp_vcf: dbsnp_vcf
+            bqsr_intervals: bqsr_intervals
+            bait_intervals: bait_intervals
+            target_intervals: target_intervals
+            per_base_intervals: per_base_intervals
+            per_target_intervals: per_target_intervals
+            summary_intervals: summary_intervals
+            omni_vcf: omni_vcf
+            picard_metric_accumulation_level: picard_metric_accumulation_level   
+            qc_minimum_mapping_quality: qc_minimum_mapping_quality
+            qc_minimum_base_quality: qc_minimum_base_quality
+            interval_list: interval_list
+            cosmic_vcf: cosmic_vcf
+            panel_of_normals_vcf: panel_of_normals_vcf
+            strelka_cpu_reserved: strelka_cpu_reserved
+            mutect_scatter_count: mutect_scatter_count
+            mutect_artifact_detection_mode: mutect_artifact_detection_mode
+            mutect_max_alt_allele_in_normal_fraction: mutect_max_alt_allele_in_normal_fraction
+            mutect_max_alt_alleles_in_normal_count: mutect_max_alt_alleles_in_normal_count
+            varscan_strand_filter: varscan_strand_filter
+            varscan_min_coverage: varscan_min_coverage
+            varscan_min_var_freq: varscan_min_var_freq
+            varscan_p_value: varscan_p_value
+            varscan_max_normal_freq: varscan_max_normal_freq
+            pindel_insert_size: pindel_insert_size
+            docm_vcf: docm_vcf
+            vep_cache_dir: vep_cache_dir
+            synonyms_file: synonyms_file
+            annotate_coding_only: annotate_coding_only
+            hgvs_annotation: hgvs_annotation
+            vep_pick: vep_pick
+            cle_vcf_filter: cle_vcf_filter
+            variants_to_table_fields: variants_to_table_fields
+            variants_to_table_genotype_fields: variants_to_table_genotype_fields
+            vep_to_table_fields: vep_to_table_fields
+            custom_gnomad_vcf: custom_gnomad_vcf
+            somalier_vcf: somalier_vcf
+        out:
+            [tumor_cram, tumor_mark_duplicates_metrics, tumor_insert_size_metrics, tumor_alignment_summary_metrics, tumor_hs_metrics, tumor_per_target_coverage_metrics, tumor_per_base_coverage_metrics, tumor_per_base_hs_metrics, tumor_summary_hs_metrics, tumor_flagstats, tumor_verify_bam_id_metrics, tumor_verify_bam_id_depth, normal_cram, normal_mark_duplicates_metrics, normal_insert_size_metrics, normal_alignment_summary_metrics, normal_hs_metrics, normal_per_target_coverage_metrics, normal_per_target_hs_metrics, normal_per_base_coverage_metrics, normal_per_base_hs_metrics, normal_summary_hs_metrics, normal_flagstats, normal_verify_bam_id_metrics, normal_verify_bam_id_depth, mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv, somalier_concordance_metrics, somalier_concordance_statistics]
+    gatherer:
+        run: ../tools/gatherer.cwl
+        in:
+            output_dir: output_dir
+            all_files:
+                source: [somatic_exome/tumor_cram, somatic_exome/tumor_mark_duplicates_metrics, somatic_exome/tumor_insert_size_metrics, somatic_exome/tumor_alignment_summary_metrics, somatic_exome/tumor_hs_metrics, somatic_exome/tumor_per_target_coverage_metrics, somatic_exome/tumor_per_base_coverage_metrics, somatic_exome/tumor_per_base_hs_metrics, somatic_exome/tumor_summary_hs_metrics, somatic_exome/tumor_flagstats, somatic_exome/tumor_verify_bam_id_metrics, somatic_exome/tumor_verify_bam_id_depth, somatic_exome/normal_cram, somatic_exome/normal_mark_duplicates_metrics, somatic_exome/normal_insert_size_metrics, somatic_exome/normal_alignment_summary_metrics, somatic_exome/normal_hs_metrics, somatic_exome/normal_per_target_coverage_metrics, somatic_exome/normal_per_target_hs_metrics, somatic_exome/normal_per_base_coverage_metrics, somatic_exome/normal_per_base_hs_metrics, somatic_exome/normal_summary_hs_metrics, somatic_exome/normal_flagstats, somatic_exome/normal_verify_bam_id_metrics, somatic_exome/normal_verify_bam_id_depth, somatic_exome/mutect_unfiltered_vcf, somatic_exome/mutect_filtered_vcf, somatic_exome/strelka_unfiltered_vcf, somatic_exome/strelka_filtered_vcf, somatic_exome/varscan_unfiltered_vcf, somatic_exome/varscan_filtered_vcf, somatic_exome/pindel_unfiltered_vcf, somatic_exome/pindel_filtered_vcf, somatic_exome/docm_filtered_vcf, somatic_exome/final_vcf, somatic_exome/final_filtered_vcf, somatic_exome/final_tsv, somatic_exome/vep_summary, somatic_exome/tumor_snv_bam_readcount_tsv, somatic_exome/tumor_indel_bam_readcount_tsv, somatic_exome/normal_snv_bam_readcount_tsv, somatic_exome/normal_indel_bam_readcount_tsv, somatic_exome/somalier_concordance_metrics, somatic_exome/somalier_concordance_statistics]
+                valueFrom: ${
+                                function flatten(inArr, outArr) {
+                                    var arrLen = inArr.length;
+                                    for (var i = 0; i < arrLen; i++) {
+                                        if (Array.isArray(inArr[i])) {
+                                            flatten(inArr[i], outArr);
+                                        }
+                                        else {
+                                            outArr.push(inArr[i]);
+                                        }
+                                    }
+                                    return outArr;
+                                }
+                                var no_secondaries = flatten(self, []);
+                                var all_files = []; 
+                                var arrLen = no_secondaries.length;
+                                for (var i = 0; i < arrLen; i++) {
+                                    all_files.push(no_secondaries[i]);
+                                    var secondaryLen = no_secondaries[i].secondaryFiles.length;
+                                    for (var j = 0; j < secondaryLen; j++) {
+                                        all_files.push(no_secondaries[i].secondaryFiles[j]);
+                                    }
+                                }
+                                return all_files;
+                            }
+        out: [gathered_files]

--- a/example_data/cle_IDT_somatic_exome_template.yaml
+++ b/example_data/cle_IDT_somatic_exome_template.yaml
@@ -1,0 +1,116 @@
+---
+bait_intervals:
+  class: File
+  path: /gscmnt/gc2709/info/production_reference_GRCh38DH/CLE/IDTExome/xgen-exome-research-panel-probes.interval_list
+bqsr_intervals:
+- chr1
+- chr2
+- chr3
+- chr4
+- chr5
+- chr6
+- chr7
+- chr8
+- chr9
+- chr10
+- chr11
+- chr12
+- chr13
+- chr14
+- chr15
+- chr16
+- chr17
+- chr18
+- chr19
+- chr20
+- chr21
+- chr22
+cosmic_vcf:
+  class: File
+  path: /gscmnt/gc2560/core/build_merged_alignments/detect-variants--linus2112.gsc.wustl.edu-jwalker-774-52fa2dadc4ba4b6490abe0701907d394/snvs.hq.vcf.gz
+custom_gnomad_vcf:
+  class: File
+  path: /gscmnt/gc2560/core/model_data/genome-db-ensembl-gnomad/2dd4b53431674786b760adad60a29273/fixed_b38_exome.vcf.gz
+dbsnp_vcf:
+  class: File
+  path: /gscmnt/gc2560/core/build_merged_alignments/detect-variants--linus2112.gsc.wustl.edu-jwalker-19443-e48c595a620a432c93e8dd29e4af64f2/snvs.hq.vcf.gz
+docm_vcf:
+  class: File
+  path: /gscmnt/gc2709/info/production_reference_GRCh38DH/CLE/IDTExome/DoCM.hs37_011117_sanitized_sort_new_LiftOver_hg19ToHg38.vcf.gz
+interval_list:
+  class: File
+  path: /gscmnt/gc2709/info/production_reference_GRCh38DH/CLE/IDTExome/xgen-exome-research-panel-targets.interval_list
+known_indels:
+  class: File
+  path: /gscmnt/gc2560/core/build_merged_alignments/detect-variants--linus2112.gsc.wustl.edu-jwalker-20267-00cb8ff552914c17ad66d86031e10d30/indels.hq.vcf.gz
+mills:
+  class: File
+  path: /gscmnt/gc2560/core/build_merged_alignments/detect-variants--linus2112.gsc.wustl.edu-jwalker-20211-26b393cc7ab04120ac68cc2cbd4a15df/indels.hq.vcf.gz
+mutect_scatter_count: 80
+mutect_artifact_detection_mode: false
+mutect_max_alt_allele_in_normal_fraction: 0.1
+mutect_max_alt_alleles_in_normal_count: 5
+varscan_strand_filter: 1
+varscan_min_var_freq: 0.08
+varscan_p_value: 0.1
+varscan_max_normal_freq: 0.1
+normal_bams:
+- class: File
+  path: NORMAL_BAM_PATH
+normal_readgroups:
+- "NORMAL_RG_STR"
+omni_vcf:
+  class: File
+  path: /gscmnt/gc2709/info/production_reference_GRCh38DH/accessory_vcf/omni25-ld-pruned-20000-2000-0.5-annotated.wchr.sites_only.b38.autosomes_only.vcf.gz
+panel_of_normals_vcf:
+  class: File
+  path: /gscmnt/gc2560/core/build_merged_alignments/detect-variants--linus2112.gsc.wustl.edu-jwalker-2237-db881b860992443da9d6aac8b36a7ea6/snvs.hq.vcf.gz
+per_base_intervals: []
+per_target_intervals: []
+picard_metric_accumulation_level: LIBRARY
+reference: /gscmnt/gc2709/info/production_reference_GRCh38DH/reference/all_sequences.fa
+summary_intervals: []
+synonyms_file:
+  class: File
+  path: /gscmnt/gc2560/core/model_data/2887491634/build50f99e75d14340ffb5b7d21b03887637/chromAlias.ensembl.txt
+target_intervals:
+  class: File
+  path: /gscmnt/gc2709/info/production_reference_GRCh38DH/CLE/IDTExome/xgen-exome-research-panel-targets.interval_list
+tumor_bams:
+- class: File
+  path: TUMOR_BAM_PATH 
+tumor_readgroups:
+- "TUMOR_RG_STR"
+filter_docm_variants: false
+cle_vcf_filter: true
+annotate_coding_only: false
+variants_to_table_fields:
+- CHROM
+- POS
+- ID
+- REF
+- ALT
+- set
+variants_to_table_genotype_fields:
+- GT
+- AD
+- AF
+- DP
+vep_to_table_fields:
+- Consequence
+- SYMBOL
+- Feature_type
+- Feature
+- HGVSc
+- HGVSp
+- cDNA_position
+- CDS_position
+- Protein_position
+- Amino_acids
+- Codons
+- HGNC_ID
+- Existing_variation
+- gnomADe_AF
+vep_cache_dir: /gscmnt/gc2560/core/cwl/inputs/VEP_cache
+somalier_vcf: /gscmnt/gc2560/core/annotation_data/concordance_snps/GRC-human-build38_gnomad_exome_common_snps.vcf
+output_dir: OUTPUT_DIR


### PR DESCRIPTION
This cwl pipeline is to replace current hybrid of alignment_QC wdl and detect_variant toil_cwl implemented in LIMS IDT tumor/normal exome assay.  It will run normal/tumor alignment_QC, tumor/normal concordance check, and variant detection that does NOT include sv detections: manta and cnvkit. Three full tests succeeded (https://jira.ris.wustl.edu/browse/CI-326).