### PR TITLE
Add a tool to logically rename a file and use it in our VCF filter subworkflow.

### DIFF
--- a/definitions/subworkflows/filter_vcf.cwl
+++ b/definitions/subworkflows/filter_vcf.cwl
@@ -5,6 +5,7 @@ class: Workflow
 label: "Apply filters to VCF file"
 requirements:
     - class: SubworkflowFeatureRequirement
+    - class: StepInputExpressionRequirement
 inputs:
     vcf:
         type: File
@@ -28,7 +29,7 @@ inputs:
 outputs: 
     filtered_vcf:
         type: File
-        outputSource: filter_vcf_somatic_llr/somatic_llr_filtered_vcf
+        outputSource: set_final_vcf_name/replacement
         secondaryFiles: [.tbi]
 steps:
     filter_vcf_gnomADe_allele_freq:
@@ -69,3 +70,11 @@ steps:
             threshold: filter_somatic_llr_threshold
         out:
             [somatic_llr_filtered_vcf]
+    set_final_vcf_name:
+        run: ../tools/rename.cwl
+        in:
+            original: filter_vcf_somatic_llr/somatic_llr_filtered_vcf
+            name:
+                valueFrom: 'annotated_filtered.vcf'
+        out:
+            [replacement]

--- a/definitions/subworkflows/filter_vcf.cwl
+++ b/definitions/subworkflows/filter_vcf.cwl
@@ -30,7 +30,6 @@ outputs:
     filtered_vcf:
         type: File
         outputSource: set_final_vcf_name/replacement
-        secondaryFiles: [.tbi]
 steps:
     filter_vcf_gnomADe_allele_freq:
         run: ../tools/filter_vcf_gnomADe_allele_freq.cwl

--- a/definitions/subworkflows/filter_vcf.cwl
+++ b/definitions/subworkflows/filter_vcf.cwl
@@ -70,7 +70,7 @@ steps:
         out:
             [somatic_llr_filtered_vcf]
     set_final_vcf_name:
-        run: ../tools/rename.cwl
+        run: ../tools/staged_rename.cwl
         in:
             original: filter_vcf_somatic_llr/somatic_llr_filtered_vcf
             name:

--- a/definitions/subworkflows/filter_vcf_mouse.cwl
+++ b/definitions/subworkflows/filter_vcf_mouse.cwl
@@ -28,7 +28,6 @@ outputs:
     filtered_vcf:
         type: File
         outputSource: filter_vcf_somatic_llr/somatic_llr_filtered_vcf
-        secondaryFiles: [.tbi]
 steps:
     filter_vcf_mapq0:
         run: ../tools/filter_vcf_mapq0.cwl

--- a/definitions/subworkflows/filter_vcf_mouse.cwl
+++ b/definitions/subworkflows/filter_vcf_mouse.cwl
@@ -5,6 +5,7 @@ class: Workflow
 label: "Apply filters to VCF file"
 requirements:
     - class: SubworkflowFeatureRequirement
+    - class: StepInputExpressionRequirement
 inputs:
     vcf:
         type: File
@@ -60,3 +61,11 @@ steps:
             threshold: filter_somatic_llr_threshold
         out:
             [somatic_llr_filtered_vcf]
+    set_final_vcf_name:
+        run: ../tools/rename.cwl
+        in:
+            original: filter_vcf_somatic_llr/somatic_llr_filtered_vcf
+            name:
+                valueFrom: 'annotated_filtered.vcf'
+        out:
+            [replacement]

--- a/definitions/subworkflows/filter_vcf_mouse.cwl
+++ b/definitions/subworkflows/filter_vcf_mouse.cwl
@@ -61,7 +61,7 @@ steps:
         out:
             [somatic_llr_filtered_vcf]
     set_final_vcf_name:
-        run: ../tools/rename.cwl
+        run: ../tools/staged_rename.cwl
         in:
             original: filter_vcf_somatic_llr/somatic_llr_filtered_vcf
             name:

--- a/definitions/tools/rename.cwl
+++ b/definitions/tools/rename.cwl
@@ -2,6 +2,8 @@
 
 cwlVersion: v1.0
 class: ExpressionTool
+label: "Renamer"
+doc: "Logically renames a file, but not all workflow engines currently support it.  See also staged_rename.cwl"
 requirements:
     - class: InlineJavascriptRequirement
 inputs:

--- a/definitions/tools/rename.cwl
+++ b/definitions/tools/rename.cwl
@@ -1,0 +1,20 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: ExpressionTool
+requirements:
+    - class: InlineJavascriptRequirement
+inputs:
+    original:
+        type: File
+    name:
+        type: string
+outputs:
+    replacement:
+        type: File
+expression: |
+    ${
+        var f = inputs.original;
+        f.basename = inputs.name;
+        return {'replacement': f};
+    }

--- a/definitions/tools/staged_rename.cwl
+++ b/definitions/tools/staged_rename.cwl
@@ -1,0 +1,23 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: "A crude file-renamer to work around workflow engines that don't support rename.cwl"
+requirements:
+    - class: DockerRequirement
+      dockerPull: ubuntu:bionic
+    - class: InitialWorkDirRequirement
+      listing:
+          - $(inputs.original)
+baseCommand: ["/bin/mv"]
+arguments: [$(inputs.original.basename), $(inputs.name)]
+inputs:
+    original:
+        type: File
+    name:
+        type: string
+outputs:
+    replacement:
+        type: File
+        outputBinding:
+            glob: $(inputs.name)

--- a/definitions/tools/staged_rename.cwl
+++ b/definitions/tools/staged_rename.cwl
@@ -2,7 +2,8 @@
 
 cwlVersion: v1.0
 class: CommandLineTool
-label: "A crude file-renamer to work around workflow engines that don't support rename.cwl"
+label: "Staged Renamer"
+doc: "Renames a file by staging and then `mv`ing it.  A workaround for workflow engines that don't support rename.cwl.  If running in cwltool, use the other one instead."
 requirements:
     - class: DockerRequirement
       dockerPull: ubuntu:bionic


### PR DESCRIPTION
This closes #733. It mostly supersedes #734.

The Expression tool could've been inline in the workflow, but this will hopefully be more convenient for re-using in other pipelines.