### PR TITLE
Fixing strandedness settings in RNAseq pipeline

### DIFF
--- a/definitions/pipelines/rnaseq.cwl
+++ b/definitions/pipelines/rnaseq.cwl
@@ -101,13 +101,7 @@ steps:
         in:
             kallisto_index: kallisto_index
             strand: strand
-            fastqs:
-                source: bam_to_trimmed_fastq_and_hisat_alignments/fastqs
-                valueFrom: |
-                    ${
-                      for(var i=0;i<self.length;i++){self[i] = self[i].reverse()}
-                      return(self)
-                     }
+            fastqs: bam_to_trimmed_fastq_and_hisat_alignments/fastqs
         out:
             [expression_transcript_table,expression_transcript_h5,fusion_evidence]
     transcript_to_gene:

--- a/definitions/tools/generate_qc_metrics.cwl
+++ b/definitions/tools/generate_qc_metrics.cwl
@@ -28,14 +28,14 @@ inputs:
           - "null"
           - type: enum
             symbols: ["first", "second", "unstranded"]
-        inputBinding:
-            valueFrom: |
+        inputBinding:      # the mismatch between first and second here is intentional (and the nomenclature clash is stupid)
+            valueFrom: |   # see https://github.com/griffithlab/rnaseq_tutorial/blob/master/manuscript/supplementary_tables/supplementary_table_5.md
                 ${
                     if (inputs.strand) {
-                        if (inputs.strand == 'first') {
-                            return ['STRAND=FIRST_READ_TRANSCRIPTION_STRAND'];
-                        } else if (inputs.strand == 'second') {
+                        if (inputs.strand == 'first') {  
                             return ['STRAND=SECOND_READ_TRANSCRIPTION_STRAND'];
+                        } else if (inputs.strand == 'second') {
+                            return ['STRAND=FIRST_READ_TRANSCRIPTION_STRAND'];
                         } else {
                             return ['STRAND=NONE'];
                         }


### PR DESCRIPTION
This fixes the errors outlined in issues https://github.com/genome/analysis-workflows/issues/658 and https://github.com/genome/analysis-workflows/issues/659, related to strandedness settings in QC, and to fastq order in Kallisto
