### PR TITLE
Support multiple species and builds with VEP

### DIFF
--- a/definitions/pipelines/cle_somatic_exome.cwl
+++ b/definitions/pipelines/cle_somatic_exome.cwl
@@ -104,13 +104,13 @@ inputs:
         type: string
     vep_ensembl_assembly:
         type: string
-        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+        doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"
     vep_ensembl_version:
         type: string
-        doc: ensembl version - Must be present in the cache directory. Example: "95"
+        doc: "ensembl version - Must be present in the cache directory. Example: 95"
     vep_ensembl_species:
         type: string
-        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
+        doc: "ensembl species - Must be present in the cache directory. Examples: homo_sapiens or mus_musculus"
     synonyms_file:
         type: File?
     annotate_coding_only:

--- a/definitions/pipelines/cle_somatic_exome.cwl
+++ b/definitions/pipelines/cle_somatic_exome.cwl
@@ -102,6 +102,15 @@ inputs:
         default: true
     vep_cache_dir:
         type: string
+    vep_ensembl_assembly:
+        type: string
+        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+    vep_ensembl_version:
+        type: string
+        doc: ensembl version - Must be present in the cache directory. Example: "95"
+    vep_ensembl_species:
+        type: string
+        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
     synonyms_file:
         type: File?
     annotate_coding_only:
@@ -129,9 +138,6 @@ inputs:
     custom_clinvar_vcf:
         type: File?
         secondaryFiles: [.tbi]
-    vep_assembly:
-        type: string
-        doc: Used to explicitly define which assembly to use; required if there are two or more in the same directory
     somalier_vcf:
         type: File
 outputs:
@@ -365,6 +371,9 @@ steps:
             docm_vcf: docm_vcf
             filter_docm_variants: filter_docm_variants
             vep_cache_dir: vep_cache_dir
+            vep_ensembl_assembly: vep_ensembl_assembly
+            vep_ensembl_version: vep_ensembl_version
+            vep_ensembl_species: vep_ensembl_species
             synonyms_file: synonyms_file
             annotate_coding_only: annotate_coding_only
             vep_pick: vep_pick
@@ -374,7 +383,6 @@ steps:
             vep_to_table_fields: vep_to_table_fields
             custom_gnomad_vcf: custom_gnomad_vcf
             custom_clinvar_vcf: custom_clinvar_vcf
-            vep_assembly: vep_assembly
         out:
             [mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv]
     tumor_bam_to_cram:

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -67,6 +67,15 @@ inputs:
         default: true
     vep_cache_dir:
         type: string
+    vep_ensembl_assembly:
+        type: string
+        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+    vep_ensembl_version:
+        type: string
+        doc: ensembl version - Must be present in the cache directory. Example: "95"
+    vep_ensembl_species:
+        type: string
+        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
     synonyms_file:
         type: File?
     annotate_coding_only:
@@ -273,6 +282,9 @@ steps:
         in:
             vcf: add_docm_variants/merged_vcf
             cache_dir: vep_cache_dir
+            ensembl_assembly: vep_ensembl_assembly
+            ensembl_version: vep_ensembl_version
+            ensembl_species: vep_ensembl_species
             synonyms_file: synonyms_file
             coding_only: annotate_coding_only
             reference: reference

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -118,9 +118,6 @@ inputs:
     custom_clinvar_vcf:
         type: File?
         secondaryFiles: [.tbi]
-    vep_assembly:
-        type: string
-        doc: Used to explicitly define which assembly version to use; required when there are two or more in the same directory
 outputs:
     mutect_unfiltered_vcf:
         type: File
@@ -291,7 +288,6 @@ steps:
             custom_gnomad_vcf: custom_gnomad_vcf
             pick: vep_pick
             custom_clinvar_vcf: custom_clinvar_vcf
-            assembly: vep_assembly
             plugins: vep_plugins
         out:
             [annotated_vcf, vep_summary]

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -69,13 +69,13 @@ inputs:
         type: string
     vep_ensembl_assembly:
         type: string
-        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+        doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"
     vep_ensembl_version:
         type: string
-        doc: ensembl version - Must be present in the cache directory. Example: "95"
+        doc: "ensembl version - Must be present in the cache directory. Example: 95"
     vep_ensembl_species:
         type: string
-        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
+        doc: "ensembl species - Must be present in the cache directory. Examples: homo_sapiens or mus_musculus"
     synonyms_file:
         type: File?
     annotate_coding_only:

--- a/definitions/pipelines/exome.cwl
+++ b/definitions/pipelines/exome.cwl
@@ -62,13 +62,13 @@ inputs:
         type: string
     vep_ensembl_assembly:
         type: string
-        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+        doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"
     vep_ensembl_version:
         type: string
-        doc: ensembl version - Must be present in the cache directory. Example: "95"
+        doc: "ensembl version - Must be present in the cache directory. Example: 95"
     vep_ensembl_species:
         type: string
-        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
+        doc: "ensembl species - Must be present in the cache directory. Examples: homo_sapiens or mus_musculus"
     synonyms_file:
         type: File?
     annotate_coding_only:

--- a/definitions/pipelines/exome.cwl
+++ b/definitions/pipelines/exome.cwl
@@ -60,6 +60,15 @@ inputs:
         default: 0.001
     vep_cache_dir:
         type: string
+    vep_ensembl_assembly:
+        type: string
+        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+    vep_ensembl_version:
+        type: string
+        doc: ensembl version - Must be present in the cache directory. Example: "95"
+    vep_ensembl_species:
+        type: string
+        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
     synonyms_file:
         type: File?
     annotate_coding_only:
@@ -95,9 +104,6 @@ inputs:
         type: int?
     readcount_minimum_base_quality:
         type: int?
-    vep_assembly:
-        type: string
-        doc: Used to explicitly define which version of the assembly to use; required if there are two or more in the same directory
 outputs:
     cram:
         type: File
@@ -203,6 +209,9 @@ steps:
             varscan_min_reads: varscan_min_reads
             maximum_population_allele_frequency: maximum_population_allele_frequency
             vep_cache_dir: vep_cache_dir
+            vep_ensembl_assembly: vep_ensembl_assembly
+            vep_ensembl_version: vep_ensembl_version
+            vep_ensembl_species: vep_ensembl_species
             synonyms_file: synonyms_file
             vep_pick: vep_pick
             variants_to_table_fields: variants_to_table_fields
@@ -213,7 +222,6 @@ steps:
             custom_gnomad_vcf: custom_gnomad_vcf
             readcount_minimum_mapping_quality: readcount_minimum_mapping_quality
             readcount_minimum_base_quality: readcount_minimum_base_quality
-            vep_assembly: vep_assembly
         out:
             [varscan_vcf, docm_gatk_vcf, annotated_vcf, final_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv]
     bam_to_cram:

--- a/definitions/pipelines/gathered_cle_somatic_exome.cwl
+++ b/definitions/pipelines/gathered_cle_somatic_exome.cwl
@@ -103,13 +103,13 @@ inputs:
         type: string?
     vep_ensembl_assembly:
         type: string
-        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+        doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"
     vep_ensembl_version:
         type: string
-        doc: ensembl version - Must be present in the cache directory. Example: "95"
+        doc: "ensembl version - Must be present in the cache directory. Example: 95"
     vep_ensembl_species:
         type: string
-        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
+        doc: "ensembl species - Must be present in the cache directory. Examples: homo_sapiens or mus_musculus"
     synonyms_file:
         type: File?
     annotate_coding_only:

--- a/definitions/pipelines/gathered_cle_somatic_exome.cwl
+++ b/definitions/pipelines/gathered_cle_somatic_exome.cwl
@@ -101,6 +101,15 @@ inputs:
         default: true
     vep_cache_dir:
         type: string?
+    vep_ensembl_assembly:
+        type: string
+        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+    vep_ensembl_version:
+        type: string
+        doc: ensembl version - Must be present in the cache directory. Example: "95"
+    vep_ensembl_species:
+        type: string
+        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
     synonyms_file:
         type: File?
     annotate_coding_only:
@@ -129,9 +138,6 @@ inputs:
         secondaryFiles: [.tbi]
     output_dir: 
         type: string
-    vep_assembly:
-        type: string
-        doc: Used to explicitly define which assembly to use; required if there are two or more in the same directory
     somalier_vcf:
         type: File
 outputs:
@@ -178,6 +184,9 @@ steps:
             pindel_insert_size: pindel_insert_size
             docm_vcf: docm_vcf
             vep_cache_dir: vep_cache_dir
+            vep_ensembl_assembly: vep_ensembl_assembly
+            vep_ensembl_version: vep_ensembl_version
+            vep_ensembl_species: vep_ensembl_species
             synonyms_file: synonyms_file
             annotate_coding_only: annotate_coding_only
             hgvs_annotation: hgvs_annotation
@@ -189,7 +198,6 @@ steps:
             vep_to_table_fields: vep_to_table_fields
             custom_gnomad_vcf: custom_gnomad_vcf
             somalier_vcf: somalier_vcf
-            vep_assembly: vep_assembly
         out:
             [tumor_cram, tumor_mark_duplicates_metrics, tumor_insert_size_metrics, tumor_alignment_summary_metrics, tumor_hs_metrics, tumor_per_target_coverage_metrics, tumor_per_base_coverage_metrics, tumor_per_base_hs_metrics, tumor_summary_hs_metrics, tumor_flagstats, tumor_verify_bam_id_metrics, tumor_verify_bam_id_depth, normal_cram, normal_mark_duplicates_metrics, normal_insert_size_metrics, normal_alignment_summary_metrics, normal_hs_metrics, normal_per_target_coverage_metrics, normal_per_target_hs_metrics, normal_per_base_coverage_metrics, normal_per_base_hs_metrics, normal_summary_hs_metrics, normal_flagstats, normal_verify_bam_id_metrics, normal_verify_bam_id_depth, mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv, somalier_concordance_metrics, somalier_concordance_statistics]
     gatherer:

--- a/definitions/pipelines/gathered_somatic_exome.cwl
+++ b/definitions/pipelines/gathered_somatic_exome.cwl
@@ -103,13 +103,13 @@ inputs:
         type: string?
     vep_ensembl_assembly:
         type: string
-        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+        doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"
     vep_ensembl_version:
         type: string
-        doc: ensembl version - Must be present in the cache directory. Example: "95"
+        doc: "ensembl version - Must be present in the cache directory. Example: 95"
     vep_ensembl_species:
         type: string
-        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
+        doc: "ensembl species - Must be present in the cache directory. Examples: homo_sapiens or mus_musculus"
     synonyms_file:
         type: File?
     annotate_coding_only:

--- a/definitions/pipelines/gathered_somatic_exome.cwl
+++ b/definitions/pipelines/gathered_somatic_exome.cwl
@@ -101,6 +101,15 @@ inputs:
         default: true
     vep_cache_dir:
         type: string?
+    vep_ensembl_assembly:
+        type: string
+        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+    vep_ensembl_version:
+        type: string
+        doc: ensembl version - Must be present in the cache directory. Example: "95"
+    vep_ensembl_species:
+        type: string
+        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
     synonyms_file:
         type: File?
     annotate_coding_only:
@@ -129,9 +138,6 @@ inputs:
         secondaryFiles: [.tbi]
     output_dir: 
         type: string
-    vep_assembly:
-        type: string
-        doc: Used to explicitly define which assembly version to use; required if there are two or more in the same directory
     somalier_vcf:
         type: File
 outputs:
@@ -178,6 +184,9 @@ steps:
             pindel_insert_size: pindel_insert_size
             docm_vcf: docm_vcf
             vep_cache_dir: vep_cache_dir
+            vep_ensembl_assembly: vep_ensembl_assembly
+            vep_ensembl_version: vep_ensembl_version
+            vep_ensembl_species: vep_ensembl_species
             synonyms_file: synonyms_file
             annotate_coding_only: annotate_coding_only
             hgvs_annotation: hgvs_annotation
@@ -187,7 +196,6 @@ steps:
             variants_to_table_genotype_fields: variants_to_table_genotype_fields
             vep_to_table_fields: vep_to_table_fields
             custom_gnomad_vcf: custom_gnomad_vcf
-            vep_assembly: vep_assembly
             somalier_vcf: somalier_vcf
         out:
             [tumor_cram, tumor_mark_duplicates_metrics, tumor_insert_size_metrics, tumor_alignment_summary_metrics, tumor_hs_metrics, tumor_per_target_coverage_metrics, tumor_per_base_coverage_metrics, tumor_per_base_hs_metrics, tumor_summary_hs_metrics, tumor_flagstats, tumor_verify_bam_id_metrics, tumor_verify_bam_id_depth, normal_cram, normal_mark_duplicates_metrics, normal_insert_size_metrics, normal_alignment_summary_metrics, normal_hs_metrics, normal_per_target_coverage_metrics, normal_per_target_hs_metrics, normal_per_base_coverage_metrics, normal_per_base_hs_metrics, normal_summary_hs_metrics, normal_flagstats, normal_verify_bam_id_metrics, normal_verify_bam_id_depth, mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv, somalier_concordance_metrics, somalier_concordance_statistics]

--- a/definitions/pipelines/germline_exome.cwl
+++ b/definitions/pipelines/germline_exome.cwl
@@ -52,6 +52,15 @@ inputs:
                 items: string
     vep_cache_dir:
         type: string
+    vep_ensembl_assembly:
+        type: string
+        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+    vep_ensembl_version:
+        type: string
+        doc: ensembl version - Must be present in the cache directory. Example: "95"
+    vep_ensembl_species:
+        type: string
+        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
     synonyms_file:
         type: File?
     annotate_coding_only:
@@ -66,9 +75,6 @@ inputs:
     custom_clinvar_vcf:
         type: File?
         secondaryFiles: [.tbi]
-    vep_assembly:
-        type: string
-        doc: Used to explicitly define which assembly version to use; required when there are two or more in the same directory
 outputs:
     cram:
         type: File
@@ -193,7 +199,9 @@ steps:
             custom_gnomad_vcf: custom_gnomad_vcf
             limit_variant_intervals: target_intervals
             custom_clinvar_vcf: custom_clinvar_vcf
-            vep_assembly: vep_assembly
+            vep_ensembl_assembly: vep_ensembl_assembly
+            vep_ensembl_version: vep_ensembl_version
+            vep_ensembl_species: vep_ensembl_species
         out:
             [gvcf, final_vcf, coding_vcf, limited_vcf, vep_summary]
     bam_to_cram:

--- a/definitions/pipelines/germline_exome.cwl
+++ b/definitions/pipelines/germline_exome.cwl
@@ -54,13 +54,13 @@ inputs:
         type: string
     vep_ensembl_assembly:
         type: string
-        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+        doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"
     vep_ensembl_version:
         type: string
-        doc: ensembl version - Must be present in the cache directory. Example: "95"
+        doc: "ensembl version - Must be present in the cache directory. Example: 95"
     vep_ensembl_species:
         type: string
-        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
+        doc: "ensembl species - Must be present in the cache directory. Examples: homo_sapiens or mus_musculus"
     synonyms_file:
         type: File?
     annotate_coding_only:

--- a/definitions/pipelines/germline_exome_hla_typing.cwl
+++ b/definitions/pipelines/germline_exome_hla_typing.cwl
@@ -52,6 +52,15 @@ inputs:
                 items: string
     vep_cache_dir:
         type: string
+    vep_ensembl_assembly:
+        type: string
+        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+    vep_ensembl_version:
+        type: string
+        doc: ensembl version - Must be present in the cache directory. Example: "95"
+    vep_ensembl_species:
+        type: string
+        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
     synonyms_file:
         type: File?
     annotate_coding_only:
@@ -68,9 +77,6 @@ inputs:
         secondaryFiles: [.tbi]
     optitype_name:
         type: string?
-    vep_assembly:
-        type: string
-        doc: Used to explicitly define which assembly version to use; required when there are two or more in the same directory
 outputs:
     cram:
         type: File
@@ -160,13 +166,15 @@ steps:
             gvcf_gq_bands: gvcf_gq_bands
             intervals: intervals
             vep_cache_dir: vep_cache_dir
+            vep_ensembl_assembly: vep_ensembl_assembly
+            vep_ensembl_version: vep_ensembl_version
+            vep_ensembl_species: vep_ensembl_species
             synonyms_file: synonyms_file
             annotate_coding_only: annotate_coding_only
             custom_gnomad_vcf: custom_gnomad_vcf
             qc_minimum_mapping_quality: qc_minimum_mapping_quality
             qc_minimum_base_quality: qc_minimum_base_quality
             custom_clinvar_vcf: custom_clinvar_vcf
-            vep_assembly: vep_assembly
         out:
             [cram, mark_duplicates_metrics, insert_size_metrics, insert_size_histogram, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, summary_hs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth, gvcf, final_vcf, coding_vcf, limited_vcf, vep_summary]
     optitype:

--- a/definitions/pipelines/germline_exome_hla_typing.cwl
+++ b/definitions/pipelines/germline_exome_hla_typing.cwl
@@ -54,13 +54,13 @@ inputs:
         type: string
     vep_ensembl_assembly:
         type: string
-        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+        doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"
     vep_ensembl_version:
         type: string
-        doc: ensembl version - Must be present in the cache directory. Example: "95"
+        doc: "ensembl version - Must be present in the cache directory. Example: 95"
     vep_ensembl_species:
         type: string
-        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
+        doc: "ensembl species - Must be present in the cache directory. Examples: homo_sapiens or mus_musculus"
     synonyms_file:
         type: File?
     annotate_coding_only:

--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -338,7 +338,9 @@ steps:
             merge_sv_pop_freq_db: merge_sv_pop_freq_db
             sv_filter_interval_lists: sv_filter_interval_lists
             vep_cache_dir: vep_cache_dir
-            vep_assembly: vep_assembly
+            vep_ensembl_assembly: vep_ensembl_assembly
+            vep_ensembl_version: vep_ensembl_version
+            vep_ensembl_species: vep_ensembl_species
             maximum_sv_pop_freq: maximum_sv_pop_freq
             variants_to_table_fields: sv_variants_to_table_fields
             variants_to_table_genotype_fields: sv_variants_to_table_genotype_fields

--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -46,13 +46,13 @@ inputs:
         type: string
     vep_ensembl_assembly:
         type: string
-        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+        doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"
     vep_ensembl_version:
         type: string
-        doc: ensembl version - Must be present in the cache directory. Example: "95"
+        doc: "ensembl version - Must be present in the cache directory. Example: 95"
     vep_ensembl_species:
         type: string
-        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
+        doc: "ensembl species - Must be present in the cache directory. Examples: homo_sapiens or mus_musculus"
     synonyms_file:
         type: File?
     annotate_coding_only:

--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -44,6 +44,15 @@ inputs:
         type: File
     vep_cache_dir:
         type: string
+    vep_ensembl_assembly:
+        type: string
+        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+    vep_ensembl_version:
+        type: string
+        doc: ensembl version - Must be present in the cache directory. Example: "95"
+    vep_ensembl_species:
+        type: string
+        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
     synonyms_file:
         type: File?
     annotate_coding_only:
@@ -89,9 +98,6 @@ inputs:
         type: boolean?
     smoove_exclude_regions:
         type: File?
-    vep_assembly:
-        type: string
-        doc: Used to explicitly define which assembly version to use; required when there are two or more in the same directory
     merge_max_distance:
         type: int
     merge_min_svs:
@@ -302,7 +308,9 @@ steps:
             custom_gnomad_vcf: custom_gnomad_vcf
             limit_variant_intervals: variant_reporting_intervals
             custom_clinvar_vcf: custom_clinvar_vcf
-            vep_assembly: vep_assembly
+            vep_ensembl_assembly: vep_ensembl_assembly
+            vep_ensembl_version: vep_ensembl_version
+            vep_ensembl_species: vep_ensembl_species
         out:
             [gvcf, final_vcf, coding_vcf, limited_vcf, vep_summary]
     variant_callers:

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -726,7 +726,6 @@ steps:
             qc_minimum_base_quality: qc_minimum_base_quality
             custom_clinvar_vcf: custom_clinvar_vcf
             optitype_name: optitype_name
-            vep_assembly: vep_assembly
         out:
             [cram,mark_duplicates_metrics,insert_size_metrics,insert_size_histogram,alignment_summary_metrics,hs_metrics,per_target_coverage_metrics,per_target_hs_metrics,per_base_coverage_metrics,per_base_hs_metrics,summary_hs_metrics,flagstats,verify_bam_id_metrics,verify_bam_id_depth,gvcf,final_vcf,coding_vcf,limited_vcf,vep_summary,optitype_tsv,optitype_plot]
     phase_vcf:

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -146,13 +146,13 @@ inputs:
         type: string
     vep_ensembl_assembly:
         type: string
-        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+        doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"
     vep_ensembl_version:
         type: string
-        doc: ensembl version - Must be present in the cache directory. Example: "95"
+        doc: "ensembl version - Must be present in the cache directory. Example: 95"
     vep_ensembl_species:
         type: string
-        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
+        doc: "ensembl species - Must be present in the cache directory. Examples: homo_sapiens or mus_musculus"
     synonyms_file:
         type: File?
     annotate_coding_only:

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -144,6 +144,15 @@ inputs:
         default: true
     vep_cache_dir:
         type: string
+    vep_ensembl_assembly:
+        type: string
+        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+    vep_ensembl_version:
+        type: string
+        doc: ensembl version - Must be present in the cache directory. Example: "95"
+    vep_ensembl_species:
+        type: string
+        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
     synonyms_file:
         type: File?
     annotate_coding_only:
@@ -171,9 +180,6 @@ inputs:
     custom_clinvar_vcf:
         type: File?
         secondaryFiles: [.tbi]
-    vep_assembly:
-        type: string
-        doc: Used to explicitly define which assembly to use; required if there are two or more in the same directory
     manta_call_regions:
         type: File?
         secondaryFiles: [.tbi]
@@ -671,6 +677,9 @@ steps:
             docm_vcf: docm_vcf
             filter_docm_variants: filter_docm_variants
             vep_cache_dir: vep_cache_dir
+            vep_ensembl_assembly: vep_ensembl_assembly
+            vep_ensembl_version: vep_ensembl_version
+            vep_ensembl_species: vep_ensembl_species
             synonyms_file: synonyms_file
             annotate_coding_only: annotate_coding_only
             vep_pick: vep_pick
@@ -680,7 +689,6 @@ steps:
             vep_to_table_fields: vep_to_table_fields
             custom_gnomad_vcf: custom_gnomad_vcf
             custom_clinvar_vcf: custom_clinvar_vcf
-            vep_assembly: vep_assembly
             manta_call_regions: manta_call_regions
             manta_non_wgs: manta_non_wgs
             manta_output_contigs: manta_output_contigs
@@ -708,6 +716,9 @@ steps:
             gvcf_gq_bands: gvcf_gq_bands
             intervals: gatk_haplotypecaller_intervals
             vep_cache_dir: vep_cache_dir
+            vep_ensembl_assembly: vep_ensembl_assembly
+            vep_ensembl_version: vep_ensembl_version
+            vep_ensembl_species: vep_ensembl_species
             synonyms_file: synonyms_file
             annotate_coding_only: annotate_coding_only
             custom_gnomad_vcf: custom_gnomad_vcf

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -104,13 +104,13 @@ inputs:
         type: string
     vep_ensembl_assembly:
         type: string
-        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+        doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"
     vep_ensembl_version:
         type: string
-        doc: ensembl version - Must be present in the cache directory. Example: "95"
+        doc: "ensembl version - Must be present in the cache directory. Example: 95"
     vep_ensembl_species:
         type: string
-        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
+        doc: "ensembl species - Must be present in the cache directory. Examples: homo_sapiens or mus_musculus"
     synonyms_file:
         type: File?
     annotate_coding_only:

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -102,6 +102,15 @@ inputs:
         default: true
     vep_cache_dir:
         type: string
+    vep_ensembl_assembly:
+        type: string
+        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+    vep_ensembl_version:
+        type: string
+        doc: ensembl version - Must be present in the cache directory. Example: "95"
+    vep_ensembl_species:
+        type: string
+        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
     synonyms_file:
         type: File?
     annotate_coding_only:
@@ -129,9 +138,6 @@ inputs:
     custom_clinvar_vcf:
         type: File?
         secondaryFiles: [.tbi]
-    vep_assembly:
-        type: string
-        doc: Used to explicitly define which assembly to use; required if there are two or more in the same directory
     manta_call_regions:
         type: File?
         secondaryFiles: [.tbi]
@@ -426,6 +432,9 @@ steps:
             docm_vcf: docm_vcf
             filter_docm_variants: filter_docm_variants
             vep_cache_dir: vep_cache_dir
+            vep_ensembl_assembly: vep_ensembl_assembly
+            vep_ensembl_version: vep_ensembl_version
+            vep_ensembl_species: vep_ensembl_species
             synonyms_file: synonyms_file
             annotate_coding_only: annotate_coding_only
             vep_pick: vep_pick
@@ -435,7 +444,6 @@ steps:
             vep_to_table_fields: vep_to_table_fields
             custom_gnomad_vcf: custom_gnomad_vcf
             custom_clinvar_vcf: custom_clinvar_vcf
-            vep_assembly: vep_assembly
         out:
             [mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv]
     cnvkit:

--- a/definitions/pipelines/tumor_only_detect_variants.cwl
+++ b/definitions/pipelines/tumor_only_detect_variants.cwl
@@ -37,13 +37,13 @@ inputs:
         type: string
     vep_ensembl_assembly:
         type: string
-        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+        doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"
     vep_ensembl_version:
         type: string
-        doc: ensembl version - Must be present in the cache directory. Example: "95"
+        doc: "ensembl version - Must be present in the cache directory. Example: 95"
     vep_ensembl_species:
         type: string
-        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
+        doc: "ensembl species - Must be present in the cache directory. Examples: homo_sapiens or mus_musculus"
     synonyms_file:
         type: File?
     annotate_coding_only:

--- a/definitions/pipelines/tumor_only_detect_variants.cwl
+++ b/definitions/pipelines/tumor_only_detect_variants.cwl
@@ -35,6 +35,15 @@ inputs:
         default: 0.001
     vep_cache_dir:
         type: string
+    vep_ensembl_assembly:
+        type: string
+        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+    vep_ensembl_version:
+        type: string
+        doc: ensembl version - Must be present in the cache directory. Example: "95"
+    vep_ensembl_species:
+        type: string
+        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
     synonyms_file:
         type: File?
     annotate_coding_only:
@@ -69,9 +78,6 @@ inputs:
         type: int?
     readcount_minimum_base_quality:
         type: int?
-    vep_assembly:
-        type: string
-        doc: Used to explicitly define which version of the assembly to use; required when there are two or more in the same directory
 outputs:
     varscan_vcf:
         type: File
@@ -148,7 +154,9 @@ steps:
             reference: reference
             custom_gnomad_vcf: custom_gnomad_vcf
             pick: vep_pick
-            assembly: vep_assembly
+            ensembl_assembly: vep_ensembl_assembly
+            ensembl_version: vep_ensembl_version
+            ensembl_species: vep_ensembl_species
             plugins: vep_plugins
         out:
             [annotated_vcf, vep_summary]

--- a/definitions/pipelines/wgs.cwl
+++ b/definitions/pipelines/wgs.cwl
@@ -34,6 +34,15 @@ inputs:
         type: File
     vep_cache_dir:
         type: string
+    vep_ensembl_assembly:
+        type: string
+        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+    vep_ensembl_version:
+        type: string
+        doc: ensembl version - Must be present in the cache directory. Example: "95"
+    vep_ensembl_species:
+        type: string
+        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
     synonyms_file:
         type: File?
     vep_pick:
@@ -58,9 +67,6 @@ inputs:
         type: ../types/labelled_file.yml#labelled_file[]
     summary_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
-    vep_assembly:
-        type: string
-        doc: Used to explicitly define which version of the assembly to use; required if there are two or more in the same directory
 outputs:
     cram:
         type: File
@@ -178,6 +184,9 @@ steps:
             vep_cache_dir: vep_cache_dir
             synonyms_file: synonyms_file
             vep_pick: vep_pick
+            vep_ensembl_assembly: vep_ensembl_assembly
+            vep_ensembl_version: vep_ensembl_version
+            vep_ensembl_species: vep_ensembl_species
             #variants_to_table_fields:
             #variants_to_table_genotype_fields:
             #vep_to_table_fields:
@@ -186,7 +195,6 @@ steps:
             custom_gnomad_vcf: custom_gnomad_vcf
             readcount_minimum_mapping_quality: readcount_minimum_mapping_quality
             readcount_minimum_base_quality: readcount_minimum_base_quality
-            vep_assembly: vep_assembly
         out:
             [varscan_vcf, docm_gatk_vcf, annotated_vcf, final_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv]
     bam_to_cram:

--- a/definitions/pipelines/wgs.cwl
+++ b/definitions/pipelines/wgs.cwl
@@ -36,13 +36,13 @@ inputs:
         type: string
     vep_ensembl_assembly:
         type: string
-        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+        doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"
     vep_ensembl_version:
         type: string
-        doc: ensembl version - Must be present in the cache directory. Example: "95"
+        doc: "ensembl version - Must be present in the cache directory. Example: 95"
     vep_ensembl_species:
         type: string
-        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
+        doc: "ensembl species - Must be present in the cache directory. Examples: homo_sapiens or mus_musculus"
     synonyms_file:
         type: File?
     vep_pick:

--- a/definitions/subworkflows/germline_detect_variants.cwl
+++ b/definitions/subworkflows/germline_detect_variants.cwl
@@ -26,13 +26,13 @@ inputs:
         type: string
     vep_ensembl_assembly:
         type: string
-        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+        doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"
     vep_ensembl_version:
         type: string
-        doc: ensembl version - Must be present in the cache directory. Example: "95"
+        doc: "ensembl version - Must be present in the cache directory. Example: 95"
     vep_ensembl_species:
         type: string
-        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
+        doc: "ensembl species - Must be present in the cache directory. Examples: homo_sapiens or mus_musculus"
     vep_plugins:
         type: string[]?
         default: [Downstream, Wildtype]

--- a/definitions/subworkflows/germline_detect_variants.cwl
+++ b/definitions/subworkflows/germline_detect_variants.cwl
@@ -24,6 +24,15 @@ inputs:
         type: string?
     vep_cache_dir:
         type: string
+    vep_ensembl_assembly:
+        type: string
+        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+    vep_ensembl_version:
+        type: string
+        doc: ensembl version - Must be present in the cache directory. Example: "95"
+    vep_ensembl_species:
+        type: string
+        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
     vep_plugins:
         type: string[]?
         default: [Downstream, Wildtype]
@@ -39,8 +48,6 @@ inputs:
     custom_clinvar_vcf:
         type: File?
         secondaryFiles: [.tbi]
-    vep_assembly:
-        type: string
 outputs:
     gvcf:
         type: File[]
@@ -84,6 +91,9 @@ steps:
         in:
             vcf: genotype_gvcfs/genotype_vcf
             cache_dir: vep_cache_dir
+            ensembl_assembly: vep_ensembl_assembly
+            ensembl_version: vep_ensembl_version
+            ensembl_species: vep_ensembl_species
             synonyms_file: synonyms_file
             coding_only: annotate_coding_only
             reference: reference

--- a/definitions/subworkflows/germline_detect_variants.cwl
+++ b/definitions/subworkflows/germline_detect_variants.cwl
@@ -99,7 +99,6 @@ steps:
             reference: reference
             custom_gnomad_vcf: custom_gnomad_vcf
             custom_clinvar_vcf: custom_clinvar_vcf
-            assembly: vep_assembly
             plugins: vep_plugins
         out:
             [annotated_vcf, vep_summary]

--- a/definitions/subworkflows/merge_svs.cwl
+++ b/definitions/subworkflows/merge_svs.cwl
@@ -28,13 +28,13 @@ inputs:
         type: string
     vep_ensembl_assembly:
         type: string
-        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+        doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"
     vep_ensembl_version:
         type: string
-        doc: ensembl version - Must be present in the cache directory. Example: "95"
+        doc: "ensembl version - Must be present in the cache directory. Example: 95"
     vep_ensembl_species:
         type: string
-        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
+        doc: "ensembl species - Must be present in the cache directory. Examples: homo_sapiens or mus_musculus"
     coding_only:
         type: boolean?
     custom_gnomad_vcf:

--- a/definitions/subworkflows/merge_svs.cwl
+++ b/definitions/subworkflows/merge_svs.cwl
@@ -26,6 +26,15 @@ inputs:
         type: File
     vep_cache_dir:
         type: string
+    vep_ensembl_assembly:
+        type: string
+        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+    vep_ensembl_version:
+        type: string
+        doc: ensembl version - Must be present in the cache directory. Example: "95"
+    vep_ensembl_species:
+        type: string
+        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
     coding_only:
         type: boolean?
     custom_gnomad_vcf:
@@ -39,8 +48,6 @@ inputs:
     vep_plugins:
         type: string[]?
         default: []
-    vep_assembly:
-        type: string
 outputs:
     merged_annotated_vcf:
         type: File
@@ -73,9 +80,11 @@ steps:
     annotate_variants:
         run: ../tools/vep.cwl
         in:
-            assembly: vep_assembly
             vcf: add_population_frequency/merged_annotated_vcf
             cache_dir: vep_cache_dir
+            ensembl_assembly: vep_ensembl_assembly
+            ensembl_version: vep_ensembl_version
+            ensembl_species: vep_ensembl_species
             synonyms_file: synonyms_file
             coding_only: coding_only
             reference: reference

--- a/definitions/subworkflows/single_sample_sv_callers.cwl
+++ b/definitions/subworkflows/single_sample_sv_callers.cwl
@@ -68,6 +68,15 @@ inputs:
 
     vep_cache_dir:
         type: string
+    vep_ensembl_assembly:
+        type: string
+        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+    vep_ensembl_version:
+        type: string
+        doc: ensembl version - Must be present in the cache directory. Example: "95"
+    vep_ensembl_species:
+        type: string
+        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
     variants_to_table_fields:
         type: string[]?
         default: [CHROM,POS,ID,REF,ALT,SVLEN,CHR2,END,POPFREQ_AF,POPFREQ_VarID,NSAMP]
@@ -179,7 +188,9 @@ steps:
             minimum_sv_size: merge_min_sv_size
             sv_db: merge_sv_pop_freq_db
             vep_cache_dir: vep_cache_dir
-            vep_assembly: vep_assembly
+            vep_ensembl_assembly: vep_ensembl_assembly
+            vep_ensembl_version: vep_ensembl_version
+            vep_ensembl_species: vep_ensembl_species
             reference: reference
         out:
             [merged_annotated_vcf, vep_summary]

--- a/definitions/subworkflows/single_sample_sv_callers.cwl
+++ b/definitions/subworkflows/single_sample_sv_callers.cwl
@@ -86,8 +86,6 @@ inputs:
     vep_to_table_fields:
         type: string[]?
         default: [SYMBOL]
-    vep_assembly:
-        type: string
 outputs:
     cn_diagram:
         type: File?

--- a/definitions/subworkflows/single_sample_sv_callers.cwl
+++ b/definitions/subworkflows/single_sample_sv_callers.cwl
@@ -70,13 +70,13 @@ inputs:
         type: string
     vep_ensembl_assembly:
         type: string
-        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+        doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"
     vep_ensembl_version:
         type: string
-        doc: ensembl version - Must be present in the cache directory. Example: "95"
+        doc: "ensembl version - Must be present in the cache directory. Example: 95"
     vep_ensembl_species:
         type: string
-        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
+        doc: "ensembl species - Must be present in the cache directory. Examples: homo_sapiens or mus_musculus"
     variants_to_table_fields:
         type: string[]?
         default: [CHROM,POS,ID,REF,ALT,SVLEN,CHR2,END,POPFREQ_AF,POPFREQ_VarID,NSAMP]

--- a/definitions/tools/vep.cwl
+++ b/definitions/tools/vep.cwl
@@ -96,17 +96,30 @@ inputs:
                 prefix: "--plugin"
         inputBinding:
             position: 9
-    assembly:
-        type: string
-        inputBinding:
-            prefix: "--assembly"
-            position: 10
     everything:
         type: boolean?
         default: true
         inputBinding:
             prefix: "--everything"
+            position: 10
+    ensembl_assembly:
+        type: string
+        inputBinding:
+            prefix: "--assembly"
             position: 11
+        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+    ensembl_version:
+        type: string
+        inputBinding:
+            prefix: "--cache_version"
+            position: 12
+        doc: ensembl version - Must be present in the cache directory. Example: "95"
+    ensembl_species:
+        type: string
+        inputBinding:
+            prefix: "--species"
+            position: 13
+        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
 outputs:
     annotated_vcf:
         type: File

--- a/definitions/tools/vep.cwl
+++ b/definitions/tools/vep.cwl
@@ -107,19 +107,19 @@ inputs:
         inputBinding:
             prefix: "--assembly"
             position: 11
-        doc: genome assembly to use in vep. Examples: "GRCh38" or "GRCm38"
+        doc: "genome assembly to use in vep. Examples: 'GRCh38' or 'GRCm38'"
     ensembl_version:
         type: string
         inputBinding:
             prefix: "--cache_version"
             position: 12
-        doc: ensembl version - Must be present in the cache directory. Example: "95"
+        doc: "ensembl version - Must be present in the cache directory. Example: '95'"
     ensembl_species:
         type: string
         inputBinding:
             prefix: "--species"
             position: 13
-        doc: ensembl species - Must be present in the cache directory. Examples: "homo_sapiens" or "mus_musculus"
+        doc: "ensembl species - Must be present in the cache directory. Examples: 'homo_sapiens' or 'mus_musculus'"
 outputs:
     annotated_vcf:
         type: File


### PR DESCRIPTION
This is a big one, since it touches anything that uses VEP, which is most workflows. 

We previously assumed that we'd point our tool to a VEP cache, and that it would always be human, and always match the version referred to in the vep tool docker version.  This doesn't work for mouse, or other species, and limits our ability to support multiple projects that may want to anchor themselves to a particular VEP build.

The solution is to expose a bunch of parameters for reference assembly, ensembl version, and species, so that they must be explicitly specified.  While I don't love adding extra complexity to the (already kind of overwhelming) input yamls, asking users to specify the  ensembl version and such seems like a reasonable ask, IMO.