### PR TITLE
Use Picard-specific docker image instead of CLE image.

### DIFF
--- a/definitions/tools/collect_wgs_metrics.cwl
+++ b/definitions/tools/collect_wgs_metrics.cwl
@@ -10,7 +10,7 @@ requirements:
     - class: ResourceRequirement
       ramMin: 18000
     - class: DockerRequirement
-      dockerPull: mgibio/cle:v1.3.1
+      dockerPull: mgibio/picard-cwl:2.18.1
 inputs:
     bam:
         type: File


### PR DESCRIPTION
This is still the same version of the tool:
```
$ /usr/bin/java -jar /usr/picard/picard.jar CollectWgsMetrics --version
2.18.1-SNAPSHOT
```

Closes #695.