### PR TITLE
bumping to v0.2 to fix an edge case error

### DIFF
--- a/definitions/tools/filter_vcf_mapq0.cwl
+++ b/definitions/tools/filter_vcf_mapq0.cwl
@@ -5,7 +5,7 @@ class: CommandLineTool
 label: "filter vcf for variants with high percentage of mapq0 reads"
 requirements:
     - class: DockerRequirement
-      dockerPull: mgibio/mapq0-filter:v0.1
+      dockerPull: mgibio/mapq0-filter:v0.2
     - class: ResourceRequirement
       ramMin: 8000
       tmpdirMin: 10000


### PR DESCRIPTION
Change described here - fixes an edge case error when all variants already have MQ values.  Tests pass

https://github.com/genome/docker-mapq0-filter/commit/6b5002c5d519bede7eaf546873616e45387a458f