### PR TITLE
add annotsv.cwl tool

### DIFF
--- a/definitions/tools/annotsv.cwl
+++ b/definitions/tools/annotsv.cwl
@@ -1,0 +1,49 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+
+arguments: ["$(inputs.AnnotSV_path)/bin/AnnotSV", "-bedtools", "/usr/bin/bedtools", "-outputDir", "$(runtime.outdir)"]
+requirements:
+    - class: ResourceRequirement
+      ramMin: 8000
+    - class: DockerRequirement
+      dockerPull: "mgibio/annotsv-cwl:1.0.0"
+    - class: EnvVarRequirement
+      envDef:
+        - envName: "ANNOTSV"
+          envValue: "$(inputs.AnnotSV_path)"
+
+inputs:
+    AnnotSV_path:
+        type: string
+    genome_build:
+        type: string
+        inputBinding:
+            position: 2
+            prefix: "-genomeBuild"
+    input_vcf:
+        type: File
+        inputBinding:
+            position: 3
+            prefix: "-SVinputFile"
+        doc: "vcf file to filter"
+    output_tsv_name:
+        type: string?
+        default: "AnnotSV.tsv"
+        inputBinding:
+            position: 4
+            prefix: "-outputFile"
+        doc: "output file name"
+    snps_vcf:
+        type: File?
+        inputBinding:
+            position: 5
+            prefix: "-vcfFiles"
+        doc: "snps vcf for adding hom/het snp counts found within svs"
+
+outputs:
+    sv_variants_tsv:
+        type: File
+        outputBinding:
+            glob: $(inputs.output_tsv_name)


### PR DESCRIPTION
This PR adds the cwl tool for running AnnotSV. One unique thing with running AnnotSV is that it requires the path to the AnnotSV installation to be an enviornment variable. Found that the cwl requirement `EnvVarRequirement` allows me to set that.

Thought about having the AnnotSV installation aa part of the docker image but that would make the image kinda large and make it more challenging for adding custom annotations.

Future PR will add this and filtering to single sample sv caller sub workflow.