### PR TITLE
strips trailing empty lines that may cause problems

### DIFF
--- a/definitions/tools/get_chromosome_list.cwl
+++ b/definitions/tools/get_chromosome_list.cwl
@@ -2,7 +2,7 @@
 cwlVersion: v1.0
 class: CommandLineTool
 baseCommand: [
-    "bash", "-c", "/bin/grep -v '^@' $1 | /usr/bin/cut -f 1 | /usr/bin/sort | /usr/bin/uniq", "--"
+    "bash", "-c", "/bin/grep -v '^@' $1 | /usr/bin/cut -f 1 | /usr/bin/sort | grep -v ^$ | /usr/bin/uniq", "--"
 ]
 requirements:
     - class: InlineJavascriptRequirement


### PR DESCRIPTION
If there's a stray extra newline at the end of an interval list, that gets put into the chromosomes list and causes steps like Pindel to choke (when given an empty string for the -c argument)

The underlying fix is really "fix the interval list", but there's no reason not to make this a little more robust as well