### PR TITLE
Adding Mouse somatic exome workflow

### DIFF
--- a/definitions/pipelines/detect_variants_mouse.cwl
+++ b/definitions/pipelines/detect_variants_mouse.cwl
@@ -16,15 +16,6 @@ inputs:
         secondaryFiles: [.bai,^.bai]
     interval_list:
         type: File
-    dbsnp_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
-    cosmic_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
-    panel_of_normals_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
     strelka_exome_mode:
         type: boolean
     strelka_cpu_reserved:
@@ -75,7 +66,7 @@ inputs:
         default: [Downstream, Wildtype]
     filter_gnomADe_maximum_population_allele_frequency:
         type: float?
-        default: 0.001
+        default: 0.000
     filter_mapq0_threshold:
         type: float?
         default: 0.15
@@ -96,13 +87,7 @@ inputs:
         default: [GT,AD]
     vep_to_table_fields:
         type: string[]?
-        default: [HGVSc,HGVSp]
-    custom_gnomad_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
-    custom_clinvar_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
+        default: []
 outputs:
     mutect_unfiltered_vcf:
         type: File
@@ -170,13 +155,10 @@ steps:
             tumor_bam: tumor_bam
             normal_bam: normal_bam
             interval_list: interval_list
-            dbsnp_vcf: dbsnp_vcf
-            cosmic_vcf: cosmic_vcf
             max_alt_allele_in_normal_fraction: mutect_max_alt_allele_in_normal_fraction
             max_alt_alleles_in_normal_count: mutect_max_alt_alleles_in_normal_count
             scatter_count: mutect_scatter_count
             artifact_detection_mode: mutect_artifact_detection_mode
-            panel_of_normals_vcf: panel_of_normals_vcf
         out:
             [unfiltered_vcf, filtered_vcf]
     strelka:
@@ -244,9 +226,7 @@ steps:
             synonyms_file: synonyms_file
             coding_only: annotate_coding_only
             reference: reference
-            custom_gnomad_vcf: custom_gnomad_vcf
             pick: vep_pick
-            custom_clivnar_vcf: custom_clinvar_vcf
             plugins: vep_plugins
         out:
             [annotated_vcf, vep_summary]

--- a/definitions/pipelines/detect_variants_mouse.cwl
+++ b/definitions/pipelines/detect_variants_mouse.cwl
@@ -304,25 +304,10 @@ steps:
             vcf: add_normal_bam_readcount_to_vcf/annotated_bam_readcount_vcf
         out:
             [indexed_vcf]
-    filter_vcf:
-        run: ../subworkflows/filter_vcf.cwl
-        in: 
-            vcf: index/indexed_vcf
-            filter_gnomADe_maximum_population_allele_frequency: filter_gnomADe_maximum_population_allele_frequency
-            filter_mapq0_threshold: filter_mapq0_threshold
-            filter_somatic_llr_threshold: filter_somatic_llr_threshold
-            filter_minimum_depth: filter_minimum_depth
-            sample_names:
-                default: 'NORMAL,TUMOR'
-            tumor_bam: tumor_bam
-            do_cle_vcf_filter: cle_vcf_filter
-            reference: reference
-        out: 
-            [filtered_vcf]
     annotated_filter_bgzip:
         run: ../tools/bgzip.cwl
         in:
-            file: filter_vcf/filtered_vcf
+            file: index/indexed_vcf
         out:
             [bgzipped_file]
     annotated_filter_index:

--- a/definitions/pipelines/detect_variants_mouse.cwl
+++ b/definitions/pipelines/detect_variants_mouse.cwl
@@ -1,0 +1,349 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+label: "Detect Variants workflow"
+requirements:
+    - class: SubworkflowFeatureRequirement
+inputs:
+    reference:
+        type: string
+    tumor_bam:
+        type: File
+        secondaryFiles: [.bai,^.bai]
+    normal_bam:
+        type: File
+        secondaryFiles: [.bai,^.bai]
+    interval_list:
+        type: File
+    dbsnp_vcf:
+        type: File?
+        secondaryFiles: [.tbi]
+    cosmic_vcf:
+        type: File?
+        secondaryFiles: [.tbi]
+    panel_of_normals_vcf:
+        type: File?
+        secondaryFiles: [.tbi]
+    strelka_exome_mode:
+        type: boolean
+    strelka_cpu_reserved:
+        type: int?
+        default: 8
+    readcount_minimum_base_quality:
+        type: int?
+    readcount_minimum_mapping_quality:
+        type: int?
+    mutect_scatter_count:
+        type: int?
+    mutect_artifact_detection_mode:
+        type: boolean?
+    mutect_max_alt_allele_in_normal_fraction:
+        type: float?
+    mutect_max_alt_alleles_in_normal_count:
+        type: int?
+    varscan_strand_filter:
+        type: int?
+        default: 0
+    varscan_min_coverage:
+        type: int?
+        default: 8
+    varscan_min_var_freq:
+        type: float?
+        default: 0.1
+    varscan_p_value:
+        type: float?
+        default: 0.99
+    varscan_max_normal_freq:
+        type: float?
+    pindel_insert_size:
+        type: int
+        default: 400
+    vep_cache_dir:
+        type: string
+    synonyms_file:
+        type: File?
+    annotate_coding_only:
+        type: boolean?
+    vep_pick:
+        type:
+            - "null"
+            - type: enum
+              symbols: ["pick", "flag_pick", "pick_allele", "per_gene", "pick_allele_gene", "flag_pick_allele", "flag_pick_allele_gene"]
+    vep_plugins:
+        type: string[]?
+        default: [Downstream, Wildtype]
+    filter_gnomADe_maximum_population_allele_frequency:
+        type: float?
+        default: 0.001
+    filter_mapq0_threshold:
+        type: float?
+        default: 0.15
+    filter_minimum_depth:
+        type: int?
+        default: 1
+    cle_vcf_filter:
+        type: boolean?
+        default: false
+    filter_somatic_llr_threshold:
+        type: float?
+        default: 5
+    variants_to_table_fields:
+        type: string[]?
+        default: [CHROM,POS,ID,REF,ALT,set,AC,AF]
+    variants_to_table_genotype_fields:
+        type: string[]?
+        default: [GT,AD]
+    vep_to_table_fields:
+        type: string[]?
+        default: [HGVSc,HGVSp]
+    custom_gnomad_vcf:
+        type: File?
+        secondaryFiles: [.tbi]
+    custom_clinvar_vcf:
+        type: File?
+        secondaryFiles: [.tbi]
+outputs:
+    mutect_unfiltered_vcf:
+        type: File
+        outputSource: mutect/unfiltered_vcf
+        secondaryFiles: [.tbi]
+    mutect_filtered_vcf:
+        type: File
+        outputSource: mutect/filtered_vcf
+        secondaryFiles: [.tbi]
+    strelka_unfiltered_vcf:
+        type: File
+        outputSource: strelka/unfiltered_vcf
+        secondaryFiles: [.tbi]
+    strelka_filtered_vcf:
+        type: File
+        outputSource: strelka/filtered_vcf
+        secondaryFiles: [.tbi]
+    varscan_unfiltered_vcf:
+        type: File
+        outputSource: varscan/unfiltered_vcf
+        secondaryFiles: [.tbi]
+    varscan_filtered_vcf:
+        type: File
+        outputSource: varscan/filtered_vcf
+        secondaryFiles: [.tbi]
+    pindel_unfiltered_vcf:
+        type: File
+        outputSource: pindel/unfiltered_vcf
+        secondaryFiles: [.tbi]
+    pindel_filtered_vcf:
+        type: File
+        outputSource: pindel/filtered_vcf
+        secondaryFiles: [.tbi]
+    final_vcf:
+        type: File
+        outputSource: index/indexed_vcf
+        secondaryFiles: [.tbi]
+    final_filtered_vcf:
+        type: File
+        outputSource: annotated_filter_index/indexed_vcf
+        secondaryFiles: [.tbi]
+    final_tsv:
+        type: File
+        outputSource: add_vep_fields_to_table/annotated_variants_tsv
+    vep_summary:
+        type: File
+        outputSource: annotate_variants/vep_summary
+    tumor_snv_bam_readcount_tsv:
+        type: File
+        outputSource: tumor_bam_readcount/snv_bam_readcount_tsv
+    tumor_indel_bam_readcount_tsv:
+        type: File
+        outputSource: tumor_bam_readcount/indel_bam_readcount_tsv
+    normal_snv_bam_readcount_tsv:
+        type: File
+        outputSource: normal_bam_readcount/snv_bam_readcount_tsv
+    normal_indel_bam_readcount_tsv:
+        type: File
+        outputSource: normal_bam_readcount/indel_bam_readcount_tsv
+steps:
+    mutect:
+        run: ../subworkflows/mutect.cwl
+        in:
+            reference: reference
+            tumor_bam: tumor_bam
+            normal_bam: normal_bam
+            interval_list: interval_list
+            dbsnp_vcf: dbsnp_vcf
+            cosmic_vcf: cosmic_vcf
+            max_alt_allele_in_normal_fraction: mutect_max_alt_allele_in_normal_fraction
+            max_alt_alleles_in_normal_count: mutect_max_alt_alleles_in_normal_count
+            scatter_count: mutect_scatter_count
+            artifact_detection_mode: mutect_artifact_detection_mode
+            panel_of_normals_vcf: panel_of_normals_vcf
+        out:
+            [unfiltered_vcf, filtered_vcf]
+    strelka:
+        run: ../subworkflows/strelka_and_post_processing.cwl
+        in:
+            reference: reference
+            tumor_bam: tumor_bam
+            normal_bam: normal_bam
+            interval_list: interval_list
+            exome_mode: strelka_exome_mode
+            cpu_reserved: strelka_cpu_reserved
+        out:
+            [unfiltered_vcf, filtered_vcf]
+    varscan:
+        run: ../subworkflows/varscan_pre_and_post_processing.cwl
+        in:
+            reference: reference
+            tumor_bam: tumor_bam
+            normal_bam: normal_bam
+            interval_list: interval_list
+            strand_filter: varscan_strand_filter
+            min_coverage: varscan_min_coverage
+            min_var_freq: varscan_min_var_freq
+            p_value: varscan_p_value
+            max_normal_freq: varscan_max_normal_freq
+        out:
+            [unfiltered_vcf, filtered_vcf]
+    pindel:
+        run: ../subworkflows/pindel.cwl
+        in:
+            reference: reference
+            tumor_bam: tumor_bam
+            normal_bam: normal_bam
+            interval_list: interval_list
+            insert_size: pindel_insert_size
+        out:
+            [unfiltered_vcf, filtered_vcf]
+    combine:
+        run: ../tools/combine_variants.cwl
+        in:
+            reference: reference
+            mutect_vcf: mutect/filtered_vcf
+            strelka_vcf: strelka/filtered_vcf
+            varscan_vcf: varscan/filtered_vcf
+            pindel_vcf: pindel/filtered_vcf
+        out:
+            [combined_vcf]
+    decompose:
+        run: ../tools/vt_decompose.cwl
+        in:
+            vcf: combine/combined_vcf
+        out:
+            [decomposed_vcf]
+    decompose_index:
+        run: ../tools/index_vcf.cwl
+        in:
+            vcf: decompose/decomposed_vcf
+        out:
+            [indexed_vcf]
+    annotate_variants:
+        run: ../tools/vep.cwl
+        in:
+            vcf: decompose_index/indexed_vcf
+            cache_dir: vep_cache_dir
+            synonyms_file: synonyms_file
+            coding_only: annotate_coding_only
+            reference: reference
+            custom_gnomad_vcf: custom_gnomad_vcf
+            pick: vep_pick
+            custom_clivnar_vcf: custom_clinvar_vcf
+            plugins: vep_plugins
+        out:
+            [annotated_vcf, vep_summary]
+    tumor_bam_readcount:
+        run: ../tools/bam_readcount.cwl
+        in:
+            vcf: annotate_variants/annotated_vcf
+            sample:
+                default: 'TUMOR'
+            reference_fasta: reference
+            bam: tumor_bam
+            min_base_quality: readcount_minimum_base_quality
+            min_mapping_quality: readcount_minimum_mapping_quality
+        out:
+            [snv_bam_readcount_tsv, indel_bam_readcount_tsv]
+    normal_bam_readcount:
+        run: ../tools/bam_readcount.cwl
+        in:
+            vcf: annotate_variants/annotated_vcf
+            sample:
+                default: 'NORMAL'
+            reference_fasta: reference
+            bam: normal_bam
+            min_base_quality: readcount_minimum_base_quality
+            min_mapping_quality: readcount_minimum_mapping_quality
+        out:
+            [snv_bam_readcount_tsv, indel_bam_readcount_tsv]
+    add_tumor_bam_readcount_to_vcf:
+        run: ../subworkflows/vcf_readcount_annotator.cwl
+        in:
+            vcf: annotate_variants/annotated_vcf
+            snv_bam_readcount_tsv: tumor_bam_readcount/snv_bam_readcount_tsv
+            indel_bam_readcount_tsv: tumor_bam_readcount/indel_bam_readcount_tsv
+            data_type:
+                default: 'DNA'
+            sample_name:
+                default: 'TUMOR'
+        out:
+            [annotated_bam_readcount_vcf]
+    add_normal_bam_readcount_to_vcf:
+        run: ../subworkflows/vcf_readcount_annotator.cwl
+        in:
+            vcf: add_tumor_bam_readcount_to_vcf/annotated_bam_readcount_vcf
+            snv_bam_readcount_tsv: normal_bam_readcount/snv_bam_readcount_tsv
+            indel_bam_readcount_tsv: normal_bam_readcount/indel_bam_readcount_tsv
+            data_type:
+                default: 'DNA'
+            sample_name:
+                default: 'NORMAL'
+        out:
+            [annotated_bam_readcount_vcf]
+    index:
+        run: ../tools/index_vcf.cwl
+        in:
+            vcf: add_normal_bam_readcount_to_vcf/annotated_bam_readcount_vcf
+        out:
+            [indexed_vcf]
+    filter_vcf:
+        run: ../subworkflows/filter_vcf.cwl
+        in: 
+            vcf: index/indexed_vcf
+            filter_gnomADe_maximum_population_allele_frequency: filter_gnomADe_maximum_population_allele_frequency
+            filter_mapq0_threshold: filter_mapq0_threshold
+            filter_somatic_llr_threshold: filter_somatic_llr_threshold
+            filter_minimum_depth: filter_minimum_depth
+            sample_names:
+                default: 'NORMAL,TUMOR'
+            tumor_bam: tumor_bam
+            do_cle_vcf_filter: cle_vcf_filter
+            reference: reference
+        out: 
+            [filtered_vcf]
+    annotated_filter_bgzip:
+        run: ../tools/bgzip.cwl
+        in:
+            file: filter_vcf/filtered_vcf
+        out:
+            [bgzipped_file]
+    annotated_filter_index:
+        run: ../tools/index_vcf.cwl
+        in:
+            vcf: annotated_filter_bgzip/bgzipped_file
+        out:
+            [indexed_vcf]
+    variants_to_table:
+        run: ../tools/variants_to_table.cwl
+        in:
+            reference: reference
+            vcf: annotated_filter_index/indexed_vcf
+            fields: variants_to_table_fields
+            genotype_fields: variants_to_table_genotype_fields
+        out:
+            [variants_tsv]
+    add_vep_fields_to_table:
+        run: ../tools/add_vep_fields_to_table.cwl
+        in:
+            vcf: annotated_filter_index/indexed_vcf
+            vep_fields: vep_to_table_fields
+            tsv: variants_to_table/variants_tsv
+        out: [annotated_variants_tsv]

--- a/definitions/pipelines/detect_variants_mouse.cwl
+++ b/definitions/pipelines/detect_variants_mouse.cwl
@@ -73,9 +73,6 @@ inputs:
     vep_plugins:
         type: string[]?
         default: [Downstream, Wildtype]
-    filter_gnomADe_maximum_population_allele_frequency:
-        type: float?
-        default: 0.000
     filter_mapq0_threshold:
         type: float?
         default: 0.15

--- a/definitions/pipelines/exome_alignment_mouse.cwl
+++ b/definitions/pipelines/exome_alignment_mouse.cwl
@@ -77,7 +77,7 @@ steps:
             bams: bams
             readgroups: readgroups
             final_name: final_name
-        out: [indexed_bam,mark_duplicates_metrics_file]
+        out: [final_bam,mark_duplicates_metrics_file]
     qc:
         run: ../subworkflows/qc_exome_no_verify_bam.cwl
         in:

--- a/definitions/pipelines/exome_alignment_mouse.cwl
+++ b/definitions/pipelines/exome_alignment_mouse.cwl
@@ -1,0 +1,95 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+label: "exome alignment with qc, no bqsr, no verify_bam_id"
+requirements:
+    - class: SchemaDefRequirement
+      types:
+          - $import: ../types/labelled_file.yml
+    - class: SubworkflowFeatureRequirement
+inputs:
+    reference: string
+    bams:
+        type: File[]
+    readgroups:
+        type: string[]
+    bait_intervals:
+        type: File
+    final_name:
+        type: string?
+    target_intervals:
+        type: File
+    per_base_intervals:
+        type: ../types/labelled_file.yml#labelled_file[]
+    per_target_intervals:
+        type: ../types/labelled_file.yml#labelled_file[]
+    summary_intervals:
+        type: ../types/labelled_file.yml#labelled_file[]
+    picard_metric_accumulation_level:
+        type: string
+    qc_minimum_mapping_quality:
+        type: int?
+    qc_minimum_base_quality:
+        type: int?
+outputs:
+    bam:
+        type: File
+        outputSource: alignment/final_bam
+    mark_duplicates_metrics:
+        type: File
+        outputSource: alignment/mark_duplicates_metrics_file
+    insert_size_metrics:
+        type: File
+        outputSource: qc/insert_size_metrics
+    insert_size_histogram:
+        type: File
+        outputSource: qc/insert_size_histogram
+    alignment_summary_metrics:
+        type: File
+        outputSource: qc/alignment_summary_metrics
+    hs_metrics:
+        type: File
+        outputSource: qc/hs_metrics
+    per_target_coverage_metrics:
+        type: File[]
+        outputSource: qc/per_target_coverage_metrics
+    per_target_hs_metrics:
+        type: File[]
+        outputSource: qc/per_target_hs_metrics
+    per_base_coverage_metrics:
+        type: File[]
+        outputSource: qc/per_base_coverage_metrics
+    per_base_hs_metrics:
+        type: File[]
+        outputSource: qc/per_base_hs_metrics
+    summary_hs_metrics:
+        type: File[]
+        outputSource: qc/summary_hs_metrics
+    flagstats:
+        type: File
+        outputSource: qc/flagstats
+steps:
+    alignment:
+        run: ../subworkflows/align_sort_markdup.cwl
+        in:
+            reference: reference
+            bams: bams
+            readgroups: readgroups
+            final_name: final_name
+        out: [indexed_bam,mark_duplicates_metrics_file]
+    qc:
+        run: ../subworkflows/qc_exome_no_verify_bam.cwl
+        in:
+            bam: alignment/final_bam
+            reference: reference
+            bait_intervals: bait_intervals
+            target_intervals: target_intervals
+            per_base_intervals: per_base_intervals
+            per_target_intervals: per_target_intervals
+            summary_intervals: summary_intervals
+            picard_metric_accumulation_level: picard_metric_accumulation_level
+            minimum_mapping_quality: qc_minimum_mapping_quality
+            minimum_base_quality: qc_minimum_base_quality
+        out: [insert_size_metrics, insert_size_histogram, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, summary_hs_metrics, flagstats]
+

--- a/definitions/pipelines/somatic_exome_mouse.cwl
+++ b/definitions/pipelines/somatic_exome_mouse.cwl
@@ -35,9 +35,6 @@ inputs:
         type: ../types/labelled_file.yml#labelled_file[]
     summary_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
-    omni_vcf:
-        type: File
-        secondaryFiles: [.tbi]
     picard_metric_accumulation_level:
         type: string
     qc_minimum_mapping_quality:
@@ -48,12 +45,6 @@ inputs:
         default: 0
     interval_list:
         type: File
-    cosmic_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
-    panel_of_normals_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
     strelka_cpu_reserved:
         type: int?
         default: 8
@@ -295,9 +286,6 @@ steps:
             tumor_bam: tumor_alignment_and_qc/bam
             normal_bam: normal_alignment_and_qc/bam
             interval_list: interval_list
-            dbsnp_vcf: dbsnp_vcf
-            cosmic_vcf: cosmic_vcf
-            panel_of_normals_vcf: panel_of_normals_vcf
             strelka_exome_mode:
                 default: true
             strelka_cpu_reserved: strelka_cpu_reserved
@@ -319,8 +307,6 @@ steps:
             variants_to_table_fields: variants_to_table_fields
             variants_to_table_genotype_fields: variants_to_table_genotype_fields
             vep_to_table_fields: vep_to_table_fields
-            custom_gnomad_vcf: custom_gnomad_vcf
-            custom_clinvar_vcf: custom_clinvar_vcf
         out:
             [mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv]
     tumor_bam_to_cram:

--- a/definitions/pipelines/somatic_exome_mouse.cwl
+++ b/definitions/pipelines/somatic_exome_mouse.cwl
@@ -1,0 +1,471 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+label: "exome alignment and somatic variant detection"
+requirements:
+    - class: SchemaDefRequirement
+      types:
+          - $import: ../types/labelled_file.yml
+    - class: SubworkflowFeatureRequirement
+    - class: StepInputExpressionRequirement
+inputs:
+    reference: string
+    tumor_bams:
+        type: File[]
+    tumor_readgroups:
+        type: string[]
+    tumor_name:
+        type: string?
+        default: 'tumor'
+    normal_bams:
+        type: File[]
+    normal_readgroups:
+        type: string[]
+    normal_name:
+        type: string?
+        default: 'normal'
+    mills:
+        type: File
+        secondaryFiles: [.tbi]
+    known_indels:
+        type: File
+        secondaryFiles: [.tbi]
+    dbsnp_vcf:
+        type: File
+        secondaryFiles: [.tbi]
+    bqsr_intervals:
+        type: string[]
+    bait_intervals:
+        type: File
+    target_intervals:
+        type: File
+    per_base_intervals:
+        type: ../types/labelled_file.yml#labelled_file[]
+    per_target_intervals:
+        type: ../types/labelled_file.yml#labelled_file[]
+    summary_intervals:
+        type: ../types/labelled_file.yml#labelled_file[]
+    omni_vcf:
+        type: File
+        secondaryFiles: [.tbi]
+    picard_metric_accumulation_level:
+        type: string
+    qc_minimum_mapping_quality:
+        type: int?
+        default: 0
+    qc_minimum_base_quality:
+        type: int?
+        default: 0
+    interval_list:
+        type: File
+    cosmic_vcf:
+        type: File?
+        secondaryFiles: [.tbi]
+    panel_of_normals_vcf:
+        type: File?
+        secondaryFiles: [.tbi]
+    strelka_cpu_reserved:
+        type: int?
+        default: 8
+    mutect_scatter_count:
+        type: int
+    mutect_artifact_detection_mode:
+        type: boolean
+        default: false
+    mutect_max_alt_allele_in_normal_fraction:
+        type: float?
+    mutect_max_alt_alleles_in_normal_count:
+        type: int?
+    varscan_strand_filter:
+        type: int?
+        default: 0
+    varscan_min_coverage:
+        type: int?
+        default: 8
+    varscan_min_var_freq:
+        type: float?
+        default: 0.05
+    varscan_p_value:
+        type: float?
+        default: 0.99
+    varscan_max_normal_freq:
+        type: float?
+    pindel_insert_size:
+        type: int
+        default: 400
+    vep_cache_dir:
+        type: string
+    synonyms_file:
+        type: File?
+    annotate_coding_only:
+        type: boolean?
+    vep_pick:
+        type:
+            - "null"
+            - type: enum
+              symbols: ["pick", "flag_pick", "pick_allele", "per_gene", "pick_allele_gene", "flag_pick_allele", "flag_pick_allele_gene"]
+    cle_vcf_filter:
+        type: boolean
+        default: false
+    variants_to_table_fields:
+        type: string[]
+        default: [CHROM,POS,ID,REF,ALT,set,AC,AF]
+    variants_to_table_genotype_fields:
+        type: string[]
+        default: [GT,AD]
+    vep_to_table_fields:
+        type: string[]
+        default: [HGVSc,HGVSp]
+    custom_gnomad_vcf:
+        type: File?
+        secondaryFiles: [.tbi]
+    custom_clinvar_vcf:
+        type: File?
+        secondaryFiles: [.tbi]
+    manta_call_regions:
+        type: File?
+        secondaryFiles: [.tbi]
+    manta_non_wgs:
+        type: boolean?
+        default: true
+    manta_output_contigs:
+        type: boolean?
+    somalier_vcf:
+        type: File
+outputs:
+    tumor_cram:
+        type: File
+        outputSource: tumor_index_cram/indexed_cram
+    tumor_mark_duplicates_metrics:
+        type: File
+        outputSource: tumor_alignment_and_qc/mark_duplicates_metrics
+    tumor_insert_size_metrics:
+        type: File
+        outputSource: tumor_alignment_and_qc/insert_size_metrics
+    tumor_alignment_summary_metrics:
+        type: File
+        outputSource: tumor_alignment_and_qc/alignment_summary_metrics
+    tumor_hs_metrics:
+        type: File
+        outputSource: tumor_alignment_and_qc/hs_metrics
+    tumor_per_target_coverage_metrics:
+        type: File[]
+        outputSource: tumor_alignment_and_qc/per_target_coverage_metrics
+    tumor_per_target_hs_metrics:
+        type: File[]
+        outputSource: tumor_alignment_and_qc/per_target_hs_metrics
+    tumor_per_base_coverage_metrics:
+        type: File[]
+        outputSource: tumor_alignment_and_qc/per_base_coverage_metrics
+    tumor_per_base_hs_metrics:
+        type: File[]
+        outputSource: tumor_alignment_and_qc/per_base_hs_metrics
+    tumor_summary_hs_metrics:
+        type: File[]
+        outputSource: tumor_alignment_and_qc/summary_hs_metrics
+    tumor_flagstats:
+        type: File
+        outputSource: tumor_alignment_and_qc/flagstats
+    tumor_verify_bam_id_metrics:
+        type: File
+        outputSource: tumor_alignment_and_qc/verify_bam_id_metrics
+    tumor_verify_bam_id_depth:
+        type: File
+        outputSource: tumor_alignment_and_qc/verify_bam_id_depth
+    normal_cram:
+        type: File
+        outputSource: normal_index_cram/indexed_cram
+    normal_mark_duplicates_metrics:
+        type: File
+        outputSource: normal_alignment_and_qc/mark_duplicates_metrics
+    normal_insert_size_metrics:
+        type: File
+        outputSource: normal_alignment_and_qc/insert_size_metrics
+    normal_alignment_summary_metrics:
+        type: File
+        outputSource: normal_alignment_and_qc/alignment_summary_metrics
+    normal_hs_metrics:
+        type: File
+        outputSource: normal_alignment_and_qc/hs_metrics
+    normal_per_target_coverage_metrics:
+        type: File[]
+        outputSource: normal_alignment_and_qc/per_target_coverage_metrics
+    normal_per_target_hs_metrics:
+        type: File[]
+        outputSource: normal_alignment_and_qc/per_target_hs_metrics
+    normal_per_base_coverage_metrics:
+        type: File[]
+        outputSource: normal_alignment_and_qc/per_base_coverage_metrics
+    normal_per_base_hs_metrics:
+        type: File[]
+        outputSource: normal_alignment_and_qc/per_base_hs_metrics
+    normal_summary_hs_metrics:
+        type: File[]
+        outputSource: normal_alignment_and_qc/summary_hs_metrics
+    normal_flagstats:
+        type: File
+        outputSource: normal_alignment_and_qc/flagstats
+    normal_verify_bam_id_metrics:
+        type: File
+        outputSource: normal_alignment_and_qc/verify_bam_id_metrics
+    normal_verify_bam_id_depth:
+        type: File
+        outputSource: normal_alignment_and_qc/verify_bam_id_depth
+    mutect_unfiltered_vcf:
+        type: File
+        outputSource: detect_variants/mutect_unfiltered_vcf
+        secondaryFiles: [.tbi]
+    mutect_filtered_vcf:
+        type: File
+        outputSource: detect_variants/mutect_filtered_vcf
+        secondaryFiles: [.tbi]
+    strelka_unfiltered_vcf:
+        type: File
+        outputSource: detect_variants/strelka_unfiltered_vcf
+        secondaryFiles: [.tbi]
+    strelka_filtered_vcf:
+        type: File
+        outputSource: detect_variants/strelka_filtered_vcf
+        secondaryFiles: [.tbi]
+    varscan_unfiltered_vcf:
+        type: File
+        outputSource: detect_variants/varscan_unfiltered_vcf
+        secondaryFiles: [.tbi]
+    varscan_filtered_vcf:
+        type: File
+        outputSource: detect_variants/varscan_filtered_vcf
+        secondaryFiles: [.tbi]
+    pindel_unfiltered_vcf:
+        type: File
+        outputSource: detect_variants/pindel_unfiltered_vcf
+        secondaryFiles: [.tbi]
+    pindel_filtered_vcf:
+        type: File
+        outputSource: detect_variants/pindel_filtered_vcf
+        secondaryFiles: [.tbi]
+    final_vcf:
+        type: File
+        outputSource: detect_variants/final_vcf
+        secondaryFiles: [.tbi]
+    final_filtered_vcf:
+        type: File
+        outputSource: detect_variants/final_filtered_vcf
+        secondaryFiles: [.tbi]
+    final_tsv:
+        type: File
+        outputSource: detect_variants/final_tsv
+    vep_summary:
+        type: File
+        outputSource: detect_variants/vep_summary
+    tumor_snv_bam_readcount_tsv:
+        type: File
+        outputSource: detect_variants/tumor_snv_bam_readcount_tsv
+    tumor_indel_bam_readcount_tsv:
+        type: File
+        outputSource: detect_variants/tumor_indel_bam_readcount_tsv
+    normal_snv_bam_readcount_tsv:
+        type: File
+        outputSource: detect_variants/normal_snv_bam_readcount_tsv
+    normal_indel_bam_readcount_tsv:
+        type: File
+        outputSource: detect_variants/normal_indel_bam_readcount_tsv
+    intervals_antitarget:
+        type: File?
+        outputSource: cnvkit/intervals_antitarget
+    intervals_target:
+        type: File?
+        outputSource: cnvkit/intervals_target
+    normal_antitarget_coverage:
+        type: File
+        outputSource: cnvkit/normal_antitarget_coverage
+    normal_target_coverage:
+        type: File
+        outputSource: cnvkit/normal_target_coverage
+    reference_coverage:
+        type: File?
+        outputSource: cnvkit/reference_coverage
+    cn_diagram:
+        type: File?
+        outputSource: cnvkit/cn_diagram
+    cn_scatter_plot:
+        type: File?
+        outputSource: cnvkit/cn_scatter_plot
+    tumor_antitarget_coverage:
+        type: File
+        outputSource: cnvkit/tumor_antitarget_coverage
+    tumor_target_coverage:
+        type: File
+        outputSource: cnvkit/tumor_target_coverage
+    tumor_bin_level_ratios:
+        type: File
+        outputSource: cnvkit/tumor_bin_level_ratios
+    tumor_segmented_ratios:
+        type: File
+        outputSource: cnvkit/tumor_segmented_ratios
+    diploid_variants:
+        type: File?
+        outputSource: manta/diploid_variants
+        secondaryFiles: [.tbi]
+    somatic_variants:
+        type: File?
+        outputSource: manta/somatic_variants
+        secondaryFiles: [.tbi]
+    all_candidates:
+        type: File
+        outputSource: manta/all_candidates
+        secondaryFiles: [.tbi]
+    small_candidates:
+        type: File
+        outputSource: manta/small_candidates
+        secondaryFiles: [.tbi]
+    tumor_only_variants:
+        type: File?
+        outputSource: manta/tumor_only_variants
+        secondaryFiles: [.tbi]
+    somalier_concordance_metrics:
+        type: File
+        outputSource: concordance/somalier_pairs
+    somalier_concordance_statistics:
+        type: File
+        outputSource: concordance/somalier_samples
+steps:
+    tumor_alignment_and_qc:
+        run: exome_alignment.cwl
+        in:
+            reference: reference
+            bams: tumor_bams
+            readgroups: tumor_readgroups
+            mills: mills
+            known_indels: known_indels
+            dbsnp_vcf: dbsnp_vcf
+            bqsr_intervals: bqsr_intervals
+            bait_intervals: bait_intervals
+            target_intervals: target_intervals
+            per_base_intervals: per_base_intervals
+            per_target_intervals: per_target_intervals
+            summary_intervals: summary_intervals
+            omni_vcf: omni_vcf
+            picard_metric_accumulation_level: picard_metric_accumulation_level   
+            minimum_mapping_quality: qc_minimum_mapping_quality
+            minimum_base_quality: qc_minimum_base_quality
+            final_name:
+                source: tumor_name
+                valueFrom: "$(self).bam"
+        out:
+            [bam, mark_duplicates_metrics, insert_size_metrics, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, summary_hs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]
+    normal_alignment_and_qc:
+        run: exome_alignment.cwl
+        in:
+            reference: reference
+            bams: normal_bams
+            readgroups: normal_readgroups
+            mills: mills
+            known_indels: known_indels
+            dbsnp_vcf: dbsnp_vcf
+            bqsr_intervals: bqsr_intervals
+            bait_intervals: bait_intervals
+            target_intervals: target_intervals
+            per_base_intervals: per_base_intervals
+            per_target_intervals: per_target_intervals
+            summary_intervals: summary_intervals
+            omni_vcf: omni_vcf
+            picard_metric_accumulation_level: picard_metric_accumulation_level   
+            minimum_mapping_quality: qc_minimum_mapping_quality
+            minimum_base_quality: qc_minimum_base_quality
+            final_name:
+                source: normal_name
+                valueFrom: "$(self).bam"
+        out:
+            [bam, mark_duplicates_metrics, insert_size_metrics, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, summary_hs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]
+    concordance:
+        run: ../tools/concordance.cwl
+        in:
+            reference: reference
+            bam_1: tumor_alignment_and_qc/bam
+            bam_2: normal_alignment_and_qc/bam
+            vcf: somalier_vcf
+        out:
+            [somalier_pairs, somalier_samples]
+    detect_variants:
+        run: detect_variants.cwl
+        in:
+            reference: reference
+            tumor_bam: tumor_alignment_and_qc/bam
+            normal_bam: normal_alignment_and_qc/bam
+            interval_list: interval_list
+            dbsnp_vcf: dbsnp_vcf
+            cosmic_vcf: cosmic_vcf
+            panel_of_normals_vcf: panel_of_normals_vcf
+            strelka_exome_mode:
+                default: true
+            strelka_cpu_reserved: strelka_cpu_reserved
+            mutect_scatter_count: mutect_scatter_count
+            mutect_artifact_detection_mode: mutect_artifact_detection_mode
+            mutect_max_alt_allele_in_normal_fraction: mutect_max_alt_allele_in_normal_fraction
+            mutect_max_alt_alleles_in_normal_count: mutect_max_alt_alleles_in_normal_count
+            varscan_strand_filter: varscan_strand_filter
+            varscan_min_coverage: varscan_min_coverage
+            varscan_min_var_freq: varscan_min_var_freq
+            varscan_p_value: varscan_p_value
+            varscan_max_normal_freq: varscan_max_normal_freq
+            pindel_insert_size: pindel_insert_size
+            vep_cache_dir: vep_cache_dir
+            synonyms_file: synonyms_file
+            annotate_coding_only: annotate_coding_only
+            vep_pick: vep_pick
+            cle_vcf_filter: cle_vcf_filter
+            variants_to_table_fields: variants_to_table_fields
+            variants_to_table_genotype_fields: variants_to_table_genotype_fields
+            vep_to_table_fields: vep_to_table_fields
+            custom_gnomad_vcf: custom_gnomad_vcf
+            custom_clinvar_vcf: custom_clinvar_vcf
+        out:
+            [mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv]
+    cnvkit:
+        run: ../tools/cnvkit_batch.cwl
+        in: 
+            tumor_bam: tumor_alignment_and_qc/bam
+            normal_bam: normal_alignment_and_qc/bam
+            reference: reference
+            bait_intervals: bait_intervals
+        out:
+            [intervals_antitarget, intervals_target, normal_antitarget_coverage, normal_target_coverage, reference_coverage, cn_diagram, cn_scatter_plot, tumor_antitarget_coverage, tumor_target_coverage, tumor_bin_level_ratios, tumor_segmented_ratios]
+    manta: 
+        run: ../tools/manta_somatic.cwl
+        in:
+            normal_bam: normal_alignment_and_qc/bam
+            tumor_bam: tumor_alignment_and_qc/bam
+            reference: reference
+            call_regions: manta_call_regions
+            non_wgs: manta_non_wgs
+            output_contigs: manta_output_contigs
+        out:
+            [diploid_variants, somatic_variants, all_candidates, small_candidates, tumor_only_variants]
+    tumor_bam_to_cram:
+        run: ../tools/bam_to_cram.cwl
+        in:
+            bam: tumor_alignment_and_qc/bam
+            reference: reference
+        out:
+            [cram]
+    tumor_index_cram:
+         run: ../tools/index_cram.cwl
+         in:
+            cram: tumor_bam_to_cram/cram
+         out:
+            [indexed_cram]
+    normal_bam_to_cram:
+        run: ../tools/bam_to_cram.cwl
+        in:
+            bam: normal_alignment_and_qc/bam
+            reference: reference
+        out:
+            [cram]
+    normal_index_cram:
+         run: ../tools/index_cram.cwl
+         in:
+            cram: normal_bam_to_cram/cram
+         out:
+            [indexed_cram]
+

--- a/definitions/pipelines/somatic_exome_mouse.cwl
+++ b/definitions/pipelines/somatic_exome_mouse.cwl
@@ -25,17 +25,6 @@ inputs:
     normal_name:
         type: string?
         default: 'normal'
-    mills:
-        type: File
-        secondaryFiles: [.tbi]
-    known_indels:
-        type: File
-        secondaryFiles: [.tbi]
-    dbsnp_vcf:
-        type: File
-        secondaryFiles: [.tbi]
-    bqsr_intervals:
-        type: string[]
     bait_intervals:
         type: File
     target_intervals:
@@ -323,21 +312,16 @@ outputs:
         secondaryFiles: [.tbi]
 steps:
     tumor_alignment_and_qc:
-        run: exome_alignment.cwl
+        run: exome_alignment_mouse.cwl
         in:
             reference: reference
             bams: tumor_bams
             readgroups: tumor_readgroups
-            mills: mills
-            known_indels: known_indels
-            dbsnp_vcf: dbsnp_vcf
-            bqsr_intervals: bqsr_intervals
             bait_intervals: bait_intervals
             target_intervals: target_intervals
             per_base_intervals: per_base_intervals
             per_target_intervals: per_target_intervals
             summary_intervals: summary_intervals
-            omni_vcf: omni_vcf
             picard_metric_accumulation_level: picard_metric_accumulation_level   
             minimum_mapping_quality: qc_minimum_mapping_quality
             minimum_base_quality: qc_minimum_base_quality
@@ -345,23 +329,18 @@ steps:
                 source: tumor_name
                 valueFrom: "$(self).bam"
         out:
-            [bam, mark_duplicates_metrics, insert_size_metrics, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, summary_hs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]
+            [bam, mark_duplicates_metrics, insert_size_metrics, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, summary_hs_metrics, flagstats]
     normal_alignment_and_qc:
-        run: exome_alignment.cwl
+        run: exome_alignment_mouse.cwl
         in:
             reference: reference
             bams: normal_bams
             readgroups: normal_readgroups
-            mills: mills
-            known_indels: known_indels
-            dbsnp_vcf: dbsnp_vcf
-            bqsr_intervals: bqsr_intervals
             bait_intervals: bait_intervals
             target_intervals: target_intervals
             per_base_intervals: per_base_intervals
             per_target_intervals: per_target_intervals
             summary_intervals: summary_intervals
-            omni_vcf: omni_vcf
             picard_metric_accumulation_level: picard_metric_accumulation_level   
             minimum_mapping_quality: qc_minimum_mapping_quality
             minimum_base_quality: qc_minimum_base_quality
@@ -369,7 +348,7 @@ steps:
                 source: normal_name
                 valueFrom: "$(self).bam"
         out:
-            [bam, mark_duplicates_metrics, insert_size_metrics, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, summary_hs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]
+            [bam, mark_duplicates_metrics, insert_size_metrics, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, summary_hs_metrics, flagstats]
     detect_variants:
         run: detect_variants_mouse.cwl
         in:

--- a/definitions/pipelines/somatic_exome_mouse.cwl
+++ b/definitions/pipelines/somatic_exome_mouse.cwl
@@ -96,7 +96,7 @@ inputs:
         default: [GT,AD]
     vep_to_table_fields:
         type: string[]
-        default: [HGVSc,HGVSp]
+        default: ['Consequence','SYMBOL','Feature']
     custom_gnomad_vcf:
         type: File?
         secondaryFiles: [.tbi]
@@ -137,12 +137,6 @@ outputs:
     tumor_flagstats:
         type: File
         outputSource: tumor_alignment_and_qc/flagstats
-    tumor_verify_bam_id_metrics:
-        type: File
-        outputSource: tumor_alignment_and_qc/verify_bam_id_metrics
-    tumor_verify_bam_id_depth:
-        type: File
-        outputSource: tumor_alignment_and_qc/verify_bam_id_depth
     normal_cram:
         type: File
         outputSource: normal_index_cram/indexed_cram
@@ -176,12 +170,6 @@ outputs:
     normal_flagstats:
         type: File
         outputSource: normal_alignment_and_qc/flagstats
-    normal_verify_bam_id_metrics:
-        type: File
-        outputSource: normal_alignment_and_qc/verify_bam_id_metrics
-    normal_verify_bam_id_depth:
-        type: File
-        outputSource: normal_alignment_and_qc/verify_bam_id_depth
     mutect_unfiltered_vcf:
         type: File
         outputSource: detect_variants/mutect_unfiltered_vcf
@@ -253,8 +241,8 @@ steps:
             per_target_intervals: per_target_intervals
             summary_intervals: summary_intervals
             picard_metric_accumulation_level: picard_metric_accumulation_level   
-            minimum_mapping_quality: qc_minimum_mapping_quality
-            minimum_base_quality: qc_minimum_base_quality
+            qc_minimum_mapping_quality: qc_minimum_mapping_quality
+            qc_minimum_base_quality: qc_minimum_base_quality
             final_name:
                 source: tumor_name
                 valueFrom: "$(self).bam"
@@ -272,8 +260,8 @@ steps:
             per_target_intervals: per_target_intervals
             summary_intervals: summary_intervals
             picard_metric_accumulation_level: picard_metric_accumulation_level   
-            minimum_mapping_quality: qc_minimum_mapping_quality
-            minimum_base_quality: qc_minimum_base_quality
+            qc_minimum_mapping_quality: qc_minimum_mapping_quality
+            qc_minimum_base_quality: qc_minimum_base_quality
             final_name:
                 source: normal_name
                 valueFrom: "$(self).bam"

--- a/definitions/pipelines/somatic_exome_mouse.cwl
+++ b/definitions/pipelines/somatic_exome_mouse.cwl
@@ -131,8 +131,6 @@ inputs:
         default: true
     manta_output_contigs:
         type: boolean?
-    somalier_vcf:
-        type: File
 outputs:
     tumor_cram:
         type: File
@@ -323,12 +321,6 @@ outputs:
         type: File?
         outputSource: manta/tumor_only_variants
         secondaryFiles: [.tbi]
-    somalier_concordance_metrics:
-        type: File
-        outputSource: concordance/somalier_pairs
-    somalier_concordance_statistics:
-        type: File
-        outputSource: concordance/somalier_samples
 steps:
     tumor_alignment_and_qc:
         run: exome_alignment.cwl
@@ -378,15 +370,6 @@ steps:
                 valueFrom: "$(self).bam"
         out:
             [bam, mark_duplicates_metrics, insert_size_metrics, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, summary_hs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]
-    concordance:
-        run: ../tools/concordance.cwl
-        in:
-            reference: reference
-            bam_1: tumor_alignment_and_qc/bam
-            bam_2: normal_alignment_and_qc/bam
-            vcf: somalier_vcf
-        out:
-            [somalier_pairs, somalier_samples]
     detect_variants:
         run: detect_variants.cwl
         in:

--- a/definitions/pipelines/somatic_exome_mouse.cwl
+++ b/definitions/pipelines/somatic_exome_mouse.cwl
@@ -106,12 +106,6 @@ inputs:
     vep_to_table_fields:
         type: string[]
         default: ['Consequence','SYMBOL','Feature']
-    custom_gnomad_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
-    custom_clinvar_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
 outputs:
     tumor_cram:
         type: File

--- a/definitions/pipelines/somatic_exome_mouse.cwl
+++ b/definitions/pipelines/somatic_exome_mouse.cwl
@@ -371,7 +371,7 @@ steps:
         out:
             [bam, mark_duplicates_metrics, insert_size_metrics, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, summary_hs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]
     detect_variants:
-        run: detect_variants.cwl
+        run: detect_variants_mouse.cwl
         in:
             reference: reference
             tumor_bam: tumor_alignment_and_qc/bam

--- a/definitions/pipelines/somatic_exome_mouse.cwl
+++ b/definitions/pipelines/somatic_exome_mouse.cwl
@@ -112,14 +112,6 @@ inputs:
     custom_clinvar_vcf:
         type: File?
         secondaryFiles: [.tbi]
-    manta_call_regions:
-        type: File?
-        secondaryFiles: [.tbi]
-    manta_non_wgs:
-        type: boolean?
-        default: true
-    manta_output_contigs:
-        type: boolean?
 outputs:
     tumor_cram:
         type: File
@@ -257,59 +249,6 @@ outputs:
     normal_indel_bam_readcount_tsv:
         type: File
         outputSource: detect_variants/normal_indel_bam_readcount_tsv
-    intervals_antitarget:
-        type: File?
-        outputSource: cnvkit/intervals_antitarget
-    intervals_target:
-        type: File?
-        outputSource: cnvkit/intervals_target
-    normal_antitarget_coverage:
-        type: File
-        outputSource: cnvkit/normal_antitarget_coverage
-    normal_target_coverage:
-        type: File
-        outputSource: cnvkit/normal_target_coverage
-    reference_coverage:
-        type: File?
-        outputSource: cnvkit/reference_coverage
-    cn_diagram:
-        type: File?
-        outputSource: cnvkit/cn_diagram
-    cn_scatter_plot:
-        type: File?
-        outputSource: cnvkit/cn_scatter_plot
-    tumor_antitarget_coverage:
-        type: File
-        outputSource: cnvkit/tumor_antitarget_coverage
-    tumor_target_coverage:
-        type: File
-        outputSource: cnvkit/tumor_target_coverage
-    tumor_bin_level_ratios:
-        type: File
-        outputSource: cnvkit/tumor_bin_level_ratios
-    tumor_segmented_ratios:
-        type: File
-        outputSource: cnvkit/tumor_segmented_ratios
-    diploid_variants:
-        type: File?
-        outputSource: manta/diploid_variants
-        secondaryFiles: [.tbi]
-    somatic_variants:
-        type: File?
-        outputSource: manta/somatic_variants
-        secondaryFiles: [.tbi]
-    all_candidates:
-        type: File
-        outputSource: manta/all_candidates
-        secondaryFiles: [.tbi]
-    small_candidates:
-        type: File
-        outputSource: manta/small_candidates
-        secondaryFiles: [.tbi]
-    tumor_only_variants:
-        type: File?
-        outputSource: manta/tumor_only_variants
-        secondaryFiles: [.tbi]
 steps:
     tumor_alignment_and_qc:
         run: exome_alignment_mouse.cwl
@@ -384,26 +323,6 @@ steps:
             custom_clinvar_vcf: custom_clinvar_vcf
         out:
             [mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv]
-    cnvkit:
-        run: ../tools/cnvkit_batch.cwl
-        in: 
-            tumor_bam: tumor_alignment_and_qc/bam
-            normal_bam: normal_alignment_and_qc/bam
-            reference: reference
-            bait_intervals: bait_intervals
-        out:
-            [intervals_antitarget, intervals_target, normal_antitarget_coverage, normal_target_coverage, reference_coverage, cn_diagram, cn_scatter_plot, tumor_antitarget_coverage, tumor_target_coverage, tumor_bin_level_ratios, tumor_segmented_ratios]
-    manta: 
-        run: ../tools/manta_somatic.cwl
-        in:
-            normal_bam: normal_alignment_and_qc/bam
-            tumor_bam: tumor_alignment_and_qc/bam
-            reference: reference
-            call_regions: manta_call_regions
-            non_wgs: manta_non_wgs
-            output_contigs: manta_output_contigs
-        out:
-            [diploid_variants, somatic_variants, all_candidates, small_candidates, tumor_only_variants]
     tumor_bam_to_cram:
         run: ../tools/bam_to_cram.cwl
         in:

--- a/definitions/pipelines/somatic_exome_mouse.cwl
+++ b/definitions/pipelines/somatic_exome_mouse.cwl
@@ -76,6 +76,15 @@ inputs:
         default: 400
     vep_cache_dir:
         type: string
+    vep_ensembl_assembly:
+        type: string
+        doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"
+    vep_ensembl_version:
+        type: string
+        doc: "ensembl version - Must be present in the cache directory. Example: 95"
+    vep_ensembl_species:
+        type: string
+        doc: "ensembl species - Must be present in the cache directory. Examples: homo_sapiens or mus_musculus"
     synonyms_file:
         type: File?
     annotate_coding_only:
@@ -294,6 +303,9 @@ steps:
             cle_vcf_filter: cle_vcf_filter
             variants_to_table_fields: variants_to_table_fields
             variants_to_table_genotype_fields: variants_to_table_genotype_fields
+            vep_ensembl_assembly: vep_ensembl_assembly
+            vep_ensembl_version: vep_ensembl_version
+            vep_ensembl_species: vep_ensembl_species
             vep_to_table_fields: vep_to_table_fields
         out:
             [mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv]

--- a/definitions/subworkflows/align_sort_markdup.cwl
+++ b/definitions/subworkflows/align_sort_markdup.cwl
@@ -1,0 +1,64 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+label: "Unaligned bam to sorted, markduped bam"
+requirements:
+    - class: ScatterFeatureRequirement
+    - class: SubworkflowFeatureRequirement
+    - class: MultipleInputFeatureRequirement
+
+inputs:
+    bams:
+        type: File[]
+    readgroups:
+        type: string[]
+    reference:
+        type: string
+    final_name:
+        type: string?
+        default: 'final.bam'
+outputs:
+    final_bam:
+        type: File
+        outputSource: index_bam/indexed_bam
+        secondaryFiles: [.bai, ^.bai]
+    mark_duplicates_metrics_file:
+        type: File
+        outputSource: mark_duplicates_and_sort/metrics_file
+steps:
+    align:
+        scatter: [bam, readgroup]
+        scatterMethod: dotproduct
+        run: align.cwl
+        in:
+            bam: bams
+            readgroup: readgroups
+            reference: reference
+        out:
+            [tagged_bam]
+    merge:
+        run: ../tools/merge_bams_samtools.cwl
+        in:
+            bams: align/tagged_bam
+            name: final_name
+        out:
+            [merged_bam]
+    name_sort:
+        run: ../tools/name_sort.cwl
+        in:
+            bam: merge/merged_bam
+        out:
+            [name_sorted_bam]
+    mark_duplicates_and_sort:
+        run: ../tools/mark_duplicates_and_sort.cwl
+        in:
+            bam: name_sort/name_sorted_bam
+        out:
+            [sorted_bam, metrics_file]
+    index_bam:
+        run: ../tools/index_bam.cwl
+        in:
+            bam: mark_duplicates_and_sort/sorted_bam
+        out:
+            [indexed_bam]

--- a/definitions/subworkflows/filter_vcf_mouse.cwl
+++ b/definitions/subworkflows/filter_vcf_mouse.cwl
@@ -1,0 +1,62 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+label: "Apply filters to VCF file"
+requirements:
+    - class: SubworkflowFeatureRequirement
+inputs:
+    vcf:
+        type: File
+    filter_mapq0_threshold: 
+        type: float
+    tumor_bam: 
+        type: File
+        secondaryFiles: [.bai]
+    do_cle_vcf_filter: 
+        type: boolean
+    filter_somatic_llr_threshold:
+        type: float
+    reference: 
+        type: string
+    filter_minimum_depth:
+        type: int
+    sample_names:
+        type: string
+outputs: 
+    filtered_vcf:
+        type: File
+        outputSource: filter_vcf_cle/cle_filtered_vcf
+        secondaryFiles: [.tbi]
+steps:
+    filter_vcf_mapq0:
+        run: ../tools/filter_vcf_mapq0.cwl
+        in: 
+            vcf: vcf
+            tumor_bam: tumor_bam
+            threshold: filter_mapq0_threshold
+            reference: reference
+        out:
+            [mapq0_filtered_vcf]
+    filter_vcf_cle:
+        run: ../tools/filter_vcf_cle.cwl
+        in:
+            vcf: filter_vcf_mapq0/mapq0_filtered_vcf
+            filter: do_cle_vcf_filter
+        out:
+            [cle_filtered_vcf]
+    filter_vcf_depth:
+        run: ../tools/filter_vcf_depth.cwl
+        in:
+            vcf: filter_vcf_cle/cle_filtered_vcf
+            minimum_depth: filter_minimum_depth
+            sample_names: sample_names
+        out:
+            [depth_filtered_vcf]
+    filter_vcf_somatic_llr:
+        run: ../tools/filter_vcf_somatic_llr.cwl
+        in:
+            vcf: filter_vcf_depth/depth_filtered_vcf
+            threshold: filter_somatic_llr_threshold
+        out:
+            [somatic_llr_filtered_vcf]

--- a/definitions/subworkflows/mutect.cwl
+++ b/definitions/subworkflows/mutect.cwl
@@ -13,10 +13,10 @@ inputs:
         type: string
     tumor_bam:
         type: File
-        secondaryFiles: [.bai]
+        secondaryFiles: [.bai,^.bai]
     normal_bam:
         type: File?
-        secondaryFiles: [.bai]
+        secondaryFiles: [.bai,^.bai]
     interval_list:
         type: File
     scatter_count:

--- a/definitions/subworkflows/mutect.cwl
+++ b/definitions/subworkflows/mutect.cwl
@@ -13,10 +13,10 @@ inputs:
         type: string
     tumor_bam:
         type: File
-        secondaryFiles: [.bai,^.bai]
+        secondaryFiles: [^.bai]
     normal_bam:
         type: File?
-        secondaryFiles: [.bai,^.bai]
+        secondaryFiles: [^.bai]
     interval_list:
         type: File
     scatter_count:

--- a/definitions/subworkflows/pindel.cwl
+++ b/definitions/subworkflows/pindel.cwl
@@ -13,10 +13,10 @@ inputs:
         type: string
     tumor_bam:
         type: File
-        secondaryFiles: [.bai,^.bai]
+        secondaryFiles: [^.bai]
     normal_bam:
         type: File
-        secondaryFiles: [.bai,^.bai]
+        secondaryFiles: [^.bai]
     interval_list:
         type: File
     insert_size:

--- a/definitions/subworkflows/pindel.cwl
+++ b/definitions/subworkflows/pindel.cwl
@@ -13,10 +13,10 @@ inputs:
         type: string
     tumor_bam:
         type: File
-        secondaryFiles: ["^.bai"]
+        secondaryFiles: [.bai,^.bai]
     normal_bam:
         type: File
-        secondaryFiles: ["^.bai"]
+        secondaryFiles: [.bai,^.bai]
     interval_list:
         type: File
     insert_size:

--- a/definitions/subworkflows/qc_exome_no_verify_bam.cwl
+++ b/definitions/subworkflows/qc_exome_no_verify_bam.cwl
@@ -1,0 +1,117 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+label: "Exome QC workflow"
+requirements:
+    - class: SchemaDefRequirement
+      types:
+          - $import: ../types/labelled_file.yml
+    - class: SubworkflowFeatureRequirement
+inputs:
+    bam:
+        type: File
+        secondaryFiles: [^.bai]
+    reference:
+        type: string
+    bait_intervals:
+        type: File
+    target_intervals:
+        type: File
+    picard_metric_accumulation_level:
+        type: string?
+        default: ALL_READS
+    minimum_mapping_quality:
+        type: int?
+    minimum_base_quality:
+        type: int?
+    per_base_intervals:
+        type: ../types/labelled_file.yml#labelled_file[]
+    per_target_intervals:
+        type: ../types/labelled_file.yml#labelled_file[]
+    summary_intervals:
+        type: ../types/labelled_file.yml#labelled_file[]
+outputs:
+    insert_size_metrics:
+        type: File
+        outputSource: collect_insert_size_metrics/insert_size_metrics
+    insert_size_histogram:
+        type: File
+        outputSource: collect_insert_size_metrics/insert_size_histogram
+    alignment_summary_metrics:
+        type: File
+        outputSource: collect_alignment_summary_metrics/alignment_summary_metrics
+    hs_metrics:
+        type: File
+        outputSource: collect_roi_hs_metrics/hs_metrics
+    per_target_coverage_metrics:
+        type: File[]
+        outputSource: collect_detailed_hs_metrics/per_target_coverage_metrics
+    per_target_hs_metrics:
+        type: File[]
+        outputSource: collect_detailed_hs_metrics/per_target_hs_metrics
+    per_base_coverage_metrics:
+        type: File[]
+        outputSource: collect_detailed_hs_metrics/per_base_coverage_metrics
+    per_base_hs_metrics:
+        type: File[]
+        outputSource: collect_detailed_hs_metrics/per_base_hs_metrics
+    summary_hs_metrics:
+        type: File[]
+        outputSource: collect_detailed_hs_metrics/summary_hs_metrics
+    flagstats:
+        type: File
+        outputSource: samtools_flagstat/flagstats
+steps:
+    collect_insert_size_metrics:
+        run: ../tools/collect_insert_size_metrics.cwl
+        in:
+            bam: bam
+            reference: reference
+            metric_accumulation_level: picard_metric_accumulation_level
+        out:
+            [insert_size_metrics, insert_size_histogram]
+    collect_alignment_summary_metrics:
+        run: ../tools/collect_alignment_summary_metrics.cwl
+        in:
+            bam: bam
+            reference: reference
+            metric_accumulation_level: picard_metric_accumulation_level
+        out:
+            [alignment_summary_metrics]
+    collect_roi_hs_metrics:
+        run: ../tools/collect_hs_metrics.cwl
+        in:
+            bam: bam
+            reference: reference
+            metric_accumulation_level:
+                valueFrom: "ALL_READS"
+            bait_intervals: bait_intervals
+            target_intervals: target_intervals
+            per_target_coverage:
+                default: false
+            per_base_coverage:
+                default: false
+            output_prefix:
+                valueFrom: "roi"
+            minimum_mapping_quality: minimum_mapping_quality
+            minimum_base_quality: minimum_base_quality
+        out:
+            [hs_metrics]
+    collect_detailed_hs_metrics:
+        run: hs_metrics.cwl
+        in:
+            bam: bam
+            minimum_mapping_quality: minimum_mapping_quality
+            minimum_base_quality: minimum_base_quality
+            per_base_intervals: per_base_intervals
+            per_target_intervals: per_target_intervals
+            reference: reference
+            summary_intervals: summary_intervals
+        out:
+            [per_base_coverage_metrics, per_base_hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, summary_hs_metrics]
+    samtools_flagstat:
+        run: ../tools/samtools_flagstat.cwl
+        in:
+            bam: bam
+        out: [flagstats]

--- a/definitions/subworkflows/varscan_pre_and_post_processing.cwl
+++ b/definitions/subworkflows/varscan_pre_and_post_processing.cwl
@@ -12,10 +12,10 @@ inputs:
         type: string
     tumor_bam:
         type: File
-        secondaryFiles: [^.bai]
+        secondaryFiles: [.bai,^.bai]
     normal_bam:
         type: File
-        secondaryFiles: [^.bai]
+        secondaryFiles: [.bai,^.bai]
     interval_list:
         type: File
     strand_filter:

--- a/definitions/subworkflows/varscan_pre_and_post_processing.cwl
+++ b/definitions/subworkflows/varscan_pre_and_post_processing.cwl
@@ -12,10 +12,10 @@ inputs:
         type: string
     tumor_bam:
         type: File
-        secondaryFiles: [.bai,^.bai]
+        secondaryFiles: [^.bai]
     normal_bam:
         type: File
-        secondaryFiles: [.bai,^.bai]
+        secondaryFiles: [^.bai]
     interval_list:
         type: File
     strand_filter:

--- a/example_data/alignment_mouse.yaml
+++ b/example_data/alignment_mouse.yaml
@@ -1,0 +1,42 @@
+---
+bams:
+- class: File
+  path: exome_workflow/mouse_test_bams/tum.2896232918.bam
+- class: File
+  path: exome_workflow/mouse_test_bams/tum.2896233121.bam
+readgroups:
+- "@RG\tID:2896232918\tPL:illumina\tPU:CA3N9ANXX.3-ACATGGAG-ACATGGAG\tLB:M_BQ-17857-082516-7-EZ41A1-APL19-lg1-lib1\tDS:paired end\tDT:2016-10-27T19:00:00-0500\tSM:M_BQ-17857-082516-7-EZ41A1-APL19\tCN:WUGSC"
+- "@RG\tID:2896233121\tPL:illumina\tPU:CA3N9ANXX.2-ACATGGAG-ACATGGAG\tLB:M_BQ-17857-082516-7-EZ41A1-APL19-lg1-lib1\tDS:paired end\tDT:2016-10-27T19:00:00-0500\tSM:M_BQ-17857-082516-7-EZ41A1-APL19\tCN:WUGSC"
+bait_intervals:
+  class: File
+  path: /gscmnt/gc2560/core/reference_sequences/mouse_exome_reference_cwl_test/targets.interval_list
+interval_list:
+  class: File
+  path: /gscmnt/gc2560/core/reference_sequences/mouse_exome_reference_cwl_test/genes.interval_list
+per_base_intervals:
+  - label: testing
+    file:
+      class: File
+      path: /gscmnt/gc2560/core/reference_sequences/mouse_exome_reference_cwl_test/targets.interval_list
+per_target_intervals:
+  - label: targets
+    file:
+      class: File
+      path: /gscmnt/gc2560/core/reference_sequences/mouse_exome_reference_cwl_test/targets.interval_list
+summary_intervals:
+  - label: baits 
+    file:
+      class: File
+      path: /gscmnt/gc2560/core/reference_sequences/mouse_exome_reference_cwl_test/targets.interval_list
+  - label: genes
+    file:
+      class: File
+      path: /gscmnt/gc2560/core/reference_sequences/mouse_exome_reference_cwl_test/genes.interval_list
+target_intervals:
+  class: File
+  path: /gscmnt/gc2560/core/reference_sequences/mouse_exome_reference_cwl_test/targets.interval_list
+picard_metric_accumulation_level: ALL_READS
+reference: "/gscmnt/gc2560/core/reference_sequences/mouse_exome_reference_cwl_test/reference_small.fa"
+synonyms_file:
+  class: File
+  path: /gscmnt/gc2560/core/reference_sequences/mouse_exome_reference_cwl_test/chromAlias.ensembl.txt

--- a/example_data/exome_workflow.tgz.md5
+++ b/example_data/exome_workflow.tgz.md5
@@ -1,1 +1,1 @@
-b6faf8b6afbf694fbd1377414609d820  exome_workflow.tgz
+4428b9645c093416700cf5768857db53  exome_workflow.tgz

--- a/example_data/somatic_exome_mouse.yaml
+++ b/example_data/somatic_exome_mouse.yaml
@@ -1,0 +1,52 @@
+---
+tumor_bams:
+- class: File
+  path: exome_workflow/mouse_test_bams/tum.2896232918.bam
+- class: File
+  path: exome_workflow/mouse_test_bams/tum.2896233121.bam
+tumor_readgroups:
+- "@RG\tID:2896232918\tPL:illumina\tPU:CA3N9ANXX.3-ACATGGAG-ACATGGAG\tLB:M_BQ-17857-082516-7-EZ41A1-APL19-lg1-lib1\tDS:paired end\tDT:2016-10-27T19:00:00-0500\tSM:M_BQ-17857-082516-7-EZ41A1-APL19\tCN:WUGSC"
+- "@RG\tID:2896233121\tPL:illumina\tPU:CA3N9ANXX.2-ACATGGAG-ACATGGAG\tLB:M_BQ-17857-082516-7-EZ41A1-APL19-lg1-lib1\tDS:paired end\tDT:2016-10-27T19:00:00-0500\tSM:M_BQ-17857-082516-7-EZ41A1-APL19\tCN:WUGSC"
+normal_bams:
+- class: File
+  path: exome_workflow/mouse_test_bams/nrm.2888697054.bam
+- class: File
+  path: exome_workflow/mouse_test_bams/nrm.2888697058.bam
+normal_readgroups:
+- "@RG\tID:2888697054\tPL:illumina\tPU:C17NUACXX.5-TGACCA\tLB:M_BQ-17857-17857_N-lib1\tDS:paired end\tDT:2012-10-02T19:00:00-0500\tSM:M_BQ-17857-17857_N\tCN:WUGSC"
+- "@RG\tID:2888697058\tPL:illumina\tPU:C17NUACXX.6-TGACCA\tLB:M_BQ-17857-17857_N-lib1\tDS:paired end\tDT:2012-10-02T19:00:00-0500\tSM:M_BQ-17857-17857_N\tCN:WUGSC"
+bait_intervals:
+  class: File
+  path: exome_workflow/mouse_test_reference/targets.interval_list
+interval_list:
+  class: File
+  path: exome_workflow/mouse_test_reference/genes.interval_list
+per_base_intervals:
+  - label: testing
+    file:
+      class: File
+      path: exome_workflow/mouse_test_reference/targets.interval_list
+per_target_intervals:
+  - label: targets
+    file:
+      class: File
+      path: exome_workflow/mouse_test_reference/targets.interval_list
+summary_intervals:
+  - label: baits 
+    file:
+      class: File
+      path: exome_workflow/mouse_test_reference/targets.interval_list
+  - label: genes
+    file:
+      class: File
+      path: exome_workflow/mouse_test_reference/genes.interval_list
+target_intervals:
+  class: File
+  path: exome_workflow/mouse_test_reference/targets.interval_list
+picard_metric_accumulation_level: ALL_READS
+reference: "/gscmnt/gc2560/core/reference_sequences/mouse_exome_reference_cwl_test/reference_small.fa"
+vep_cache_dir: "/gscmnt/gc2560/core/cwl/inputs/VEP_cache/"
+vep_ensembl_assembly: "GRCm38"
+vep_ensembl_version: "96"
+vep_ensembl_species: "mus_musculus"
+mutect_scatter_count: 2

--- a/example_data/somatic_exome_mouse.yaml
+++ b/example_data/somatic_exome_mouse.yaml
@@ -17,32 +17,32 @@ normal_readgroups:
 - "@RG\tID:2888697058\tPL:illumina\tPU:C17NUACXX.6-TGACCA\tLB:M_BQ-17857-17857_N-lib1\tDS:paired end\tDT:2012-10-02T19:00:00-0500\tSM:M_BQ-17857-17857_N\tCN:WUGSC"
 bait_intervals:
   class: File
-  path: exome_workflow/mouse_test_reference/targets.interval_list
+  path: /gscmnt/gc2560/core/reference_sequences/mouse_exome_reference_cwl_test/targets.interval_list
 interval_list:
   class: File
-  path: exome_workflow/mouse_test_reference/genes.interval_list
+  path: /gscmnt/gc2560/core/reference_sequences/mouse_exome_reference_cwl_test/genes.interval_list
 per_base_intervals:
   - label: testing
     file:
       class: File
-      path: exome_workflow/mouse_test_reference/targets.interval_list
+      path: /gscmnt/gc2560/core/reference_sequences/mouse_exome_reference_cwl_test/targets.interval_list
 per_target_intervals:
   - label: targets
     file:
       class: File
-      path: exome_workflow/mouse_test_reference/targets.interval_list
+      path: /gscmnt/gc2560/core/reference_sequences/mouse_exome_reference_cwl_test/targets.interval_list
 summary_intervals:
   - label: baits 
     file:
       class: File
-      path: exome_workflow/mouse_test_reference/targets.interval_list
+      path: /gscmnt/gc2560/core/reference_sequences/mouse_exome_reference_cwl_test/targets.interval_list
   - label: genes
     file:
       class: File
-      path: exome_workflow/mouse_test_reference/genes.interval_list
+      path: /gscmnt/gc2560/core/reference_sequences/mouse_exome_reference_cwl_test/genes.interval_list
 target_intervals:
   class: File
-  path: exome_workflow/mouse_test_reference/targets.interval_list
+  path: /gscmnt/gc2560/core/reference_sequences/mouse_exome_reference_cwl_test/targets.interval_list
 picard_metric_accumulation_level: ALL_READS
 reference: "/gscmnt/gc2560/core/reference_sequences/mouse_exome_reference_cwl_test/reference_small.fa"
 vep_cache_dir: "/gscmnt/gc2560/core/cwl/inputs/VEP_cache/"


### PR DESCRIPTION
This adds a mouse somatic exome workflow. Major changes include:
- adding pipeline-level cwls that remove human specific steps, including:
  - removing docm, since no comparable list exists for human
  - removing T/N concordance checking, since they will almost always be 100% for inbred mice
  - removes bsqr and verify bam id from alignment workflows
  - remove gnomad, dbsnp, cosmic, and pon filters
- removing manta and cnvkit for now, since they both have human-specific annotations (we should re-add them or something comparable soon (see issue https://github.com/genome/analysis-workflows/issues/683) 
- adding test data and yamls that allow it to be run (locally, for now)

(P.S. Thanks to @Matthew-Mosior for some contributions)
