### PR TITLE
Add aml_trio cwl pipeline

### DIFF
--- a/definitions/pipelines/cle_aml_trio.cwl
+++ b/definitions/pipelines/cle_aml_trio.cwl
@@ -1,0 +1,614 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+label: "Replace legacy AML Trio Assay"
+requirements:
+    - class: SchemaDefRequirement
+      types:
+          - $import: ../types/labelled_file.yml
+    - class: SubworkflowFeatureRequirement
+    - class: StepInputExpressionRequirement
+inputs:
+    reference: string
+    tumor_bams:
+        type: File[]
+    tumor_readgroups:
+        type: string[]
+    tumor_name:
+        type: string?
+        default: 'tumor'
+    normal_bams:
+        type: File[]
+    normal_readgroups:
+        type: string[]
+    normal_name:
+        type: string?
+        default: 'normal'
+    followup_bams:
+        type: File[]
+    followup_readgroups:
+        type: string[]
+    followup_name:
+        type: string?
+        default: 'followup'
+    mills:
+        type: File
+        secondaryFiles: [.tbi]
+    known_indels:
+        type: File
+        secondaryFiles: [.tbi]
+    dbsnp_vcf:
+        type: File
+        secondaryFiles: [.tbi]
+    bqsr_intervals:
+        type: string[]
+    bait_intervals:
+        type: File
+    target_intervals:
+        type: File
+    per_base_intervals:
+        type: ../types/labelled_file.yml#labelled_file[]
+    per_target_intervals:
+        type: ../types/labelled_file.yml#labelled_file[]
+    summary_intervals:
+        type: ../types/labelled_file.yml#labelled_file[]
+    omni_vcf:
+        type: File
+        secondaryFiles: [.tbi]
+    emit_reference_confidence:
+        type: string
+    gvcf_gq_bands:
+        type: string[]
+    intervals:
+        type:
+            type: array
+            items:
+                type: array
+                items: string
+    variant_reporting_intervals:
+        type: File    
+    picard_metric_accumulation_level:
+        type: string
+    qc_minimum_mapping_quality:
+        type: int?
+        default: 0
+    qc_minimum_base_quality:
+        type: int?
+        default: 0
+    interval_list:
+        type: File
+    cosmic_vcf:
+        type: File?
+        secondaryFiles: [.tbi]
+    panel_of_normals_vcf:
+        type: File?
+        secondaryFiles: [.tbi]
+    strelka_cpu_reserved:
+        type: int?
+        default: 8
+    mutect_scatter_count:
+        type: int
+    mutect_artifact_detection_mode:
+        type: boolean
+        default: false
+    mutect_max_alt_allele_in_normal_fraction:
+        type: float?
+    mutect_max_alt_alleles_in_normal_count:
+        type: int?
+    varscan_strand_filter:
+        type: int?
+        default: 0
+    varscan_min_coverage:
+        type: int?
+        default: 8
+    varscan_min_var_freq:
+        type: float?
+        default: 0.05
+    varscan_p_value:
+        type: float?
+        default: 0.99
+    varscan_max_normal_freq:
+        type: float?
+    pindel_region_file:
+        type: File
+    pindel_insert_size:
+        type: int
+        default: 400
+    docm_vcf:
+        type: File
+        secondaryFiles: [.tbi]
+    filter_docm_variants:
+        type: boolean?
+        default: true
+    filter_minimum_depth:
+        type: int?
+        default: 20
+    vep_cache_dir:
+        type: string
+    synonyms_file:
+        type: File?
+    annotate_coding_only:
+        type: boolean?
+    germline_coding_only:
+        type: boolean?
+    vep_pick:
+        type:
+            - "null"
+            - type: enum
+              symbols: ["pick", "flag_pick", "pick_allele", "per_gene", "pick_allele_gene", "flag_pick_allele", "flag_pick_allele_gene"]
+    cle_vcf_filter:
+        type: boolean
+        default: true
+    variants_to_table_fields:
+        type: string[]
+        default: [CHROM,POS,ID,REF,ALT,set,AC,AF]
+    variants_to_table_genotype_fields:
+        type: string[]
+        default: [GT,AD]
+    vep_to_table_fields:
+        type: string[]
+        default: [HGVSc,HGVSp]
+    vep_ensembl_assembly:
+        type: string
+        doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"
+    vep_ensembl_version:
+        type: string
+        doc: "ensembl version - Must be present in the cache directory. Example: 95"
+    vep_ensembl_species:
+        type: string
+        doc: "ensembl species - Must be present in the cache directory. Examples: homo_sapiens or mus_musculus"
+    somalier_vcf:
+        type: File
+    custom_gnomad_vcf:
+        type: File?
+        secondaryFiles: [.tbi]
+    custom_clinvar_vcf:
+        type: File?
+        secondaryFiles: [.tbi]
+    germline_tsv_prefix:
+        type: string?
+        default: 'germline_variants'
+    germline_variants_to_table_fields:
+        type: string[]
+        default: [CHROM,POS,ID,REF,ALT,AC,AF]
+    germline_variants_to_table_genotype_fields:
+        type: string[]
+        default: [GT,AD]
+    germline_vep_to_table_fields:
+        type: string[]
+        default: [HGVSc,HGVSp]
+outputs:
+    tumor_cram:
+        type: File
+        outputSource: tumor_index_cram/indexed_cram
+    tumor_mark_duplicates_metrics:
+        type: File
+        outputSource: tumor_alignment_and_qc/mark_duplicates_metrics
+    tumor_insert_size_metrics:
+        type: File
+        outputSource: tumor_alignment_and_qc/insert_size_metrics
+    tumor_alignment_summary_metrics:
+        type: File
+        outputSource: tumor_alignment_and_qc/alignment_summary_metrics
+    tumor_hs_metrics:
+        type: File
+        outputSource: tumor_alignment_and_qc/hs_metrics
+    tumor_summary_hs_metrics:
+        type: File[]
+        outputSource: tumor_alignment_and_qc/summary_hs_metrics
+    tumor_flagstats:
+        type: File
+        outputSource: tumor_alignment_and_qc/flagstats
+    tumor_verify_bam_id_metrics:
+        type: File
+        outputSource: tumor_alignment_and_qc/verify_bam_id_metrics
+    tumor_verify_bam_id_depth:
+        type: File
+        outputSource: tumor_alignment_and_qc/verify_bam_id_depth
+    normal_cram:
+        type: File
+        outputSource: normal_index_cram/indexed_cram
+    normal_mark_duplicates_metrics:
+        type: File
+        outputSource: normal_alignment_and_qc/mark_duplicates_metrics
+    normal_insert_size_metrics:
+        type: File
+        outputSource: normal_alignment_and_qc/insert_size_metrics
+    normal_alignment_summary_metrics:
+        type: File
+        outputSource: normal_alignment_and_qc/alignment_summary_metrics
+    normal_hs_metrics:
+        type: File
+        outputSource: normal_alignment_and_qc/hs_metrics
+    normal_summary_hs_metrics:
+        type: File[]
+        outputSource: normal_alignment_and_qc/summary_hs_metrics
+    normal_flagstats:
+        type: File
+        outputSource: normal_alignment_and_qc/flagstats
+    normal_verify_bam_id_metrics:
+        type: File
+        outputSource: normal_alignment_and_qc/verify_bam_id_metrics
+    normal_verify_bam_id_depth:
+        type: File
+        outputSource: normal_alignment_and_qc/verify_bam_id_depth
+    mutect_unfiltered_vcf:
+        type: File
+        outputSource: tumor_detect_variants/mutect_unfiltered_vcf
+        secondaryFiles: [.tbi]
+    mutect_filtered_vcf:
+        type: File
+        outputSource: tumor_detect_variants/mutect_filtered_vcf
+        secondaryFiles: [.tbi]
+    strelka_unfiltered_vcf:
+        type: File
+        outputSource: tumor_detect_variants/strelka_unfiltered_vcf
+        secondaryFiles: [.tbi]
+    strelka_filtered_vcf:
+        type: File
+        outputSource: tumor_detect_variants/strelka_filtered_vcf
+        secondaryFiles: [.tbi]
+    varscan_unfiltered_vcf:
+        type: File
+        outputSource: tumor_detect_variants/varscan_unfiltered_vcf
+        secondaryFiles: [.tbi]
+    varscan_filtered_vcf:
+        type: File
+        outputSource: tumor_detect_variants/varscan_filtered_vcf
+        secondaryFiles: [.tbi]
+    pindel_unfiltered_vcf:
+        type: File
+        outputSource: tumor_detect_variants/pindel_unfiltered_vcf
+        secondaryFiles: [.tbi]
+    pindel_filtered_vcf:
+        type: File
+        outputSource: tumor_detect_variants/pindel_filtered_vcf
+        secondaryFiles: [.tbi]
+    docm_filtered_vcf:
+        type: File
+        outputSource: tumor_detect_variants/docm_filtered_vcf
+        secondaryFiles: [.tbi]
+    pindel_region_vcf:
+        type: File
+        outputSource: pindel_region/pindel_region_vcf
+        secondaryFiles: [.tbi]
+    tumor_snv_bam_readcount_tsv:
+        type: File
+        outputSource: tumor_detect_variants/tumor_snv_bam_readcount_tsv
+    tumor_indel_bam_readcount_tsv:
+        type: File
+        outputSource: tumor_detect_variants/tumor_indel_bam_readcount_tsv
+    normal_snv_bam_readcount_tsv:
+        type: File
+        outputSource: tumor_detect_variants/normal_snv_bam_readcount_tsv
+    normal_indel_bam_readcount_tsv:
+        type: File
+        outputSource: tumor_detect_variants/normal_indel_bam_readcount_tsv
+    followup_cram:
+        type: File
+        outputSource: followup_index_cram/indexed_cram
+    followup_snv_bam_readcount_tsv:
+        type: File
+        outputSource: followup_bam_readcount/snv_bam_readcount_tsv
+    followup_indel_bam_readcount_tsv:
+        type: File
+        outputSource: followup_bam_readcount/indel_bam_readcount_tsv
+    tumor_final_vcf:
+        type: File
+        outputSource: tumor_detect_variants/final_vcf
+        secondaryFiles: [.tbi]
+    tumor_final_filtered_vcf:
+        type: File
+        outputSource: tumor_detect_variants/final_filtered_vcf
+        secondaryFiles: [.tbi]
+    tumor_final_tsv:
+        type: File
+        outputSource: tumor_detect_variants/final_tsv
+    tumor_vep_summary:
+        type: File
+        outputSource: tumor_detect_variants/vep_summary
+    germline_final_vcf:
+        type: File
+        outputSource: germline_detect_variants/final_vcf
+        secondaryFiles: [.tbi]
+    germline_coding_vcf:
+        type: File
+        outputSource: germline_detect_variants/coding_vcf
+        secondaryFiles: [.tbi]
+    germline_limited_vcf:
+        type: File
+        outputSource: germline_detect_variants/limited_vcf
+        secondaryFiles: [.tbi]
+    germline_final_tsv:
+        type: File
+        outputSource: germline_add_vep_fields_to_table/annotated_variants_tsv
+    somalier_concordance_metrics:
+        type: File
+        outputSource: concordance/somalier_pairs
+    somalier_concordance_statistics:
+        type: File
+        outputSource: concordance/somalier_samples
+    alignment_stat_report:
+        type: File
+        outputSource: alignment_stat_report/alignment_stat
+    coverage_stat_report:
+        type: File
+        outputSource: coverage_stat_report/coverage_stat
+    full_variant_report:
+        type: File
+        outputSource:: full_variant_report/full_variant_report
+steps:
+    normal_alignment_and_qc:
+        run: exome_alignment.cwl
+        in:
+            reference: reference
+            bams: normal_bams
+            readgroups: normal_readgroups
+            mills: mills
+            known_indels: known_indels
+            dbsnp_vcf: dbsnp_vcf
+            bqsr_intervals: bqsr_intervals
+            bait_intervals: bait_intervals
+            target_intervals: target_intervals
+            per_base_intervals: per_base_intervals
+            per_target_intervals: per_target_intervals
+            summary_intervals: summary_intervals
+            omni_vcf: omni_vcf
+            picard_metric_accumulation_level: picard_metric_accumulation_level   
+            minimum_mapping_quality: qc_minimum_mapping_quality
+            minimum_base_quality: qc_minimum_base_quality
+            final_name:
+                source: normal_name
+                valueFrom: "$(self).bam"
+        out:
+            [bam, mark_duplicates_metrics, insert_size_metrics, alignment_summary_metrics, hs_metrics, summary_hs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]
+    tumor_alignment_and_qc:
+        run: exome_alignment.cwl
+        in:
+            reference: reference
+            bams: tumor_bams
+            readgroups: tumor_readgroups
+            mills: mills
+            known_indels: known_indels
+            dbsnp_vcf: dbsnp_vcf
+            bqsr_intervals: bqsr_intervals
+            bait_intervals: bait_intervals
+            target_intervals: target_intervals
+            per_base_intervals: per_base_intervals
+            per_target_intervals: per_target_intervals
+            summary_intervals: summary_intervals
+            omni_vcf: omni_vcf
+            picard_metric_accumulation_level: picard_metric_accumulation_level   
+            minimum_mapping_quality: qc_minimum_mapping_quality
+            minimum_base_quality: qc_minimum_base_quality
+            final_name:
+                source: tumor_name
+                valueFrom: "$(self).bam"
+        out:
+            [bam, mark_duplicates_metrics, insert_size_metrics, alignment_summary_metrics, hs_metrics, summary_hs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]
+    followup_alignment_and_qc:
+        run: exome_alignment.cwl
+        in:
+            reference: reference
+            bams: followup_bams
+            readgroups: followup_readgroups
+            mills: mills
+            known_indels: known_indels
+            dbsnp_vcf: dbsnp_vcf
+            bqsr_intervals: bqsr_intervals
+            bait_intervals: bait_intervals
+            target_intervals: target_intervals
+            per_base_intervals: per_base_intervals
+            per_target_intervals: per_target_intervals
+            summary_intervals: summary_intervals
+            omni_vcf: omni_vcf
+            picard_metric_accumulation_level: picard_metric_accumulation_level   
+            minimum_mapping_quality: qc_minimum_mapping_quality
+            minimum_base_quality: qc_minimum_base_quality
+            final_name:
+                source: followup_name
+                valueFrom: "$(self).bam"
+        out:
+            [bam, mark_duplicates_metrics, insert_size_metrics, alignment_summary_metrics, hs_metrics, summary_hs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]
+    concordance:
+        run: ../tools/concordance.cwl
+        in:
+            reference: reference
+            bam_1: tumor_alignment_and_qc/bam
+            bam_2: normal_alignment_and_qc/bam
+            vcf: somalier_vcf
+        out:
+            [somalier_pairs, somalier_samples]
+    tumor_detect_variants:
+        run: detect_variants.cwl
+        in:
+            reference: reference
+            tumor_bam: tumor_alignment_and_qc/bam
+            normal_bam: normal_alignment_and_qc/bam
+            interval_list: interval_list
+            dbsnp_vcf: dbsnp_vcf
+            cosmic_vcf: cosmic_vcf
+            panel_of_normals_vcf: panel_of_normals_vcf
+            strelka_exome_mode:
+                default: true
+            strelka_cpu_reserved: strelka_cpu_reserved
+            mutect_scatter_count: mutect_scatter_count
+            mutect_artifact_detection_mode: mutect_artifact_detection_mode
+            mutect_max_alt_allele_in_normal_fraction: mutect_max_alt_allele_in_normal_fraction
+            mutect_max_alt_alleles_in_normal_count: mutect_max_alt_alleles_in_normal_count
+            varscan_strand_filter: varscan_strand_filter
+            varscan_min_coverage: varscan_min_coverage
+            varscan_min_var_freq: varscan_min_var_freq
+            varscan_p_value: varscan_p_value
+            varscan_max_normal_freq: varscan_max_normal_freq
+            pindel_insert_size: pindel_insert_size
+            docm_vcf: docm_vcf
+            filter_docm_variants: filter_docm_variants
+            filter_minimum_depth: filter_minimum_depth
+            vep_ensembl_assembly: vep_ensembl_assembly
+            vep_ensembl_version: vep_ensembl_version
+            vep_ensembl_species: vep_ensembl_species
+            vep_cache_dir: vep_cache_dir
+            synonyms_file: synonyms_file
+            annotate_coding_only: annotate_coding_only
+            vep_pick: vep_pick
+            cle_vcf_filter: cle_vcf_filter
+            variants_to_table_fields: variants_to_table_fields
+            variants_to_table_genotype_fields: variants_to_table_genotype_fields
+            vep_to_table_fields: vep_to_table_fields
+            custom_gnomad_vcf: custom_gnomad_vcf
+            custom_clinvar_vcf: custom_clinvar_vcf
+        out:
+            [mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv]
+    pindel_region:
+        run: ../subworkflows/pindel_region.cwl
+        in:
+            reference: reference
+            tumor_bam: tumor_alignment_and_qc/bam
+            normal_bam: normal_alignment_and_qc/bam
+            region_file: pindel_region_file
+            insert_size: pindel_insert_size
+        out:
+            [pindel_region_vcf]
+    followup_bam_readcount:
+        run: ../tools/bam_readcount.cwl
+        in:
+            vcf: tumor_detect_variants/final_filtered_vcf
+            sample:
+                default: 'TUMOR'
+            reference_fasta: reference
+            bam: followup_alignment_and_qc/bam
+            prefix: followup_name
+        out:
+            [snv_bam_readcount_tsv, indel_bam_readcount_tsv]
+    extract_freemix:
+        in:
+            verify_bam_id_metrics: normal_alignment_and_qc/verify_bam_id_metrics
+        out:
+            [freemix_score]
+        run:
+            class: ExpressionTool
+            requirements:
+                - class: InlineJavascriptRequirement
+            inputs:
+                verify_bam_id_metrics:
+                    type: File
+                    inputBinding:
+                        loadContents: true
+            outputs:
+                freemix_score:
+                    type: string?
+            expression: |
+                        ${
+                            var metrics = inputs.verify_bam_id_metrics.contents.split("\n");
+                            if ( metrics[0].split("\t")[6] == 'FREEMIX' ) {
+                                return {'freemix_score': metrics[1].split("\t")[6]};
+                            } else {
+                                return {'freemix_score:': null };
+                            }
+                        }
+    germline_detect_variants:
+        run: ../subworkflows/germline_detect_variants.cwl
+        in:
+            reference: reference
+            bam: normal_alignment_and_qc/bam
+            emit_reference_confidence: emit_reference_confidence
+            gvcf_gq_bands: gvcf_gq_bands
+            intervals: intervals
+            contamination_fraction: extract_freemix/freemix_score
+            vep_cache_dir: vep_cache_dir
+            vep_ensembl_assembly: vep_ensembl_assembly
+            vep_ensembl_version: vep_ensembl_version
+            vep_ensembl_species: vep_ensembl_species
+            synonyms_file: synonyms_file
+            annotate_coding_only: germline_coding_only
+            custom_gnomad_vcf: custom_gnomad_vcf
+            limit_variant_intervals: variant_reporting_intervals
+            custom_clinvar_vcf: custom_clinvar_vcf
+        out:
+            [final_vcf, coding_vcf, limited_vcf]
+    germline_variants_to_table:
+        run: ../tools/variants_to_table.cwl
+        in:
+            reference: reference
+            vcf: germline_detect_variants/limited_vcf
+            fields: germline_variants_to_table_fields
+            genotype_fields: germline_variants_to_table_genotype_fields
+        out:
+            [variants_tsv]
+    germline_add_vep_fields_to_table:
+        run: ../tools/add_vep_fields_to_table.cwl
+        in:
+            vcf: germline_detect_variants/limited_vcf
+            vep_fields: germline_vep_to_table_fields
+            tsv: germline_variants_to_table/variants_tsv
+            prefix: germline_tsv_prefix 
+        out: [annotated_variants_tsv]
+    alignment_stat_report:
+        run: ../tools/cle_aml_trio_report_alignment_stat.cwl
+        in:
+            normal_alignment_summary_metrics: normal_alignment_and_qc/alignment_summary_metrics
+            tumor_alignment_summary_metrics: tumor_alignment_and_qc/alignment_summary_metrics
+            followup_alignment_summary_metrics: followup_alignment_and_qc/alignment_summary_metrics
+        out:
+            [alignment_stat]
+    coverage_stat_report:
+        run: ../tools/cle_aml_trio_report_coverage_stat.cwl
+        in:
+            normal_roi_hs_metrics: normal_alignment_and_qc/hs_metrics
+            normal_summary_hs_metrics: [normal_alignment_and_qc/summary_hs_metrics]
+            tumor_roi_hs_metrics: tumor_alignment_and_qc/hs_metrics
+            tumor_summary_hs_metrics: [tumor_alignment_and_qc/summary_hs_metrics]
+            followup_roi_hs_metrics: followup_alignment_and_qc/hs_metrics
+            followup_summary_hs_metrics: [followup_alignment_and_qc/summary_hs_metrics]
+        out:
+            [coverage_stat]
+    full_variant_report:
+        run: ../tools/cle_aml_trio_report_full_variants.cwl
+        in: 
+            variant_tsv: tumor_detect_variants/final_tsv
+            followup_snv_bam_readcount: followup_bam_readcount/snv_bam_readcount_tsv
+            followup_indel_bam_readcount: followup_bam_readcount/indel_bam_readcount_tsv
+            pindel_region_vcf: pindel_region/pindel_region_vcf
+        out:
+            [full_variant_report]       
+    normal_bam_to_cram:
+        run: ../tools/bam_to_cram.cwl
+        in:
+            bam: normal_alignment_and_qc/bam
+            reference: reference
+        out:
+            [cram]
+    normal_index_cram:
+         run: ../tools/index_cram.cwl
+         in:
+            cram: normal_bam_to_cram/cram
+         out:
+            [indexed_cram]
+    tumor_bam_to_cram:
+        run: ../tools/bam_to_cram.cwl
+        in:
+            bam: tumor_alignment_and_qc/bam
+            reference: reference
+        out:
+            [cram]
+    tumor_index_cram:
+         run: ../tools/index_cram.cwl
+         in:
+            cram: tumor_bam_to_cram/cram
+         out:
+            [indexed_cram]
+    followup_bam_to_cram:
+        run: ../tools/bam_to_cram.cwl
+        in:
+            bam: followup_alignment_and_qc/bam
+            reference: reference
+        out:
+            [cram]
+    followup_index_cram:
+         run: ../tools/index_cram.cwl
+         in:
+            cram: followup_bam_to_cram/cram
+         out:
+            [indexed_cram]

--- a/definitions/pipelines/cle_aml_trio.cwl
+++ b/definitions/pipelines/cle_aml_trio.cwl
@@ -417,6 +417,7 @@ steps:
             reference: reference
             bam_1: tumor_alignment_and_qc/bam
             bam_2: normal_alignment_and_qc/bam
+            bam_3: followup_alignment_and_qc/bam
             vcf: somalier_vcf
         out:
             [somalier_pairs, somalier_samples]

--- a/definitions/pipelines/gathered_cle_aml_trio.cwl
+++ b/definitions/pipelines/gathered_cle_aml_trio.cwl
@@ -1,0 +1,288 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+label: "gather AML trio outputs"
+requirements:
+    - class: SchemaDefRequirement
+      types:
+          - $import: ../types/labelled_file.yml
+    - class: SubworkflowFeatureRequirement
+    - class: StepInputExpressionRequirement
+inputs:
+    reference: string
+    tumor_bams:
+        type: File[]
+    tumor_readgroups:
+        type: string[]
+    tumor_name:
+        type: string?
+        default: 'tumor'
+    normal_bams:
+        type: File[]
+    normal_readgroups:
+        type: string[]
+    normal_name:
+        type: string?
+        default: 'normal'
+    followup_bams:
+        type: File[]
+    followup_readgroups:
+        type: string[]
+    followup_name:
+        type: string?
+        default: 'followup'
+    mills:
+        type: File
+        secondaryFiles: [.tbi]
+    known_indels:
+        type: File
+        secondaryFiles: [.tbi]
+    dbsnp_vcf:
+        type: File
+        secondaryFiles: [.tbi]
+    bqsr_intervals:
+        type: string[]
+    bait_intervals:
+        type: File
+    target_intervals:
+        type: File
+    per_base_intervals:
+        type: ../types/labelled_file.yml#labelled_file[]
+    per_target_intervals:
+        type: ../types/labelled_file.yml#labelled_file[]
+    summary_intervals:
+        type: ../types/labelled_file.yml#labelled_file[]
+    omni_vcf:
+        type: File
+        secondaryFiles: [.tbi]
+    emit_reference_confidence:
+        type: string
+    gvcf_gq_bands:
+        type: string[]
+    intervals:
+        type:
+            type: array
+            items:
+                type: array
+                items: string
+    variant_reporting_intervals:
+        type: File    
+    picard_metric_accumulation_level:
+        type: string
+    qc_minimum_mapping_quality:
+        type: int?
+        default: 0
+    qc_minimum_base_quality:
+        type: int?
+        default: 0
+    interval_list:
+        type: File
+    cosmic_vcf:
+        type: File?
+        secondaryFiles: [.tbi]
+    panel_of_normals_vcf:
+        type: File?
+        secondaryFiles: [.tbi]
+    strelka_cpu_reserved:
+        type: int?
+        default: 8
+    mutect_scatter_count:
+        type: int
+    mutect_artifact_detection_mode:
+        type: boolean
+        default: false
+    mutect_max_alt_allele_in_normal_fraction:
+        type: float?
+    mutect_max_alt_alleles_in_normal_count:
+        type: int?
+    varscan_strand_filter:
+        type: int?
+        default: 0
+    varscan_min_coverage:
+        type: int?
+        default: 8
+    varscan_min_var_freq:
+        type: float?
+        default: 0.05
+    varscan_p_value:
+        type: float?
+        default: 0.99
+    varscan_max_normal_freq:
+        type: float?
+    pindel_region_file:
+        type: File
+    pindel_insert_size:
+        type: int
+        default: 400
+    docm_vcf:
+        type: File
+        secondaryFiles: [.tbi]
+    filter_docm_variants:
+        type: boolean?
+        default: true
+    filter_minimum_depth:
+        type: int?
+        default: 20
+    vep_cache_dir:
+        type: string
+    vep_ensembl_assembly:
+        type: string
+        doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"
+    vep_ensembl_version:
+        type: string
+        doc: "ensembl version - Must be present in the cache directory. Example: 95"
+    vep_ensembl_species:
+        type: string
+        doc: "ensembl species - Must be present in the cache directory. Examples: homo_sapiens or mus_musculus"
+    synonyms_file:
+        type: File?
+    annotate_coding_only:
+        type: boolean?
+    germline_coding_only:
+        type: boolean?
+    vep_pick:
+        type:
+            - "null"
+            - type: enum
+              symbols: ["pick", "flag_pick", "pick_allele", "per_gene", "pick_allele_gene", "flag_pick_allele", "flag_pick_allele_gene"]
+    cle_vcf_filter:
+        type: boolean
+        default: true
+    variants_to_table_fields:
+        type: string[]
+        default: [CHROM,POS,ID,REF,ALT,set,AC,AF]
+    variants_to_table_genotype_fields:
+        type: string[]
+        default: [GT,AD]
+    vep_to_table_fields:
+        type: string[]
+        default: [HGVSc,HGVSp]
+    custom_gnomad_vcf:
+        type: File?
+        secondaryFiles: [.tbi]
+    custom_clinvar_vcf:
+        type: File?
+        secondaryFiles: [.tbi]
+    germline_tsv_prefix:
+        type: string?
+        default: 'germline_variants'
+    germline_variants_to_table_fields:
+        type: string[]
+        default: [CHROM,POS,ID,REF,ALT,AC,AF]
+    germline_variants_to_table_genotype_fields:
+        type: string[]
+        default: [GT,AD]
+    germline_vep_to_table_fields:
+        type: string[]
+        default: [HGVSc,HGVSp]
+    somalier_vcf:
+        type: File
+    output_dir: 
+        type: string
+outputs:
+    final_outputs:
+        type: string[]
+        outputSource: gatherer/gathered_files
+steps:
+    aml_trio:
+        run: cle_aml_trio.cwl
+        in:
+            reference: reference
+            tumor_bams: tumor_bams
+            tumor_readgroups: tumor_readgroups
+            tumor_name: tumor_name
+            normal_bams: normal_bams
+            normal_readgroups: normal_readgroups
+            normal_name: normal_name
+            followup_bams: followup_bams
+            followup_readgroups: followup_readgroups
+            followup_name: followup_name
+            mills: mills
+            known_indels: known_indels
+            dbsnp_vcf: dbsnp_vcf
+            bqsr_intervals: bqsr_intervals
+            bait_intervals: bait_intervals
+            target_intervals: target_intervals
+            per_base_intervals: per_base_intervals
+            per_target_intervals: per_target_intervals
+            summary_intervals: summary_intervals
+            omni_vcf: omni_vcf
+            emit_reference_confidence: emit_reference_confidence
+            gvcf_gq_bands: gvcf_gq_bands
+            intervals: intervals
+            variant_reporting_intervals: variant_reporting_intervals
+            picard_metric_accumulation_level: picard_metric_accumulation_level   
+            qc_minimum_mapping_quality: qc_minimum_mapping_quality
+            qc_minimum_base_quality: qc_minimum_base_quality
+            interval_list: interval_list
+            cosmic_vcf: cosmic_vcf
+            panel_of_normals_vcf: panel_of_normals_vcf
+            strelka_cpu_reserved: strelka_cpu_reserved
+            mutect_scatter_count: mutect_scatter_count
+            mutect_artifact_detection_mode: mutect_artifact_detection_mode
+            mutect_max_alt_allele_in_normal_fraction: mutect_max_alt_allele_in_normal_fraction
+            mutect_max_alt_alleles_in_normal_count: mutect_max_alt_alleles_in_normal_count
+            varscan_strand_filter: varscan_strand_filter
+            varscan_min_coverage: varscan_min_coverage
+            varscan_min_var_freq: varscan_min_var_freq
+            varscan_p_value: varscan_p_value
+            varscan_max_normal_freq: varscan_max_normal_freq
+            pindel_region_file: pindel_region_file
+            pindel_insert_size: pindel_insert_size
+            docm_vcf: docm_vcf
+            filter_docm_variants: filter_docm_variants
+            filter_minimum_depth: filter_minimum_depth
+            vep_cache_dir: vep_cache_dir
+            vep_ensembl_assembly: vep_ensembl_assembly
+            vep_ensembl_version: vep_ensembl_version
+            vep_ensembl_species: vep_ensembl_species
+            synonyms_file: synonyms_file
+            annotate_coding_only: annotate_coding_only
+            germline_coding_only: germline_coding_only
+            vep_pick: vep_pick
+            cle_vcf_filter: cle_vcf_filter
+            variants_to_table_fields: variants_to_table_fields
+            variants_to_table_genotype_fields: variants_to_table_genotype_fields
+            vep_to_table_fields: vep_to_table_fields
+            custom_gnomad_vcf: custom_gnomad_vcf
+            custom_clinvar_vcf: custom_clinvar_vcf
+            somalier_vcf: somalier_vcf
+            germline_tsv_prefix: germline_tsv_prefix
+            germline_variants_to_table_fields: germline_variants_to_table_fields
+            germline_variants_to_table_genotype_fields: germline_variants_to_table_genotype_fields
+            germline_vep_to_table_fields: germline_vep_to_table_fields 
+        out:
+            [tumor_cram, tumor_mark_duplicates_metrics, tumor_insert_size_metrics, tumor_alignment_summary_metrics, tumor_hs_metrics, tumor_summary_hs_metrics, tumor_flagstats, tumor_verify_bam_id_metrics, tumor_verify_bam_id_depth, normal_cram, normal_mark_duplicates_metrics, normal_insert_size_metrics, normal_alignment_summary_metrics, normal_hs_metrics, normal_summary_hs_metrics, normal_flagstats, normal_verify_bam_id_metrics, normal_verify_bam_id_depth, followup_cram, mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, docm_filtered_vcf, pindel_region_vcf, tumor_final_vcf, tumor_final_filtered_vcf, tumor_final_tsv, tumor_vep_summary, germline_final_vcf, germline_coding_vcf, germline_limited_vcf, germline_final_tsv, alignment_stat_report, coverage_stat_report, full_variant_report, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv, followup_snv_bam_readcount_tsv, followup_indel_bam_readcount_tsv, somalier_concordance_metrics, somalier_concordance_statistics]
+    gatherer:
+        run: ../tools/gatherer.cwl
+        in:
+            output_dir: output_dir
+            all_files:
+                source: [aml_trio/tumor_cram, aml_trio/tumor_mark_duplicates_metrics, aml_trio/tumor_insert_size_metrics, aml_trio/tumor_alignment_summary_metrics, aml_trio/tumor_hs_metrics, aml_trio/tumor_summary_hs_metrics, aml_trio/tumor_flagstats, aml_trio/tumor_verify_bam_id_metrics, aml_trio/tumor_verify_bam_id_depth, aml_trio/normal_cram, aml_trio/normal_mark_duplicates_metrics, aml_trio/normal_insert_size_metrics, aml_trio/normal_alignment_summary_metrics, aml_trio/normal_hs_metrics, aml_trio/normal_summary_hs_metrics, aml_trio/normal_flagstats, aml_trio/normal_verify_bam_id_metrics, aml_trio/normal_verify_bam_id_depth, aml_trio/followup_cram, aml_trio/mutect_unfiltered_vcf, aml_trio/mutect_filtered_vcf, aml_trio/strelka_unfiltered_vcf, aml_trio/strelka_filtered_vcf, aml_trio/varscan_unfiltered_vcf, aml_trio/varscan_filtered_vcf, aml_trio/pindel_unfiltered_vcf, aml_trio/pindel_filtered_vcf, aml_trio/docm_filtered_vcf, aml_trio/pindel_region_vcf, aml_trio/tumor_final_vcf, aml_trio/tumor_final_filtered_vcf, aml_trio/tumor_final_tsv, aml_trio/tumor_vep_summary, aml_trio/germline_final_vcf, aml_trio/germline_coding_vcf, aml_trio/germline_limited_vcf, aml_trio/germline_final_tsv, aml_trio/alignment_stat_report, aml_trio/coverage_stat_report, aml_trio/full_variant_report, aml_trio/tumor_snv_bam_readcount_tsv, aml_trio/tumor_indel_bam_readcount_tsv, aml_trio/normal_snv_bam_readcount_tsv, aml_trio/normal_indel_bam_readcount_tsv, aml_trio/followup_snv_bam_readcount_tsv, aml_trio/followup_indel_bam_readcount_tsv, aml_trio/somalier_concordance_metrics, aml_trio/somalier_concordance_statistics]
+                valueFrom: ${
+                                function flatten(inArr, outArr) {
+                                    var arrLen = inArr.length;
+                                    for (var i = 0; i < arrLen; i++) {
+                                        if (Array.isArray(inArr[i])) {
+                                            flatten(inArr[i], outArr);
+                                        }
+                                        else {
+                                            outArr.push(inArr[i]);
+                                        }
+                                    }
+                                    return outArr;
+                                }
+                                var no_secondaries = flatten(self, []);
+                                var all_files = []; 
+                                var arrLen = no_secondaries.length;
+                                for (var i = 0; i < arrLen; i++) {
+                                    all_files.push(no_secondaries[i]);
+                                    var secondaryLen = no_secondaries[i].secondaryFiles.length;
+                                    for (var j = 0; j < secondaryLen; j++) {
+                                        all_files.push(no_secondaries[i].secondaryFiles[j]);
+                                    }
+                                }
+                                return all_files;
+                            }
+        out: [gathered_files]

--- a/definitions/tools/bam_readcount.cwl
+++ b/definitions/tools/bam_readcount.cwl
@@ -6,10 +6,12 @@ label: "run bam-readcount"
 
 baseCommand: ["/usr/bin/python", "/usr/bin/bam_readcount_helper.py"]
 requirements:
+    - class: ShellCommandRequirement
     - class: DockerRequirement
-      dockerPull: "mgibio/bam_readcount_helper-cwl:1.0.0"
+      dockerPull: "registry.gsc.wustl.edu/fdu/bam_readcount-prefix"
     - class: ResourceRequirement
       ramMin: 4000
+    - class: InlineJavascriptRequirement
 arguments: [
     { valueFrom: $(runtime.outdir), position: -3 }
 ]
@@ -18,20 +20,25 @@ inputs:
     vcf:
         type: File
         inputBinding:
-            position: -7
+            position: -8
     sample:
         type: string
         inputBinding:
-            position: -6
+            position: -7
     reference_fasta:
         type: string
         inputBinding:
-            position: -5
+            position: -6
     bam:
         type: File
         inputBinding:
-            position: -4
+            position: -5
         secondaryFiles: [.bai]
+    prefix:
+        type: string?
+        default: 'NOPREFIX'
+        inputBinding:
+            position: -4
     min_base_quality:
         type: int?
         default: 20
@@ -46,8 +53,29 @@ outputs:
     snv_bam_readcount_tsv:
         type: File
         outputBinding:
-            glob: "$(inputs.sample)_bam_readcount_snv.tsv"
+            glob: |
+                    ${
+                        var name = "_bam_readcount_snv.tsv";
+                        if (inputs.prefix.equals("NOPREFIX")) {
+                            name = inputs.sample + name;
+                        }
+                        else {
+                            name = inputs.prefix + "_" + inputs.sample + name;
+                        }
+                        return name;
+                    }
     indel_bam_readcount_tsv:
         type: File
         outputBinding:
-            glob: "$(inputs.sample)_bam_readcount_indel.tsv"
+            glob: |
+                    ${
+                        var name = "_bam_readcount_indel.tsv";
+                        if (inputs.prefix.equals("NOPREFIX")) {
+                            name = inputs.sample + name;
+                        }
+                        else {
+                            name = inputs.prefix + "_" + inputs.sample + name;
+                        }
+                        return name;
+                    }
+            

--- a/definitions/tools/bam_readcount.cwl
+++ b/definitions/tools/bam_readcount.cwl
@@ -8,7 +8,7 @@ baseCommand: ["/usr/bin/python", "/usr/bin/bam_readcount_helper.py"]
 requirements:
     - class: ShellCommandRequirement
     - class: DockerRequirement
-      dockerPull: "registry.gsc.wustl.edu/fdu/bam_readcount-prefix"
+      dockerPull: "mgibio/bam_readcount_helper-cwl:1.1.0"
     - class: ResourceRequirement
       ramMin: 4000
     - class: InlineJavascriptRequirement

--- a/definitions/tools/concordance.cwl
+++ b/definitions/tools/concordance.cwl
@@ -33,6 +33,11 @@ inputs:
         inputBinding:
             position: 4
         secondaryFiles: [.bai]
+    bam_3:
+        type: File?
+        inputBinding:
+            position: 5
+        secondaryFiles: [.bai]
 outputs:
     somalier_pairs:
         type: File

--- a/definitions/tools/filter_vcf_docm.cwl
+++ b/definitions/tools/filter_vcf_docm.cwl
@@ -6,7 +6,7 @@ label: "Filter variants from the DoCM detector"
 baseCommand: ["/usr/bin/perl", "/usr/bin/docm_filter.pl"]
 requirements:
     - class: DockerRequirement
-      dockerPull: "mgibio/cle:v1.4.1"
+      dockerPull: "mgibio/cle:v1.4.2"
     - class: ResourceRequirement
       ramMin: 4000
 arguments: [

--- a/example_data/cle_aml_trio_template.yaml
+++ b/example_data/cle_aml_trio_template.yaml
@@ -1,0 +1,188 @@
+---
+bait_intervals:
+  class: File
+  path: /gscmnt/gc2709/info/production_reference_GRCh38DH/CLE/IDTExome/xgen-exome-research-panel-probes.interval_list
+bqsr_intervals:
+- chr1
+- chr2
+- chr3
+- chr4
+- chr5
+- chr6
+- chr7
+- chr8
+- chr9
+- chr10
+- chr11
+- chr12
+- chr13
+- chr14
+- chr15
+- chr16
+- chr17
+- chr18
+- chr19
+- chr20
+- chr21
+- chr22
+cosmic_vcf:
+  class: File
+  path: /gscmnt/gc2560/core/build_merged_alignments/detect-variants--linus2112.gsc.wustl.edu-jwalker-774-52fa2dadc4ba4b6490abe0701907d394/snvs.hq.vcf.gz
+custom_clinvar_vcf:
+  class: File
+  path: /gscmnt/gc2560/core/custom_clinvar_vcf/v20181028/custom.vcf.gz
+custom_gnomad_vcf:
+  class: File
+  path: /gscmnt/gc2560/core/model_data/genome-db-ensembl-gnomad/2dd4b53431674786b760adad60a29273/fixed_b38_exome.vcf.gz
+dbsnp_vcf:
+  class: File
+  path: /gscmnt/gc2560/core/build_merged_alignments/detect-variants--linus2112.gsc.wustl.edu-jwalker-19443-e48c595a620a432c93e8dd29e4af64f2/snvs.hq.vcf.gz
+emit_reference_confidence: GVCF
+gvcf_gq_bands: []
+intervals:
+- - chr1
+- - chr2
+- - chr3
+- - chr4
+- - chr5
+- - chr6
+- - chr7
+- - chr8
+- - chr9
+- - chr10
+- - chr11
+- - chr12
+- - chr13
+- - chr14
+- - chr15
+- - chr16
+- - chr17
+- - chr18
+- - chr19
+- - chr20
+- - chr21
+- - chr22
+- - chrX
+- - chrY
+variant_reporting_intervals:
+  class: File
+  path: /gscmnt/gc2560/core/model_data/interval-list/db8c25932fd94d2a8a073a2e20449878/a35b64d628b94df194040032d53b5616.interval_list
+docm_vcf:
+  class: File
+  path: /gscmnt/gc2560/core/build_merged_alignments/detect-variants--linus2112.gsc.wustl.edu-jwalker-16572-a6fc7db1ea124431af5271c8cb23ee26/snvs.hq.vcf.gz 
+interval_list:
+  class: File
+  path: /gscmnt/gc13016/cle/54f8f7b915cb472aa183c721307369ab_scratch_space/new_AML_trio/new_cwl/bed_file/IDT_targets_plus50bp_build38.resorted.merged.interval_list
+known_indels:
+  class: File
+  path: /gscmnt/gc2560/core/build_merged_alignments/detect-variants--linus2112.gsc.wustl.edu-jwalker-20267-00cb8ff552914c17ad66d86031e10d30/indels.hq.vcf.gz
+mills:
+  class: File
+  path: /gscmnt/gc2560/core/build_merged_alignments/detect-variants--linus2112.gsc.wustl.edu-jwalker-20211-26b393cc7ab04120ac68cc2cbd4a15df/indels.hq.vcf.gz
+mutect_scatter_count: 80
+mutect_artifact_detection_mode: false
+mutect_max_alt_allele_in_normal_fraction: 0.1
+mutect_max_alt_alleles_in_normal_count: 5
+varscan_strand_filter: 1
+varscan_min_var_freq: 0.08
+varscan_p_value: 0.1
+varscan_max_normal_freq: 0.1
+normal_bams:
+- class: File
+  path: NORMAL_BAM_PATH
+normal_readgroups:
+- "NORMAL_RG_STR"
+omni_vcf:
+  class: File
+  path: /gscmnt/gc2709/info/production_reference_GRCh38DH/accessory_vcf/omni25-ld-pruned-20000-2000-0.5-annotated.wchr.sites_only.b38.autosomes_only.vcf.gz
+panel_of_normals_vcf:
+  class: File
+  path: /gscmnt/gc2560/core/build_merged_alignments/detect-variants--linus2112.gsc.wustl.edu-jwalker-2237-db881b860992443da9d6aac8b36a7ea6/snvs.hq.vcf.gz
+pindel_region_file:
+  class: File
+  path: /gscmnt/gc13016/cle/54f8f7b915cb472aa183c721307369ab_scratch_space/new_AML_trio/new_cwl/bed_file/FLT3_region_build38.bed
+per_base_intervals: []
+per_target_intervals: []
+picard_metric_accumulation_level: LIBRARY
+reference: /gscmnt/gc2709/info/production_reference_GRCh38DH/reference/all_sequences.fa
+summary_intervals:
+- file:  /gscmnt/gc13016/cle/54f8f7b915cb472aa183c721307369ab_scratch_space/new_AML_trio/new_cwl/bed_file/AML_RMG_targets_x_IDT_plus50bp_build38.resorted.merged.interval_list
+  label: AML_RMG
+- file: /gscmnt/gc13016/cle/54f8f7b915cb472aa183c721307369ab_scratch_space/new_AML_trio/new_cwl/bed_file/AML_ComplexMutationRegions_x_IDT_plus50bp_build38.resorted.merged.interval_list
+  label: AML_CMR
+synonyms_file:
+  class: File
+  path: /gscmnt/gc2560/core/model_data/2887491634/build50f99e75d14340ffb5b7d21b03887637/chromAlias.ensembl.txt
+target_intervals:
+  class: File
+  path: /gscmnt/gc13016/cle/54f8f7b915cb472aa183c721307369ab_scratch_space/new_AML_trio/new_cwl/bed_file/IDT_targets_plus50bp_build38.resorted.merged.interval_list
+tumor_bams:
+- class: File
+  path: TUMOR_BAM_PATH 
+tumor_readgroups:
+- "TUMOR_RG_STR"
+followup_bams:
+- class: File
+  path: FOLLOWUP_BAM_PATH 
+followup_readgroups:
+- "FOLLOWUP_RG_STR"
+filter_docm_variants: false
+filter_minimum_depth: 20
+annotate_coding_only: false
+germline_coding_only: true
+variants_to_table_fields:
+- CHROM
+- POS
+- ID
+- REF
+- ALT
+- set
+variants_to_table_genotype_fields:
+- GT
+- AD
+- AF
+- DP
+vep_to_table_fields:
+- Consequence
+- SYMBOL
+- Feature_type
+- Feature
+- HGVSc
+- HGVSp
+- cDNA_position
+- CDS_position
+- Protein_position
+- Amino_acids
+- Codons
+- HGNC_ID
+- Existing_variation
+- gnomADe_AF
+germline_variants_to_table_fields:
+- CHROM
+- POS
+- ID
+- REF
+- ALT
+germline_variants_to_table_genotype_fields:
+- GT
+- AD
+- DP
+germline_vep_to_table_fields:
+- Consequence
+- SYMBOL
+- Feature_type
+- Feature
+- HGVSc
+- HGVSp
+- CDS_position
+- Codons
+- HGNC_ID
+- Existing_variation
+- gnomADe_AF
+- MAX_AF
+vep_cache_dir: /gscmnt/gc2560/core/cwl/inputs/VEP_cache
+vep_ensembl_assembly: GRCh38
+vep_ensembl_version: 95
+vep_ensembl_species: homo_sapiens
+somalier_vcf: /gscmnt/gc2560/core/annotation_data/concordance_snps/GRC-human-build38_gnomad_exome_common_snps.vcf
+output_dir: OUTPUT_DIR


### PR DESCRIPTION
This is to replace the legacy aml_trio pipeline that is based on GMS Build-VariantReportingProcess.

Note that the docker image will be "mgibio/bam_readcount_helper-cwl:1.1.0" in bam_readcount.cwl once the PR https://github.com/genome/docker-bam_readcount_helper-cwl/pull/3 is merged.