### PR TITLE
Update depth-filter to 0.1.1

### DIFF
--- a/definitions/tools/filter_vcf_depth.cwl
+++ b/definitions/tools/filter_vcf_depth.cwl
@@ -5,7 +5,7 @@ class: CommandLineTool
 label: "filter variants at sites below a given sequence depth in each sample"
 requirements:
     - class: DockerRequirement
-      dockerPull: mgibio/depth-filter:0.1
+      dockerPull: mgibio/depth-filter:0.1.1
     - class: ResourceRequirement
       ramMin: 4000
 baseCommand: ["/opt/conda/bin/python3","/usr/bin/depth_filter.py"]


### PR DESCRIPTION
This has the fix for missing values that addresses genome/docker-depth-filter#1.