### PR TITLE
Change pindel subworkflow to scatter by region

### DIFF
--- a/definitions/subworkflows/pindel.cwl
+++ b/definitions/subworkflows/pindel.cwl
@@ -22,6 +22,9 @@ inputs:
     insert_size:
         type: int
         default: 400
+    scatter_count:
+        type: int
+        default: 50
 outputs:
     unfiltered_vcf:
         type: File
@@ -32,34 +35,35 @@ outputs:
         outputSource: filter/filtered_vcf
         secondaryFiles: [".tbi"]
 steps:
-    get_chromosome_list:
-        run: ../tools/get_chromosome_list.cwl
+    split_interval_list_to_bed:
+        run: ../tools/split_interval_list_to_bed.cwl
         in: 
             interval_list: interval_list
+            scatter_count: scatter_count
         out:
-            [chromosome_list]
+            [split_beds]
     pindel_cat:
-        scatter: chromosome
+        scatter: region_file
         run: pindel_cat.cwl
         in:
             reference: reference
             tumor_bam: tumor_bam
             normal_bam: normal_bam
-            chromosome: get_chromosome_list/chromosome_list
+            region_file: split_interval_list_to_bed/split_beds
             insert_size: insert_size
         out:
-            [per_chromosome_pindel_out]
+            [per_region_pindel_out]
     cat_all:
         run: ../tools/cat_all.cwl
         in:
-            chromosome_pindel_outs: pindel_cat/per_chromosome_pindel_out
+            region_pindel_outs: pindel_cat/per_region_pindel_out
         out:
-            [all_chromosome_pindel_head]
+            [all_region_pindel_head]
     somaticfilter:
         run: ../tools/pindel_somatic_filter.cwl
         in:
             reference: reference
-            pindel_output_summary: cat_all/all_chromosome_pindel_head
+            pindel_output_summary: cat_all/all_region_pindel_head
         out: 
             [vcf]
     bgzip:
@@ -74,18 +78,10 @@ steps:
             vcf: bgzip/bgzipped_file
         out:
             [indexed_vcf]
-    region_filter:
-        run: ../tools/select_variants.cwl
-        in:
-            reference: reference
-            vcf: index/indexed_vcf
-            interval_list: interval_list
-        out:
-            [filtered_vcf]
     remove_end_tags:
         run: ../tools/remove_end_tags.cwl
         in:
-            vcf: region_filter/filtered_vcf
+            vcf: index/indexed_vcf
         out:
             [processed_vcf]
     reindex:

--- a/definitions/subworkflows/pindel_cat.cwl
+++ b/definitions/subworkflows/pindel_cat.cwl
@@ -3,7 +3,7 @@
 cwlVersion: v1.0
 
 class: Workflow
-label: "Per-chromosome pindel"
+label: "Per-region pindel"
 requirements:
     - class: MultipleInputFeatureRequirement
 inputs:
@@ -15,13 +15,13 @@ inputs:
     normal_bam:
         type: File
         secondaryFiles: ["^.bai"]
-    chromosome:
-        type: string
+    region_file:
+        type: File
     insert_size:
         type: int
         default: 400
 outputs:
-    per_chromosome_pindel_out:
+    per_region_pindel_out:
         type: File
         outputSource: cat/pindel_out
 steps:
@@ -32,7 +32,7 @@ steps:
             tumor_bam: tumor_bam
             normal_bam: normal_bam
             insert_size: insert_size
-            chromosome: chromosome
+            region_file: region_file
         out:
             [deletions, insertions, tandems, long_insertions, inversions]
     cat:

--- a/definitions/tools/cat_all.cwl
+++ b/definitions/tools/cat_all.cwl
@@ -12,12 +12,12 @@ arguments: [
     { shellQuote: false, valueFrom: "|" },
     "/bin/grep", "ChrID", "/dev/stdin"
 ]
-stdout: "all_chromosome_pindel.head"
+stdout: "all_region_pindel.head"
 inputs:
-    chromosome_pindel_outs:
+    region_pindel_outs:
         type: File[]
         inputBinding:
             position: -1 
 outputs:
-    all_chromosome_pindel_head:
+    all_region_pindel_head:
         type: stdout

--- a/definitions/tools/pindel.cwl
+++ b/definitions/tools/pindel.cwl
@@ -9,7 +9,7 @@ arguments: [
 ]
 requirements:
     - class: ResourceRequirement
-      ramMin: 64000
+      ramMin: 16000
       tmpdirMin: 100000
       coresMin: 4
     - class: DockerRequirement

--- a/definitions/tools/pindel.cwl
+++ b/definitions/tools/pindel.cwl
@@ -13,7 +13,7 @@ requirements:
       tmpdirMin: 100000
       coresMin: 4
     - class: DockerRequirement
-      dockerPull: "mgibio/cle:v1.3.1"
+      dockerPull: "mgibio/cle:v1.4.2"
 inputs:
     tumor_bam:
         type: File

--- a/definitions/tools/split_interval_list_to_bed.cwl
+++ b/definitions/tools/split_interval_list_to_bed.cwl
@@ -2,21 +2,26 @@
 
 cwlVersion: v1.0
 class: CommandLineTool
-baseCommand: ['/usr/bin/perl', '/usr/bin/interval_to_bed_split.pl']
+baseCommand: ['/usr/bin/perl', '/usr/bin/split_interval_list_to_bed_helper.pl']
 requirements:
     - class: ResourceRequirement
       ramMin: 6000
     - class: DockerRequirement
-      dockerPull: mgibio/perl_helper-cwl:1.1.0
-arguments: [$(runtime.outdir)]
+      dockerPull: mgibio/cle:v1.4.2
+arguments:
+    [{ valueFrom: OUTPUT=$(runtime.outdir) }]
 inputs:
     interval_list:
         type: File
         inputBinding:
+            prefix: "INPUT="
+            separate: false
             position: 1
     scatter_count:
         type: int
         inputBinding:
+            prefix: "SCATTER_COUNT="
+            separate: false
             position: 2
 outputs:
     split_beds:

--- a/definitions/tools/split_interval_list_to_bed.cwl
+++ b/definitions/tools/split_interval_list_to_bed.cwl
@@ -1,0 +1,25 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: ['/usr/bin/perl', '/usr/bin/interval_to_bed_split.pl']
+requirements:
+    - class: ResourceRequirement
+      ramMin: 6000
+    - class: DockerRequirement
+      dockerPull: mgibio/perl_helper-cwl:1.1.0
+arguments: [$(runtime.outdir)]
+inputs:
+    interval_list:
+        type: File
+        inputBinding:
+            position: 1
+    scatter_count:
+        type: int
+        inputBinding:
+            position: 2
+outputs:
+    split_beds:
+        type: File[]
+        outputBinding:
+            glob: "*.interval.bed"


### PR DESCRIPTION
Currently pindel workflow scatters parallel run by chromosomes, which is inefficient and often consumes large memory on big chromosomes. This PR is to change pindel subworkflow scatter by target_region.
Refer to https://jira.ris.wustl.edu/browse/CI-391