### PR TITLE
Sanitize non-ACTGN bases in VCFs

### DIFF
--- a/definitions/subworkflows/fp_filter.cwl
+++ b/definitions/subworkflows/fp_filter.cwl
@@ -30,11 +30,17 @@ outputs:
         outputSource: hard_filter/filtered_vcf
         secondaryFiles: [.tbi]
 steps:
+    sanitize_vcf:
+        run: ../tools/vcf_sanitize.cwl
+        in:
+            vcf: vcf
+        out:
+            [sanitized_vcf]
     normalize_variants:
         run: ../tools/normalize_variants.cwl
         in:
             reference: reference
-            vcf: vcf
+            vcf: sanitize_vcf/sanitized_vcf
         out:
             [normalized_vcf]
     decompose_variants:

--- a/definitions/tools/vcf_sanitize.cwl
+++ b/definitions/tools/vcf_sanitize.cwl
@@ -1,0 +1,33 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: "Sanitize a VCF"
+baseCommand: ["/bin/bash","sanitize.sh"]
+requirements:
+    - class: ResourceRequirement
+      ramMin: 4
+      coresMin: 1
+    - class: DockerRequirement
+      dockerPull: "mgibio/samtools-cwl:1.0.0"
+    - class: InitialWorkDirRequirement
+      listing:
+      - entryname: 'sanitize.sh'
+        entry: |
+            set -eou pipefail
+
+            # remove lines containing non ACTGN bases, as they conflict with the VCF spec
+            # and cause GATK to choke
+            gunzip -c "$1" | perl -a -F'\t' -ne 'print $_ if $_ =~ /^#/ || $F[3] !~ /[^ACTGNactgn]/' >sanitized.vcf
+            /opt/htslib/bin/bgzip sanitized.vcf
+            tabix sanitized.vcf.gz
+inputs:
+    vcf:
+        type: File
+        inputBinding:
+            position: 1
+outputs:
+    sanitized_vcf:
+        type: File
+        outputBinding:
+            glob: "sanitized.vcf.gz"

--- a/definitions/tools/vcf_sanitize.cwl
+++ b/definitions/tools/vcf_sanitize.cwl
@@ -6,7 +6,7 @@ label: "Sanitize a VCF"
 baseCommand: ["/bin/bash","sanitize.sh"]
 requirements:
     - class: ResourceRequirement
-      ramMin: 4
+      ramMin: 4000
       coresMin: 1
     - class: DockerRequirement
       dockerPull: "mgibio/samtools-cwl:1.0.0"

--- a/definitions/tools/vcf_sanitize.cwl
+++ b/definitions/tools/vcf_sanitize.cwl
@@ -15,12 +15,23 @@ requirements:
       - entryname: 'sanitize.sh'
         entry: |
             set -eou pipefail
-
-            # remove lines containing non ACTGN bases, as they conflict with the VCF spec
+            
+            # 1) removes lines containing non ACTGN bases, as they conflict with the VCF spec
             # and cause GATK to choke
-            gunzip -c "$1" | perl -a -F'\t' -ne 'print $_ if $_ =~ /^#/ || $F[3] !~ /[^ACTGNactgn]/' >sanitized.vcf
-            /opt/htslib/bin/bgzip sanitized.vcf
-            tabix sanitized.vcf.gz
+            # 2) removes mutect-specific format tags containing underscores, which are likewise
+            # illegal in the vcf spec
+            base=`basename $1` 
+            outbase=`echo $base | perl -pe 's/.vcf(.gz)?$//g'`
+            echo "$1   $base    $outbase"
+            if [[ "$1" =~ ".gz" ]];then
+                #gzipped input
+                gunzip -c "$1" | perl -a -F'\t' -ne 'print $_ if $_ =~ /^#/ || $F[3] !~ /[^ACTGNactgn]/' | sed -e "s/ALT_F1R2/ALTF1R2/g;s/ALT_F2R1/ALTF2R1/g;s/REF_F1R2/REFF1R2/g;s/REF_F2R1/REFF2R1/g" >$outbase.sanitized.vcf
+            else 
+                #non-gzipped input
+                cat "$1" | perl -a -F'\t' -ne 'print $_ if $_ =~ /^#/ || $F[3] !~ /[^ACTGNactgn]/' | sed -e "s/ALT_F1R2/ALTF1R2/g;s/ALT_F2R1/ALTF2R1/g;s/REF_F1R2/REFF1R2/g;s/REF_F2R1/REFF2R1/g" >$outbase.sanitized.vcf
+            fi
+            /opt/htslib/bin/bgzip $outbase.sanitized.vcf
+            tabix $outbase.sanitized.vcf.gz
 inputs:
     vcf:
         type: File
@@ -30,4 +41,10 @@ outputs:
     sanitized_vcf:
         type: File
         outputBinding:
-            glob: "sanitized.vcf.gz"
+            glob: | 
+                  ${
+                    if(inputs.vcf.nameext.equals(".gz")){
+                      return inputs.vcf.nameroot.replace(/.vcf$/, "") + ".sanitized.vcf.gz";
+                    }
+                    return inputs.vcf.nameroot + ".sanitized.vcf.gz";
+                  }

--- a/definitions/tools/vcf_sanitize.cwl
+++ b/definitions/tools/vcf_sanitize.cwl
@@ -15,23 +15,23 @@ requirements:
       - entryname: 'sanitize.sh'
         entry: |
             set -eou pipefail
-            
+
             # 1) removes lines containing non ACTGN bases, as they conflict with the VCF spec
             # and cause GATK to choke
             # 2) removes mutect-specific format tags containing underscores, which are likewise
             # illegal in the vcf spec
-            base=`basename $1` 
+            base=`basename $1`
             outbase=`echo $base | perl -pe 's/.vcf(.gz)?$//g'`
             echo "$1   $base    $outbase"
             if [[ "$1" =~ ".gz" ]];then
                 #gzipped input
                 gunzip -c "$1" | perl -a -F'\t' -ne 'print $_ if $_ =~ /^#/ || $F[3] !~ /[^ACTGNactgn]/' | sed -e "s/ALT_F1R2/ALTF1R2/g;s/ALT_F2R1/ALTF2R1/g;s/REF_F1R2/REFF1R2/g;s/REF_F2R1/REFF2R1/g" >$outbase.sanitized.vcf
-            else 
+            else
                 #non-gzipped input
                 cat "$1" | perl -a -F'\t' -ne 'print $_ if $_ =~ /^#/ || $F[3] !~ /[^ACTGNactgn]/' | sed -e "s/ALT_F1R2/ALTF1R2/g;s/ALT_F2R1/ALTF2R1/g;s/REF_F1R2/REFF1R2/g;s/REF_F2R1/REFF2R1/g" >$outbase.sanitized.vcf
             fi
             /opt/htslib/bin/bgzip $outbase.sanitized.vcf
-            tabix $outbase.sanitized.vcf.gz
+            tabix -p $outbase.sanitized.vcf.gz
 inputs:
     vcf:
         type: File
@@ -40,8 +40,9 @@ inputs:
 outputs:
     sanitized_vcf:
         type: File
+        secondaryFiles: [.tbi]
         outputBinding:
-            glob: | 
+            glob: |
                   ${
                     if(inputs.vcf.nameext.equals(".gz")){
                       return inputs.vcf.nameroot.replace(/.vcf$/, "") + ".sanitized.vcf.gz";

--- a/definitions/tools/vcf_sanitize.cwl
+++ b/definitions/tools/vcf_sanitize.cwl
@@ -31,7 +31,7 @@ requirements:
                 cat "$1" | perl -a -F'\t' -ne 'print $_ if $_ =~ /^#/ || $F[3] !~ /[^ACTGNactgn]/' | sed -e "s/ALT_F1R2/ALTF1R2/g;s/ALT_F2R1/ALTF2R1/g;s/REF_F1R2/REFF1R2/g;s/REF_F2R1/REFF2R1/g" >$outbase.sanitized.vcf
             fi
             /opt/htslib/bin/bgzip $outbase.sanitized.vcf
-            tabix -p $outbase.sanitized.vcf.gz
+            tabix -p vcf $outbase.sanitized.vcf.gz
 inputs:
     vcf:
         type: File


### PR DESCRIPTION
This PR implements a "sanitize" step that is needed to remove non-IUPAC reference bases from VCF files. Currently, this occurs when a caller like varscan is run on the GRCh38 reference, which contains 95 positions with non [ACTGN] bases, all from the IUPAC standard (R, Y, S, B, W, etc).  The VCF spec, however, does not allow these bases, and GATK tools (correctly??) choke on them in a VCF.  

GATK-based tools (HaplotypeCaller, Mutect) just skip those non-ACTGN bases, and here, we replicate that behavior by removing any lines from VCFs that contain such a base.

I imagine that we haven't run into this before because this is the first time we're using the varscan-based tumor-only calling pipeline on whole genome data.   

Head of a validation experiment, showing some of the lines that are removed:
```
$ diff input.vcf sanitized.vcf  | cut -f 1-5
273792d273791
< chr1  248755122       .       R       A
357953d357951
< chr2  109493618       .       R       G
495844,495847d495841
< chr2  233142970       .       Y       T
< chr2  233143703       .       W       A
< chr2  233143709       .       Y       T
< chr2  233143729       .       Y       C
537613d537606
< chr3  66191221        .       Y       C
1465973d1465965
< chr7  154575459       .       R       A
. . . 
```