### PR TITLE
Introducing `sequence_data` type. Align either FASTQs or BAM!

### DIFF
--- a/definitions/subworkflows/sequence_to_bqsr.cwl
+++ b/definitions/subworkflows/sequence_to_bqsr.cwl
@@ -1,0 +1,93 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+label: "Raw sequence data to BQSR"
+requirements:
+    - class: SchemaDefRequirement
+      types:
+          - $import: ../types/sequence_data.yml
+    - class: ScatterFeatureRequirement
+    - class: SubworkflowFeatureRequirement
+    - class: MultipleInputFeatureRequirement
+
+inputs:
+    unaligned:
+        type: ../types/sequence_data.yml#sequence_data[]
+    bqsr_intervals:
+        type: string[]
+    reference:
+        type: string
+    dbsnp_vcf:
+        type: File
+        secondaryFiles: [.tbi]
+    final_name:
+        type: string?
+        default: 'final.bam'
+    mills:
+        type: File
+        secondaryFiles: [.tbi]
+    known_indels:
+        type: File
+        secondaryFiles: [.tbi]
+outputs:
+    final_bam:
+        type: File
+        outputSource: index_bam/indexed_bam
+        secondaryFiles: [.bai, ^.bai]
+    mark_duplicates_metrics_file:
+        type: File
+        outputSource: mark_duplicates_and_sort/metrics_file
+steps:
+    align:
+        scatter: [unaligned]
+        scatterMethod: dotproduct
+        run: ../tools/sequence_align_and_tag.cwl
+        in:
+            unaligned: unaligned
+            reference: reference
+        out:
+            [aligned_bam]
+    merge:
+        run: ../tools/merge_bams_samtools.cwl
+        in:
+            bams: align/aligned_bam
+            name: final_name
+        out:
+            [merged_bam]
+    name_sort:
+        run: ../tools/name_sort.cwl
+        in:
+            bam: merge/merged_bam
+        out:
+            [name_sorted_bam]
+    mark_duplicates_and_sort:
+        run: ../tools/mark_duplicates_and_sort.cwl
+        in:
+            bam: name_sort/name_sorted_bam
+        out:
+            [sorted_bam, metrics_file]
+    bqsr:
+        run: ../tools/bqsr.cwl
+        in:
+            reference: reference
+            bam: mark_duplicates_and_sort/sorted_bam
+            intervals: bqsr_intervals
+            known_sites: [dbsnp_vcf, mills, known_indels]
+        out:
+            [bqsr_table]
+    apply_bqsr:
+        run: ../tools/apply_bqsr.cwl
+        in:
+            reference: reference
+            bam: mark_duplicates_and_sort/sorted_bam
+            bqsr_table: bqsr/bqsr_table
+            output_name: final_name
+        out:
+            [bqsr_bam]
+    index_bam:
+        run: ../tools/index_bam.cwl
+        in:
+            bam: apply_bqsr/bqsr_bam
+        out:
+            [indexed_bam]

--- a/definitions/tools/sequence_align_and_tag.cwl
+++ b/definitions/tools/sequence_align_and_tag.cwl
@@ -12,9 +12,9 @@ requirements:
     - class: ResourceRequirement
       coresMin: 8
       ramMin: 20000
-      #    - class: DockerRequirement
-      #      dockerPull: "mgibio/alignment_helper-cwl:1.0.0"
-    - class: InlineJavascriptRequirement #necessary for cwltool to handle the record
+    - class: DockerRequirement
+      dockerPull: "mgibio/alignment_helper-cwl:1.0.0"
+    - class: InlineJavascriptRequirement
     - class: InitialWorkDirRequirement
       listing:
       - entryname: 'sequence_alignment_helper.sh'
@@ -50,21 +50,21 @@ requirements:
             done
 
             if [[ "$MODE" == 'fastq' ]]; then
-                echo /usr/local/bin/bwa mem -K 100000000 -t "$NTHREADS" -Y -p -R "$READGROUP" "$REFERENCE" "$FASTQ1" "$FASTQ2" "|" /usr/local/bin/samblaster -a --addMateTags "|" /opt/samtools/bin/samtools view -b -S /dev/stdin
+                /usr/local/bin/bwa mem -K 100000000 -t "$NTHREADS" -Y -p -R "$READGROUP" "$REFERENCE" "$FASTQ1" "$FASTQ2" | /usr/local/bin/samblaster -a --addMateTags | /opt/samtools/bin/samtools view -b -S /dev/stdin
             fi
             if [[ "$MODE" == 'bam' ]]; then
-                echo /usr/bin/java -Xmx4g -jar /opt/picard/picard.jar SamToFastq I="$BAM" INTERLEAVE=true INCLUDE_NON_PF_READS=true FASTQ=/dev/stdout "|" /usr/local/bin/bwa mem -K 100000000 -t "$NTHREADS" -Y -p -R "$READGROUP" "$REFERENCE" /dev/stdin "|" /usr/local/bin/samblaster -a --addMateTags "|" /opt/samtools/bin/samtools view -b -S /dev/stdin
+                /usr/bin/java -Xmx4g -jar /opt/picard/picard.jar SamToFastq I="$BAM" INTERLEAVE=true INCLUDE_NON_PF_READS=true FASTQ=/dev/stdout | /usr/local/bin/bwa mem -K 100000000 -t "$NTHREADS" -Y -p -R "$READGROUP" "$REFERENCE" /dev/stdin | /usr/local/bin/samblaster -a --addMateTags | /opt/samtools/bin/samtools view -b -S /dev/stdin
             fi
 stdout: "refAlign.bam"
 arguments:
     - valueFrom: $(runtime.cores)
       position: 5
       prefix: '-n'
-    - valueFrom: $(inputs.unaligned.sequence.bam)
+    - valueFrom: "$(inputs.unaligned.sequence.hasOwnProperty('bam')? inputs.unaligned.sequence.bam : null)"
       prefix: '-b'
-    - valueFrom: $(inputs.unaligned.sequence.fastq1)
+    - valueFrom: "$(inputs.unaligned.sequence.hasOwnProperty('fastq1')? inputs.unaligned.sequence.fastq1 : null)"
       prefix: '-1'
-    - valueFrom: $(inputs.unaligned.sequence.fastq2)
+    - valueFrom: "$(inputs.unaligned.sequence.hasOwnProperty('fastq2')? inputs.unaligned.sequence.fastq2 : null)"
       prefix: '-2'
     - valueFrom: $(inputs.unaligned.readgroup)
       prefix: '-g'

--- a/definitions/tools/sequence_align_and_tag.cwl
+++ b/definitions/tools/sequence_align_and_tag.cwl
@@ -1,0 +1,83 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: "align with bwa_mem and tag"
+
+baseCommand: ["/bin/bash", "sequence_alignment_helper.sh"]
+requirements:
+    - class: SchemaDefRequirement
+      types:
+          - $import: ../types/sequence_data.yml
+    - class: ResourceRequirement
+      coresMin: 8
+      ramMin: 20000
+      #    - class: DockerRequirement
+      #      dockerPull: "mgibio/alignment_helper-cwl:1.0.0"
+    - class: InlineJavascriptRequirement #necessary for cwltool to handle the record
+    - class: InitialWorkDirRequirement
+      listing:
+      - entryname: 'sequence_alignment_helper.sh'
+        entry: |
+            set -o pipefail
+            set -o errexit
+            set -o nounset
+
+            while getopts "b:?1:?2:?g:r:n:" opt; do
+                case "$opt" in
+                    b)
+                        MODE=bam
+                        BAM="$OPTARG"
+                        ;;
+                    1)
+                        MODE=fastq
+                        FASTQ1="$OPTARG"
+                        ;;
+                    2)  
+                        MODE=fastq
+                        FASTQ2="$OPTARG"
+                        ;;
+                    g)
+                        READGROUP="$OPTARG"
+                        ;;
+                    r)
+                        REFERENCE="$OPTARG"
+                        ;;
+                    n)
+                        NTHREADS="$OPTARG"
+                        ;;
+                esac
+            done
+
+            if [[ "$MODE" == 'fastq' ]]; then
+                echo /usr/local/bin/bwa mem -K 100000000 -t "$NTHREADS" -Y -p -R "$READGROUP" "$REFERENCE" "$FASTQ1" "$FASTQ2" "|" /usr/local/bin/samblaster -a --addMateTags "|" /opt/samtools/bin/samtools view -b -S /dev/stdin
+            fi
+            if [[ "$MODE" == 'bam' ]]; then
+                echo /usr/bin/java -Xmx4g -jar /opt/picard/picard.jar SamToFastq I="$BAM" INTERLEAVE=true INCLUDE_NON_PF_READS=true FASTQ=/dev/stdout "|" /usr/local/bin/bwa mem -K 100000000 -t "$NTHREADS" -Y -p -R "$READGROUP" "$REFERENCE" /dev/stdin "|" /usr/local/bin/samblaster -a --addMateTags "|" /opt/samtools/bin/samtools view -b -S /dev/stdin
+            fi
+stdout: "refAlign.bam"
+arguments:
+    - valueFrom: $(runtime.cores)
+      position: 5
+      prefix: '-n'
+    - valueFrom: $(inputs.unaligned.sequence.bam)
+      prefix: '-b'
+    - valueFrom: $(inputs.unaligned.sequence.fastq1)
+      prefix: '-1'
+    - valueFrom: $(inputs.unaligned.sequence.fastq2)
+      prefix: '-2'
+    - valueFrom: $(inputs.unaligned.readgroup)
+      prefix: '-g'
+inputs:
+    unaligned:
+        type: ../types/sequence_data.yml#sequence_data
+        doc: "the unaligned sequence data with readgroup information"
+    reference:
+        type: string
+        inputBinding:
+            position: 4
+            prefix: '-r'
+        doc: 'bwa-indexed reference file'
+outputs:
+    aligned_bam:
+        type: stdout

--- a/definitions/types/sequence_data.yml
+++ b/definitions/types/sequence_data.yml
@@ -1,0 +1,20 @@
+type: record
+name: sequence_data
+label: sequence data with readgroup information
+fields:
+    sequence:
+        type:
+            - type: record
+              name: bam
+              fields:
+                  bam:
+                      type: File
+            - type: record
+              name: fastqs
+              fields:
+                  fastq1:
+                      type: File
+                  fastq2:
+                      type: File
+    readgroup:
+        type: string


### PR DESCRIPTION
Hot on the heels of #730 is a version that works on either FASTQ or BAM.  This approach saves us from having to maintain two versions of the pipeline and retains the efficiency of piping directly into `bwa` from BAM files.

If this approach looks good, I'll next replace the existing alignment steps in all the workflows and probably remove the existing alignment tool CWLs.