### PR TITLE
adding annotsv.cwl

### DIFF
--- a/definitions/tools/annotsv.cwl
+++ b/definitions/tools/annotsv.cwl
@@ -30,11 +30,12 @@ inputs:
             prefix: "-outputFile"
         doc: "output file name"
     snps_vcf:
-        type: File?
+        type: File[]?
         inputBinding:
             position: 5
             prefix: "-vcfFiles"
-        doc: "snps vcf for adding hom/het snp counts found within svs"
+            itemSeparator: ","
+        doc: "snps vcf(s) for adding hom/het snp counts found within svs"
 
 outputs:
     sv_variants_tsv:

--- a/definitions/tools/annotsv.cwl
+++ b/definitions/tools/annotsv.cwl
@@ -1,0 +1,43 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+
+arguments: ["AnnotSV", "-bedtools", "/usr/bin/bedtools", "-outputDir", "$(runtime.outdir)"]
+requirements:
+    - class: ResourceRequirement
+      ramMin: 8000
+    - class: DockerRequirement
+      dockerPull: "mgibio/annotsv-cwl:2.1"
+
+inputs:
+    genome_build:
+        type: string
+        inputBinding:
+            position: 2
+            prefix: "-genomeBuild"
+    input_vcf:
+        type: File
+        inputBinding:
+            position: 3
+            prefix: "-SVinputFile"
+        doc: "vcf file to filter"
+    output_tsv_name:
+        type: string?
+        default: "AnnotSV.tsv"
+        inputBinding:
+            position: 4
+            prefix: "-outputFile"
+        doc: "output file name"
+    snps_vcf:
+        type: File?
+        inputBinding:
+            position: 5
+            prefix: "-vcfFiles"
+        doc: "snps vcf for adding hom/het snp counts found within svs"
+
+outputs:
+    sv_variants_tsv:
+        type: File
+        outputBinding:
+            glob: $(inputs.output_tsv_name)


### PR DESCRIPTION
this PR adds the cwl tool for running AnnotSV. Decided to create a new branch/pr instead of pushing to #720 

Docker image now contains the AnnotSV files and the `ANNOTSV` env value necessary to run AnnotSV. This cwl does not expose the option to provide your own annotation files. Something that should be added in the future.

Future PR will add this and filtering to single sample sv caller sub workflow. 