### PR TITLE
adding cnvnator.cwl

### DIFF
--- a/definitions/tools/cnvnator.cwl
+++ b/definitions/tools/cnvnator.cwl
@@ -2,7 +2,7 @@
 
 cwlVersion: v1.0
 class: CommandLineTool
-label: "Run CNVnator to calcualte copy number variations in WGS samples"
+label: "Run CNVnator to calculate copy number variations in WGS samples"
 
 arguments: ["source", "/opt/root/bin/thisroot.sh", { shellQuote: false, valueFrom: "&&" },  "/bin/bash", "run_cnvnator.sh"]
 

--- a/definitions/tools/cnvnator.cwl
+++ b/definitions/tools/cnvnator.cwl
@@ -58,7 +58,7 @@ inputs:
         default: 100
         inputBinding:
             position: 2
-        doc: "Bin size used to calculate covearge"
+        doc: "Bin size used to calculate coverage"
     chromosomes:
         type: string[]?
         default: ["chr1", "chr2", "chr3", "chr4", "chr5", "chr6", "chr7", "chr8", "chr9", "chr10", "chr11", "chr12", "chr13", "chr14", "chr15", "chr16", "chr17", "chr18", "chr19", "chr20", "chr21", "chr22", "chrX", "chrY"]

--- a/definitions/tools/cnvnator.cwl
+++ b/definitions/tools/cnvnator.cwl
@@ -1,0 +1,92 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: "Run CNVnator to calcualte copy number variations in WGS samples"
+
+arguments: ["source", "/opt/root/bin/thisroot.sh", { shellQuote: false, valueFrom: "&&" },  "/bin/bash", "run_cnvnator.sh"]
+
+requirements:
+    - class: DockerRequirement
+      dockerPull: "mgibio/cnvnator-cwl:0.4"
+    - class: ResourceRequirement
+      ramMin: 20000
+      coresMin: 1
+      tmpdirMin: 10000
+    - class: ShellCommandRequirement
+    - class: InitialWorkDirRequirement
+      listing:
+      - entryname: "run_cnvnator.sh"
+        entry: |
+          #!/bin/bash
+          set -eou pipefail
+
+          # set vars
+          BAM="$1"
+          BIN_SIZE="$2"
+          CHROMOSOMES="${3//,/ }" # input as csv so it's one var to bash script but CNVnator wants them space separated
+          REFERENCE="$4"
+          SAMPLE="$5"
+
+          # create directory to store fasta files. CNVnator wants chromosomes in individual files
+          # while with later versions of CNVnator these steps will accept a fasta.gz file the cnvnator2VCF.pl will not
+          mkdir FASTA_CHRS
+          awk 'BEGIN { CHROM="" } { if ($1~"^>") CHROM=substr($1,2); print $0 > "FASTA_CHRS/"CHROM".fa" }' "$REFERENCE"
+                    
+          # extract read mapping from input bam(single sample)
+          cnvnator -root "${SAMPLE}.root" -tree "$BAM" -chrom "$CHROMOSOMES"
+          # generate read depth histogram
+          cnvnator -root "${SAMPLE}.root" -his "${BIN_SIZE}" -d FASTA_CHRS/ -chrom "$CHROMOSOMES"
+          # calculate statistics
+          cnvnator -root "${SAMPLE}.root" -stat "${BIN_SIZE}" -chrom "$CHROMOSOMES"
+          # read depth signal partitioning
+          cnvnator -root "${SAMPLE}.root" -partition "${BIN_SIZE}" -chrom "$CHROMOSOMES"
+          # cnv calling
+          cnvnator -root "${SAMPLE}.root" -call "${BIN_SIZE}" -chrom "$CHROMOSOMES" > "${SAMPLE}.CNVnator.cn"
+
+          # convert to vcf
+          cnvnator2VCF.pl -reference "$REFERENCE" "${SAMPLE}.CNVnator.cn" FASTA_CHRS/ >  "${SAMPLE}.CNVnator.vcf"
+          exit 0
+inputs:
+    bam:
+        type: File
+        inputBinding:
+            position: 1
+        doc: "BAM or CRAM input"
+    bin_size:
+        type: int?
+        default: 100
+        inputBinding:
+            position: 2
+        doc: "Bin size used to calculate covearge"
+    chromosomes:
+        type: string[]?
+        default: ["chr1", "chr2", "chr3", "chr4", "chr5", "chr6", "chr7", "chr8", "chr9", "chr10", "chr11", "chr12", "chr13", "chr14", "chr15", "chr16", "chr17", "chr18", "chr19", "chr20", "chr21", "chr22", "chrX", "chrY"]
+        inputBinding:
+           position: 3
+           itemSeparator: ","
+        doc: "List of chromosomes to run CNVnator on"
+    reference:
+        type: string
+        inputBinding:
+            position: 4
+        doc: "Reference used to generate the alignments"
+    sample_name:
+        type: string
+        inputBinding:
+            position: 5
+        doc: "Sample name used for output file naming"
+
+outputs:
+    vcf:
+        type: File
+        outputBinding:
+            glob: "$(inputs.sample_name).CNVnator.vcf"
+    root_file:
+        type: File
+        outputBinding:
+            glob: "$(inputs.sample_name).root"
+    cn_file:
+        type: File
+        outputBinding:
+            glob: "$(inputs.sample_name).CNVnator.cn"

--- a/definitions/tools/cnvnator.cwl
+++ b/definitions/tools/cnvnator.cwl
@@ -24,7 +24,7 @@ requirements:
           # set vars
           BAM="$1"
           BIN_SIZE="$2"
-          CHROMOSOMES="${3//,/ }" # input as csv so it's one var to bash script but CNVnator wants them space separated
+          CHROMOSOMES="$3"
           REFERENCE="$4"
           SAMPLE="$5"
 
@@ -64,7 +64,7 @@ inputs:
         default: ["chr1", "chr2", "chr3", "chr4", "chr5", "chr6", "chr7", "chr8", "chr9", "chr10", "chr11", "chr12", "chr13", "chr14", "chr15", "chr16", "chr17", "chr18", "chr19", "chr20", "chr21", "chr22", "chrX", "chrY"]
         inputBinding:
            position: 3
-           itemSeparator: ","
+           itemSeparator: " "
         doc: "List of chromosomes to run CNVnator on"
     reference:
         type: string


### PR DESCRIPTION
This PR adds the CNVnator cwl as another copy number calling tool for WGS data. This is using the latest released version of `0.4`. This version of CNVnator does have CRAM and BAM support. Originally CNVnator required the reference to be split up in individual chromosome files. With the `0.4` version they now support compressed fasta.gz as a single file input. The issue with using that is that vcf generation perl script does not support a compressed reference input. I decided to generate the individual chromosome reference files when the tool is run. Allowing the CNVnator run and the cnvnator2VCF.pl script to use the same files. 

One issue that I have not been able to find a good solution for is that CNVnator requires the [ROOT](https://root.cern.ch) data analysis framework. In order to properly setup the environment a shell script needs to be sourced in the shell running CNVnator. Originally attempted to source this within the Dockerfile. Ran into a few issues where `source` is only found in a bash shell which is not the default for a Dockerfile. Then figured out that once the file is sourced it only modifies the shell that was used to run the sourcing command. I was able to add a line to the `~/.bashrc` file that would source the necessary ROOT shell script. This allowed CNVnator to work locally on my laptop but failed to work on the cluster. Then tried to add it to the script generated by the cwl. But the ROOT script has unset variables which causes the `run_cnvnator.sh` to fail because of the flags set. Ended up adding it as the first step in the `cnvnator.cwl`. Open to any suggestions or alternatives for this. 

One question I have is that I put the cnvnator2VCF.pl script on the docker image path. Should I be running `perl /path/to/cnvnator2VCF.pl $inputs` or is `cnvnator2VCF.pl $inputs` okay?

Have also been facing some issues with getting the docker image to build through dockerhub. I pushed my local image to `apaul7/cnvnator:0.4` for testing. Attempted to have dockerhub build the image but ran out of time. Tried pushing to `mgibio/cnvnator-cwl:0.4` to add the build cache hoping that would speed up future builds. But trying to rerun the build from the dockerfile hosted on github still failed. Currently splitting the Dockerfile in parts and running a build on the first sections to build up the build cache for subsequent builds.

Will keep this PR as a draft until the docker image is built successfully on `mgibio/cnvnator-cwl:0.4` or if it's okay to push a copy of the image I created locally. (I don't think it keeps the Dockerfile associated with the build like the automated builds do)