### PR TITLE
handling both unzipped and gzipped vcfs appropriately

### DIFF
--- a/definitions/tools/filter_vcf_mapq0.cwl
+++ b/definitions/tools/filter_vcf_mapq0.cwl
@@ -5,7 +5,7 @@ class: CommandLineTool
 label: "filter vcf for variants with high percentage of mapq0 reads"
 requirements:
     - class: DockerRequirement
-      dockerPull: mgibio/mapq0-filter:v0.2
+      dockerPull: mgibio/mapq0-filter:v0.3
     - class: ResourceRequirement
       ramMin: 8000
       tmpdirMin: 10000


### PR DESCRIPTION
Commit to the script is here.
https://github.com/genome/docker-mapq0-filter/commit/61d8a43004b8a8dad84977301a916f70d84ce230

 Has been tested on both human and mouse somatic exome cwls (mouse pr forthcoming)