### PR TITLE
dropping the mem requirement of cellranger count

### DIFF
--- a/definitions/tools/cellranger_count.cwl
+++ b/definitions/tools/cellranger_count.cwl
@@ -11,7 +11,7 @@ requirements:
     - class: DockerRequirement
       dockerPull: "registry.gsc.wustl.edu/mgi/cellranger:3.0.1"
     - class: ResourceRequirement
-      ramMin: 64000
+      ramMin: 56000
       coresMin: 8
 
 inputs:

--- a/definitions/tools/cellranger_count.cwl
+++ b/definitions/tools/cellranger_count.cwl
@@ -4,7 +4,7 @@ cwlVersion: v1.0
 class: CommandLineTool
 label: "Run Cell Ranger Count"
 
-baseCommand: ["/opt/cellranger-3.0.1/cellranger", "count", "--localmem=64", "--localcores=8"]
+baseCommand: ["/opt/cellranger-3.0.1/cellranger", "count", "--localmem=56", "--localcores=8"]
 arguments: ["--id=$(inputs.sample_name)"]
 
 requirements:


### PR DESCRIPTION
We've just run through a bunch of scRNA seq data with this pipeline, and are seeing memory usages a fair amount below what's being requested:

```
$ gm list analysis_projects.id:e8cad4ecda43457bb9fe9c5cd3b61288/382eb5d530384ed19c7bf3a5070ba3ac/62fe9adcc1ed41b9bd6afd0f065920e5 --show last_succeeded_build.data_directory --nohead | while read i;do perl -nae 'print $1 . "\n" if $_ =~ /job id: (\d+)/' $i/logs/process*.out;done | while read i;do binfo $i | grep memory_bytes;done

memory_bytes       44345270272,
memory_bytes       46636138496,
memory_bytes       43644301312,
memory_bytes       47865040896,
memory_bytes       46829789184,
memory_bytes       44326752256,
memory_bytes       47019626496,
memory_bytes       47343132672,
memory_bytes       47447986176,
memory_bytes       48710610944,
memory_bytes       47017328640,
memory_bytes       43605921792,
memory_bytes       47561768960,
memory_bytes       43673407488,
memory_bytes       47748104192,
memory_bytes       45828075520,
memory_bytes       47801683968,
memory_bytes       46212792320,
memory_bytes       47093116928,
memory_bytes       47006253056,
memory_bytes       46707212288,
memory_bytes       47457820672,
memory_bytes       43790999552
memory_bytes       48538685440,
```

Suggests to me that we can drop it a bit and get more jobs running.

Does anyone else have data from recent runs (human or mouse) that show larger mem usage, contradicting this data, before we merge this?