### PR TITLE
bumping to 0.1.2 to remove PASS values when filtering

### DIFF
--- a/definitions/tools/filter_vcf_depth.cwl
+++ b/definitions/tools/filter_vcf_depth.cwl
@@ -5,7 +5,7 @@ class: CommandLineTool
 label: "filter variants at sites below a given sequence depth in each sample"
 requirements:
     - class: DockerRequirement
-      dockerPull: mgibio/depth-filter:0.1
+      dockerPull: mgibio/depth-filter:0.1.2
     - class: ResourceRequirement
       ramMin: 4000
 baseCommand: ["/opt/conda/bin/python3","/usr/bin/depth_filter.py"]


### PR DESCRIPTION
See here for the actual commit: 
https://github.com/genome/docker-depth-filter/commit/c14569ac8d88b4f226a77e975c913bb1f632f81c

using the built-in `add_filter` function correctly removes PASS values when filtering a line (instead of appending the filters and ending up with nonsense like "PASS,DEPTHFILTER"