### PR TITLE
handle multiple directory inputs

### DIFF
--- a/definitions/subworkflows/cellranger_mkfastq_and_count.cwl
+++ b/definitions/subworkflows/cellranger_mkfastq_and_count.cwl
@@ -27,7 +27,9 @@ steps:
         run: ../tools/cellranger_count.cwl
         in: 
             chemistry: chemistry
-            fastq_directory: mkfastq/fastq_dir
+            fastq_directory:
+                source: [mkfastq/fastq_dir]
+                linkMerge: merge_flattened
             reference: reference
             sample_name: sample_name
         out: [out_dir]

--- a/definitions/tools/cellranger_atac_count.cwl
+++ b/definitions/tools/cellranger_atac_count.cwl
@@ -16,12 +16,13 @@ requirements:
 
 inputs:
     fastq_directory:
-        type: Directory
+        type: Directory[]
         inputBinding:
            prefix: --fastqs=
            position: 1
+           itemSeparator: ","
            separate: false
-        doc: "Directory containing fastq files"
+        doc: "Array of directories containing fastq files"
     reference:
         type: Directory
         inputBinding:

--- a/definitions/tools/cellranger_count.cwl
+++ b/definitions/tools/cellranger_count.cwl
@@ -24,12 +24,13 @@ inputs:
         default: "auto"
         doc: "Assay configuration used, default 'auto' should usually work without issue"
     fastq_directory:
-        type: Directory
+        type: Directory[]
         inputBinding:
            prefix: --fastqs=
            position: 2
+           itemSeparator: ","
            separate: false
-        doc: "Directory containing fastq files"
+        doc: "Array of directories containing fastq files"
     reference:
         type: Directory
         inputBinding:

--- a/definitions/tools/cellranger_vdj.cwl
+++ b/definitions/tools/cellranger_vdj.cwl
@@ -16,12 +16,13 @@ requirements:
 
 inputs:
     fastq_directory:
-        type: Directory
+        type: Directory[]
         inputBinding:
             prefix: --fastqs=
             position: 1
+            itemSeparator: ","
             separate: false
-        doc: "Directory containing fastq files"
+        doc: "Array of directories containing fastq files"
     reference:
         type: Directory
         inputBinding:


### PR DESCRIPTION
The original cellranger CWLs worked great for running samples that had a single instrument data. But when there are multiple instrument data objects there was no easy way to pass them in as a single input directory. I recently learned that you can pass in multiple directory paths separated by a `,` in the `--fastqs` option. Cellranger is able to traverse the different directories and locate the correct fastq files to use. 

By switching to an array of directories we can have the Cellranger pipeline handle getting the correct fastq files instead of setting up the fastq files in the `process_inputs.pl` step or relying on Cromwell to correctly setup multiple directories. 

closes #656 