### PR TITLE
Update germline_detect_variants step

### DIFF
--- a/definitions/pipelines/cle_aml_trio.cwl
+++ b/definitions/pipelines/cle_aml_trio.cwl
@@ -322,7 +322,7 @@ outputs:
         secondaryFiles: [.tbi]
     germline_final_tsv:
         type: File
-        outputSource: germline_add_vep_fields_to_table/annotated_variants_tsv
+        outputSource: germline_detect_variants/final_tsv
     somalier_concordance_metrics:
         type: File
         outputSource: concordance/somalier_pairs
@@ -527,25 +527,12 @@ steps:
             custom_gnomad_vcf: custom_gnomad_vcf
             limit_variant_intervals: variant_reporting_intervals
             custom_clinvar_vcf: custom_clinvar_vcf
+            variants_to_table_fields: germline_variants_to_table_fields
+            variants_to_table_genotype_fields: germline_variants_to_table_genotype_fields
+            vep_to_table_fields: germline_vep_to_table_fields
+            final_tsv_prefix: germline_tsv_prefix
         out:
-            [final_vcf, coding_vcf, limited_vcf]
-    germline_variants_to_table:
-        run: ../tools/variants_to_table.cwl
-        in:
-            reference: reference
-            vcf: germline_detect_variants/limited_vcf
-            fields: germline_variants_to_table_fields
-            genotype_fields: germline_variants_to_table_genotype_fields
-        out:
-            [variants_tsv]
-    germline_add_vep_fields_to_table:
-        run: ../tools/add_vep_fields_to_table.cwl
-        in:
-            vcf: germline_detect_variants/limited_vcf
-            vep_fields: germline_vep_to_table_fields
-            tsv: germline_variants_to_table/variants_tsv
-            prefix: germline_tsv_prefix 
-        out: [annotated_variants_tsv]
+            [final_vcf, coding_vcf, limited_vcf, final_tsv]
     alignment_stat_report:
         run: ../tools/cle_aml_trio_report_alignment_stat.cwl
         in:

--- a/definitions/subworkflows/germline_detect_variants.cwl
+++ b/definitions/subworkflows/germline_detect_variants.cwl
@@ -55,6 +55,9 @@ inputs:
         type: string[]?
     vep_to_table_fields:
         type: string[]?
+    final_tsv_prefix:
+        type: string?
+        default: 'variants'
 outputs:
     gvcf:
         type: File[]
@@ -167,4 +170,5 @@ steps:
             vcf: limit_variants/filtered_vcf
             vep_fields: vep_to_table_fields
             tsv: variants_to_table/variants_tsv
+            prefix: final_tsv_prefix
         out: [annotated_variants_tsv]


### PR DESCRIPTION
germline_detect_variants.cwl now includes variants_to_table and add_vep_fields_to_table steps. Update cle_aml_trio.cwl to contain the change. Also add finaLtsv_prefix optional input to handle final_tsv from different sources. 