### PR TITLE
Simplify BAM and CRAM indexers.

### DIFF
--- a/definitions/tools/index_bam.cwl
+++ b/definitions/tools/index_bam.cwl
@@ -4,9 +4,7 @@ cwlVersion: v1.0
 class: CommandLineTool
 label: "samtools index"
 arguments: [
-    "cp", $(inputs.bam.path), "$(runtime.outdir)/$(inputs.bam.basename)",
-    { valueFrom: " && ", shellQuote: false },
-    "/opt/samtools/bin/samtools", "index", $(inputs.bam.path), "$(runtime.outdir)/$(inputs.bam.basename).bai",
+    "/opt/samtools/bin/samtools", "index", "$(runtime.outdir)/$(inputs.bam.basename)", "$(runtime.outdir)/$(inputs.bam.basename).bai",
     { valueFrom: " && ", shellQuote: false },
     "ln", "-s", "$(inputs.bam.basename).bai", "$(runtime.outdir)/$(inputs.bam.nameroot).bai"
 ]
@@ -16,6 +14,9 @@ requirements:
       dockerPull: "mgibio/samtools-cwl:1.0.0"
     - class: ResourceRequirement
       ramMin: 4000
+    - class: InitialWorkDirRequirement
+      listing:
+          - $(inputs.bam)
 inputs:
     bam:
         type: File

--- a/definitions/tools/index_bam.cwl
+++ b/definitions/tools/index_bam.cwl
@@ -6,7 +6,7 @@ label: "samtools index"
 arguments: [
     "/opt/samtools/bin/samtools", "index", "$(runtime.outdir)/$(inputs.bam.basename)", "$(runtime.outdir)/$(inputs.bam.basename).bai",
     { valueFrom: " && ", shellQuote: false },
-    "ln", "-s", "$(inputs.bam.basename).bai", "$(runtime.outdir)/$(inputs.bam.nameroot).bai"
+    "cp", "$(inputs.bam.basename).bai", "$(runtime.outdir)/$(inputs.bam.nameroot).bai"
 ]
 requirements:
     - class: ShellCommandRequirement

--- a/definitions/tools/index_cram.cwl
+++ b/definitions/tools/index_cram.cwl
@@ -6,7 +6,7 @@ label: 'samtools index cram'
 arguments: [
     "/opt/samtools/bin/samtools", "index", "$(runtime.outdir)/$(inputs.cram.basename)", "$(runtime.outdir)/$(inputs.cram.basename).crai",
     { valueFrom: " && ", shellQuote: false },
-    "ln", "-s", "$(inputs.cram.basename).crai", "$(runtime.outdir)/$(inputs.cram.nameroot).crai"
+    "cp", "$(inputs.cram.basename).crai", "$(runtime.outdir)/$(inputs.cram.nameroot).crai"
 ]
 requirements:
     - class: ShellCommandRequirement

--- a/definitions/tools/index_cram.cwl
+++ b/definitions/tools/index_cram.cwl
@@ -4,8 +4,6 @@ cwlVersion: v1.0
 class: CommandLineTool
 label: 'samtools index cram'
 arguments: [
-    "cp", $(inputs.cram.path), "$(runtime.outdir)/$(inputs.cram.basename)",
-    { valueFrom: " && ", shellQuote: false },
     "/opt/samtools/bin/samtools", "index", "$(runtime.outdir)/$(inputs.cram.basename)", "$(runtime.outdir)/$(inputs.cram.basename).crai",
     { valueFrom: " && ", shellQuote: false },
     "ln", "-s", "$(inputs.cram.basename).crai", "$(runtime.outdir)/$(inputs.cram.nameroot).crai"
@@ -16,6 +14,9 @@ requirements:
       dockerPull: "mgibio/samtools-cwl:1.0.0"
     - class: ResourceRequirement
       ramMin: 4000
+    - class: InitialWorkDirRequirement
+      listing:
+          - $(inputs.cram)
 inputs:
     cram:
         type: File


### PR DESCRIPTION
* We previously avoided the `InitialWorkDirRequirement` because a few executors didn't support it.  They generally all do now, so this is better than a manual copy.
* `cwltool` isn't propagating the symlinks, so make a copy of the index instead.  (Other executors end up making a copy later anyway.)  This addresses #691.