### PR TITLE
Strip the secondary files from the input file to be indexed.

### DIFF
--- a/definitions/tools/index_bam.cwl
+++ b/definitions/tools/index_bam.cwl
@@ -16,7 +16,8 @@ requirements:
       ramMin: 4000
     - class: InitialWorkDirRequirement
       listing:
-          - $(inputs.bam)
+        - ${ var f = inputs.bam; delete f.secondaryFiles; return f }
+    - class: InlineJavascriptRequirement
 inputs:
     bam:
         type: File

--- a/definitions/tools/index_cram.cwl
+++ b/definitions/tools/index_cram.cwl
@@ -16,7 +16,8 @@ requirements:
       ramMin: 4000
     - class: InitialWorkDirRequirement
       listing:
-          - $(inputs.cram)
+        - ${ var f = inputs.cram; delete f.secondaryFiles; return f }
+    - class: InlineJavascriptRequirement
 inputs:
     cram:
         type: File


### PR DESCRIPTION
We don't ask for them, but `cwltool` sends them along to the output directory if a previous output included them. This change assumes the secondaryFiles are indexes and should be dropped so the main file can be re-indexed.

Closes #697.