### PR TITLE
Support for both 'File' and 'string' types of 'reference' input in  varscan_pre_and_post_processing.cwl

### DIFF
--- a/definitions/pipelines/exome_alignment.cwl
+++ b/definitions/pipelines/exome_alignment.cwl
@@ -9,7 +9,11 @@ requirements:
           - $import: ../types/labelled_file.yml
     - class: SubworkflowFeatureRequirement
 inputs:
-    reference: string
+    reference:
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     bams:
         type: File[]
     readgroups:

--- a/definitions/subworkflows/align.cwl
+++ b/definitions/subworkflows/align.cwl
@@ -11,7 +11,10 @@ inputs:
     bam:
         type: File
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, .amb, .ann, .bwt, .pac, .sa]
     readgroup:
         type: string
 outputs:

--- a/definitions/subworkflows/bam_to_bqsr.cwl
+++ b/definitions/subworkflows/bam_to_bqsr.cwl
@@ -16,7 +16,10 @@ inputs:
     bqsr_intervals:
         type: string[]?
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     dbsnp_vcf:
         type: File
         secondaryFiles: [.tbi]

--- a/definitions/subworkflows/fp_filter.cwl
+++ b/definitions/subworkflows/fp_filter.cwl
@@ -10,7 +10,8 @@ inputs:
         type: File
         secondaryFiles: [.bai,^.bai]
     reference:
-        type: string
+        type: File
+        secondaryFiles: [.fai, ^.dict]
     vcf:
         type: File
         secondaryFiles: [.tbi]

--- a/definitions/subworkflows/fp_filter.cwl
+++ b/definitions/subworkflows/fp_filter.cwl
@@ -6,12 +6,14 @@ label: "fp_filter workflow"
 requirements:
     - class: SubworkflowFeatureRequirement
 inputs:
+    reference:
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
     bam:
         type: File
         secondaryFiles: [.bai,^.bai]
-    reference:
-        type: File
-        secondaryFiles: [.fai, ^.dict]
     vcf:
         type: File
         secondaryFiles: [.tbi]

--- a/definitions/subworkflows/hs_metrics.cwl
+++ b/definitions/subworkflows/hs_metrics.cwl
@@ -23,7 +23,10 @@ inputs:
     per_target_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
     summary_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
 outputs:

--- a/definitions/subworkflows/qc_exome.cwl
+++ b/definitions/subworkflows/qc_exome.cwl
@@ -8,12 +8,16 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
     - class: SubworkflowFeatureRequirement
+    - class: StepInputExpressionRequirement
 inputs:
     bam:
         type: File
         secondaryFiles: [^.bai]
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
     bait_intervals:
         type: File
     target_intervals:

--- a/definitions/subworkflows/varscan.cwl
+++ b/definitions/subworkflows/varscan.cwl
@@ -5,7 +5,9 @@ class: Workflow
 label: "varscan somatic workflow"
 inputs:
     reference:
-        type: File
+        type:
+            - string
+            - File
         secondaryFiles: [.fai, ^.dict]
     tumor_bam:
         type: File

--- a/definitions/subworkflows/varscan.cwl
+++ b/definitions/subworkflows/varscan.cwl
@@ -5,7 +5,8 @@ class: Workflow
 label: "varscan somatic workflow"
 inputs:
     reference:
-        type: string
+        type: File
+        secondaryFiles: [.fai, ^.dict]
     tumor_bam:
         type: File
         secondaryFiles: [^.bai]

--- a/definitions/subworkflows/varscan_pre_and_post_processing.cwl
+++ b/definitions/subworkflows/varscan_pre_and_post_processing.cwl
@@ -9,13 +9,14 @@ requirements:
     - class: StepInputExpressionRequirement
 inputs:
     reference:
-        type: string
+        type: File
+        secondaryFiles: [.fai, ^.dict]
     tumor_bam:
         type: File
-        secondaryFiles: [^.bai]
+        secondaryFiles: [.bai, ^.bai]
     normal_bam:
         type: File
-        secondaryFiles: [^.bai]
+        secondaryFiles: [.bai, ^.bai]
     interval_list:
         type: File
     strand_filter:

--- a/definitions/subworkflows/varscan_pre_and_post_processing.cwl
+++ b/definitions/subworkflows/varscan_pre_and_post_processing.cwl
@@ -15,10 +15,10 @@ inputs:
         secondaryFiles: [.fai, ^.dict]
     tumor_bam:
         type: File
-        secondaryFiles: [.bai, ^.bai]
+        secondaryFiles: [^.bai]
     normal_bam:
         type: File
-        secondaryFiles: [.bai, ^.bai]
+        secondaryFiles: [^.bai]
     interval_list:
         type: File
     strand_filter:

--- a/definitions/subworkflows/varscan_pre_and_post_processing.cwl
+++ b/definitions/subworkflows/varscan_pre_and_post_processing.cwl
@@ -9,7 +9,9 @@ requirements:
     - class: StepInputExpressionRequirement
 inputs:
     reference:
-        type: File
+        type:
+            - string
+            - File
         secondaryFiles: [.fai, ^.dict]
     tumor_bam:
         type: File

--- a/definitions/tools/align_and_tag.cwl
+++ b/definitions/tools/align_and_tag.cwl
@@ -25,7 +25,10 @@ inputs:
         inputBinding:
             position: 2
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, .amb, .ann, .bwt, .pac, .sa]
         inputBinding:
             position: 3
 outputs:

--- a/definitions/tools/apply_bqsr.cwl
+++ b/definitions/tools/apply_bqsr.cwl
@@ -19,7 +19,10 @@ requirements:
       dockerPull: "mgibio/gatk-cwl:3.6.0"
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "-R"
             position: 1

--- a/definitions/tools/bqsr.cwl
+++ b/definitions/tools/bqsr.cwl
@@ -18,7 +18,10 @@ requirements:
       dockerPull: "mgibio/gatk-cwl:3.6.0"
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "-R"
             position: 2

--- a/definitions/tools/collect_alignment_summary_metrics.cwl
+++ b/definitions/tools/collect_alignment_summary_metrics.cwl
@@ -18,7 +18,10 @@ inputs:
             prefix: "INPUT="
         secondaryFiles: [^.bai]
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "REFERENCE_SEQUENCE="
     metric_accumulation_level:

--- a/definitions/tools/collect_hs_metrics.cwl
+++ b/definitions/tools/collect_hs_metrics.cwl
@@ -19,7 +19,10 @@ inputs:
             prefix: "I="
         secondaryFiles: [^.bai]
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "R="
     metric_accumulation_level:

--- a/definitions/tools/collect_insert_size_metrics.cwl
+++ b/definitions/tools/collect_insert_size_metrics.cwl
@@ -19,7 +19,10 @@ inputs:
             prefix: "I="
         secondaryFiles: [^.bai]
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "REFERENCE_SEQUENCE="
     metric_accumulation_level:

--- a/definitions/tools/fp_filter.cwl
+++ b/definitions/tools/fp_filter.cwl
@@ -16,7 +16,8 @@ arguments:
     "--output", { valueFrom: $(runtime.outdir)/$(inputs.output_vcf_basename).vcf }]
 inputs:
     reference:
-        type: string
+        type: File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "--reference"
             position: 1

--- a/definitions/tools/fp_filter.cwl
+++ b/definitions/tools/fp_filter.cwl
@@ -16,7 +16,9 @@ arguments:
     "--output", { valueFrom: $(runtime.outdir)/$(inputs.output_vcf_basename).vcf }]
 inputs:
     reference:
-        type: File
+        type:
+            - string
+            - File
         secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "--reference"

--- a/definitions/tools/mark_duplicates_and_sort.cwl
+++ b/definitions/tools/mark_duplicates_and_sort.cwl
@@ -21,7 +21,7 @@ requirements:
             declare MD_BARCODE_TAG
             if [ ! -z "$6" ]; then
               MD_BARCODE_TAG="BARCODE_TAG=$6"
-            /usr/bin/java -Xmx16g -jar /opt/picard/picard.jar MarkDuplicates I=$1 O=/dev/stdout ASSUME_SORT_ORDER=$5 METRICS_FILE=$4 QUIET=true COMPRESSION_LEVEL=0 VALIDATION_STRINGENCY=LENIENT "$MD_BARCODE_TAG" | /usr/bin/sambamba sort -t $2 -m 18G -o $3 /dev/stdin
+              /usr/bin/java -Xmx16g -jar /opt/picard/picard.jar MarkDuplicates I=$1 O=/dev/stdout ASSUME_SORT_ORDER=$5 METRICS_FILE=$4 QUIET=true COMPRESSION_LEVEL=0 VALIDATION_STRINGENCY=LENIENT "$MD_BARCODE_TAG" | /usr/bin/sambamba sort -t $2 -m 18G -o $3 /dev/stdin
             else
               /usr/bin/java -Xmx16g -jar /opt/picard/picard.jar MarkDuplicates I=$1 O=/dev/stdout ASSUME_SORT_ORDER=$5 METRICS_FILE=$4 QUIET=true COMPRESSION_LEVEL=0 VALIDATION_STRINGENCY=LENIENT | /usr/bin/sambamba sort -t $2 -m 18G -o $3 /dev/stdin
             fi

--- a/definitions/tools/normalize_variants.cwl
+++ b/definitions/tools/normalize_variants.cwl
@@ -13,7 +13,8 @@ arguments:
     ["-o", { valueFrom: $(runtime.outdir)/normalized.vcf.gz }]
 inputs:
     reference:
-        type: string
+        type: File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "-R"
             position: 1

--- a/definitions/tools/normalize_variants.cwl
+++ b/definitions/tools/normalize_variants.cwl
@@ -13,7 +13,9 @@ arguments:
     ["-o", { valueFrom: $(runtime.outdir)/normalized.vcf.gz }]
 inputs:
     reference:
-        type: File
+        type:
+            - string
+            - File
         secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "-R"

--- a/definitions/tools/select_variants.cwl
+++ b/definitions/tools/select_variants.cwl
@@ -14,7 +14,8 @@ arguments:
     ["-o", { valueFrom: $(runtime.outdir)/$(inputs.output_vcf_basename).vcf.gz }]
 inputs:
     reference:
-        type: string
+        type: File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "-R"
             position: 1

--- a/definitions/tools/select_variants.cwl
+++ b/definitions/tools/select_variants.cwl
@@ -14,7 +14,9 @@ arguments:
     ["-o", { valueFrom: $(runtime.outdir)/$(inputs.output_vcf_basename).vcf.gz }]
 inputs:
     reference:
-        type: File
+        type:
+            - string
+            - File
         secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "-R"

--- a/definitions/tools/set_filter_status.cwl
+++ b/definitions/tools/set_filter_status.cwl
@@ -28,7 +28,8 @@ inputs:
             position: 3
         secondaryFiles: [.tbi]
     reference:
-        type: string
+        type: File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "-R"
             position: 1

--- a/definitions/tools/set_filter_status.cwl
+++ b/definitions/tools/set_filter_status.cwl
@@ -15,6 +15,14 @@ arguments:
     "--filterNotInMask",
     "-o", { valueFrom: $(runtime.outdir)/output.vcf.gz }]
 inputs:
+    reference:
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
+        inputBinding:
+            prefix: "-R"
+            position: 1
     vcf:
         type: File
         inputBinding:
@@ -27,12 +35,6 @@ inputs:
             prefix: "--mask"
             position: 3
         secondaryFiles: [.tbi]
-    reference:
-        type: File
-        secondaryFiles: [.fai, ^.dict]
-        inputBinding:
-            prefix: "-R"
-            position: 1
 outputs:
     merged_vcf:
         type: File

--- a/definitions/tools/varscan_somatic.cwl
+++ b/definitions/tools/varscan_somatic.cwl
@@ -10,6 +10,13 @@ requirements:
     - class: DockerRequirement
       dockerPull: "mgibio/cle:v1.3.1"
 inputs:
+    reference:
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
+        inputBinding:
+            position: 3
     tumor_bam:
         type: File
         inputBinding:
@@ -20,11 +27,6 @@ inputs:
         inputBinding:
             position: 2
         secondaryFiles: [^.bai]
-    reference:
-        type: File
-        secondaryFiles: [.fai, ^.dict]
-        inputBinding:
-            position: 3
     strand_filter:
         type: int?
         default: 0

--- a/definitions/tools/varscan_somatic.cwl
+++ b/definitions/tools/varscan_somatic.cwl
@@ -21,7 +21,8 @@ inputs:
             position: 2
         secondaryFiles: [^.bai]
     reference:
-        type: string
+        type: File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             position: 3
     strand_filter:

--- a/serge/readme_run_serge.txt
+++ b/serge/readme_run_serge.txt
@@ -1,0 +1,1 @@
+cwltool ../definitions/subworkflows/varscan_pre_and_post_processing.cwl varscan_pre_and_post_processing.val_serge01.yaml

--- a/serge/varscan_pre_and_post_processing.val_serge01.yaml
+++ b/serge/varscan_pre_and_post_processing.val_serge01.yaml
@@ -1,0 +1,25 @@
+reference:
+  class: File
+  path: /home/bio/serge/analysis-workflows_serge2016/example_data/exome_workflow/chr17_test.fa
+  secondaryFiles:
+  - class: File
+    location: /home/bio/serge/analysis-workflows_serge2016/example_data/exome_workflow/chr17_test.fa.fai
+tumor_bam:
+  class: File
+  path: /home/bio/tatahin/test_files/out_cc/2895499_tumor.realigned.bqsr.bam
+  secondaryFiles:
+  - class: File
+    location: /home/bio/tatahin/test_files/out_cc/2895499_tumor.realigned.bqsr.bai
+normal_bam:
+  class: File
+  path: /home/bio/tatahin/test_files/out_cc/2895499_normal.realigned.bqsr.bam
+  secondaryFiles:
+  - class: File
+    location: /home/bio/tatahin/test_files/out_cc/2895499_normal.realigned.bqsr.bai
+interval_list:
+  class: File
+  path: /home/bio/serge/analysis-workflows_serge2016/example_data/exome_workflow/chr17_test_genes.interval_list
+min_coverage: 8
+min_var_freq: 0.02
+p_value: 0.99
+strand_filter: 0


### PR DESCRIPTION
For better compatibility of the repo with other users in the internet I suggest to add both types (`string` and `File` with `secondaryFiles`) for `reference` input.
For now (in this PR) just to show the possibility one subworkflow was modified: `varscan_pre_and_post_processing.cwl`.

The correctness of this CWL code is discussed: https://github.com/common-workflow-language/common-workflow-language/issues/858.

The purpose of both types for this input is described: https://github.com/genome/analysis-workflows/issues/674.