### PR TITLE
Make "strand" into an enum in RNA-seq pipeline.

### DIFF
--- a/definitions/pipelines/rnaseq.cwl
+++ b/definitions/pipelines/rnaseq.cwl
@@ -41,7 +41,10 @@ inputs:
     gene_transcript_lookup_table:
        type: File
     strand:
-       type: string?
+        type:
+          - "null"
+          - type: enum
+            symbols: ["first", "second", "unstranded"]
     refFlat:
         type: File
     ribosomal_intervals:

--- a/definitions/subworkflows/bam_to_trimmed_fastq_and_hisat_alignments.cwl
+++ b/definitions/subworkflows/bam_to_trimmed_fastq_and_hisat_alignments.cwl
@@ -30,7 +30,10 @@ inputs:
         type: File
         secondaryFiles: [".1.ht2", ".2.ht2", ".3.ht2", ".4.ht2", ".5.ht2", ".6.ht2", ".7.ht2", ".8.ht2"]
     strand:
-        type: string?
+        type:
+          - "null"
+          - type: enum
+            symbols: ["first", "second", "unstranded"]
 outputs:
     fastqs:
         type: File[]

--- a/definitions/tools/generate_qc_metrics.cwl
+++ b/definitions/tools/generate_qc_metrics.cwl
@@ -24,7 +24,10 @@ inputs:
             prefix: "RIBOSOMAL_INTERVALS="
             separate: false
     strand:
-        type: string?
+        type:
+          - "null"
+          - type: enum
+            symbols: ["first", "second", "unstranded"]
         inputBinding:
             valueFrom: |
                 ${

--- a/definitions/tools/hisat2_align.cwl
+++ b/definitions/tools/hisat2_align.cwl
@@ -50,7 +50,10 @@ inputs:
         inputBinding:
             position: -4
     strand:
-        type: string?
+        type:
+          - "null"
+          - type: enum
+            symbols: ["first", "second", "unstranded"]
         inputBinding:
             valueFrom: |
                 ${

--- a/definitions/tools/kallisto.cwl
+++ b/definitions/tools/kallisto.cwl
@@ -32,7 +32,10 @@ inputs:
         inputBinding:
             position: 3
     strand:
-        type: string?
+        type:
+          - "null"
+          - type: enum
+            symbols: ["first", "second", "unstranded"]
         inputBinding:
             valueFrom: |
                 ${

--- a/definitions/tools/stringtie.cwl
+++ b/definitions/tools/stringtie.cwl
@@ -18,7 +18,10 @@ arguments: [
 ]
 inputs:
     strand:
-        type: string?
+        type:
+          - "null"
+          - type: enum
+            symbols: ["first", "second", "unstranded"]
         inputBinding:
             valueFrom: |
                 ${


### PR DESCRIPTION
Since tools rely on particular values, stop users from accidentallyspecifying the same intent other ways (e.g. "firststrand" instead of "first").  [This change is from a support ticket where that very thing
happened :smile: (XREF: BGAS-651)]