### PR TITLE
Add --allowMissingData to VariantsToTable

### DIFF
--- a/definitions/tools/variants_to_table.cwl
+++ b/definitions/tools/variants_to_table.cwl
@@ -11,7 +11,7 @@ requirements:
     - class: DockerRequirement
       dockerPull: "mgibio/gatk-cwl:3.6.0"
 arguments:
-    ["-o", { valueFrom: $(runtime.outdir)/variants.tsv }]
+    ["--allowMissingData", "-o", { valueFrom: $(runtime.outdir)/variants.tsv }]
 inputs:
     reference:
         type: string


### PR DESCRIPTION
In GATK 3.6 "If a VCF record is missing a value, then the tool by
default throws an error, but the special value NA can be emitted instead
if requested at the command line using --allowMissingData."

Depending on the arguments, we might encounter missing values which
would cause an error without this flag.

This behavior was reversed in GATK 4.0 and it will no longer throw an
error on missing values.