### PR TITLE
add output names to prevent file collisions in somatic mouse exome

### DIFF
--- a/definitions/subworkflows/align_sort_markdup.cwl
+++ b/definitions/subworkflows/align_sort_markdup.cwl
@@ -54,6 +54,7 @@ steps:
         run: ../tools/mark_duplicates_and_sort.cwl
         in:
             bam: name_sort/name_sorted_bam
+            output_name: final_name
         out:
             [sorted_bam, metrics_file]
     index_bam:

--- a/definitions/tools/mark_duplicates_and_sort.cwl
+++ b/definitions/tools/mark_duplicates_and_sort.cwl
@@ -27,7 +27,7 @@ requirements:
             fi
 arguments:
     - position: 2
-      valueFrom: $(runtime.cores)
+      valueFrom: "$(runtime.cores)"
     - position: 4
       valueFrom: "$(inputs.bam.nameroot).mark_dups_metrics.txt"
 inputs:
@@ -40,7 +40,7 @@ inputs:
         default: "queryname"
         inputBinding:
             position: 5
-     output_name:
+    output_name:
         type: string?
         default: 'MarkedSorted.bam'
         inputBinding:

--- a/definitions/tools/mark_duplicates_and_sort.cwl
+++ b/definitions/tools/mark_duplicates_and_sort.cwl
@@ -28,8 +28,6 @@ requirements:
 arguments:
     - position: 2
       valueFrom: $(runtime.cores)
-    - position: 3
-      valueFrom: $(runtime.outdir)/MarkedSorted.bam
     - position: 4
       valueFrom: "$(inputs.bam.nameroot).mark_dups_metrics.txt"
 inputs:
@@ -42,12 +40,16 @@ inputs:
         default: "queryname"
         inputBinding:
             position: 5
-    
+     output_name:
+        type: string?
+        default: 'MarkedSorted.bam'
+        inputBinding:
+            position: 3
 outputs:
     sorted_bam:
         type: File
         outputBinding:
-            glob: "MarkedSorted.bam"
+            glob: $(inputs.output_name)
         secondaryFiles: [.bai]
     metrics_file:
         type: File


### PR DESCRIPTION
Since somatic_exome_mouse.cwl doesn't run bqsr, the tumor and normal bams never get renamed, as they do in the human workflow.  This renames them at the markdup step instead 