### PR TITLE
Upgrade to version 1.5.0

### DIFF
--- a/definitions/tools/pvacbind.cwl
+++ b/definitions/tools/pvacbind.cwl
@@ -1,0 +1,135 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: "run pVACseq"
+
+baseCommand: [
+    "ln", "-s"
+]
+arguments: [
+    { valueFrom: "$TMPDIR", shellQuote: false },
+    "/tmp/pvacbind",
+    { valueFrom: " && ", shellQuote: false },
+    "export", "TMPDIR=/tmp/pvacbind",
+    { valueFrom: " && ", shellQuote: false },
+    "/opt/conda/bin/pvacbind", "run",
+    "--iedb-install-directory", "/opt/iedb",
+    { position: 5, valueFrom: $(runtime.outdir) },
+]
+requirements:
+    - class: ShellCommandRequirement
+    - class: DockerRequirement
+      dockerPull: "griffithlab/pvactools:1.5.0"
+    - class: ResourceRequirement
+      ramMin: 16000
+      coresMin: 8
+inputs:
+    input_vcf:
+        type: File
+        inputBinding:
+            position: 1
+    sample_name:
+        type: string
+        inputBinding:
+            position: 2
+    alleles:
+        type: string[]
+        inputBinding:
+            position: 3
+            itemSeparator: ','
+            separate: false
+            prefix: ""
+    prediction_algorithms:
+        type: string[]
+        inputBinding:
+            position: 4
+    epitope_lengths:
+        type: int[]?
+        inputBinding:
+            prefix: "-e"
+            itemSeparator: ','
+            separate: false
+    binding_threshold:
+        type: int?
+        inputBinding:
+            prefix: "-b"
+    allele_specific_binding_thresholds:
+        type: boolean?
+        inputBinding:
+            prefix: "--allele-specific-binding-thresholds"
+    iedb_retries:
+        type: int?
+        inputBinding:
+            prefix: "-r"
+    keep_tmp_files:
+        type: boolean?
+        inputBinding:
+            prefix: "-k"
+    net_chop_method:
+        type:
+            - "null"
+            - type: enum
+              symbols: ["cterm", "20s"]
+        inputBinding:
+            prefix: "--net-chop-method"
+    netmhc_stab:
+        type: boolean?
+        inputBinding:
+            prefix: "--netmhc-stab"
+    top_score_metric:
+        type:
+            - "null"
+            - type: enum
+              symbols: ["lowest", "median"]
+        inputBinding:
+            prefix: "-m"
+    net_chop_threshold:
+        type: float?
+        inputBinding:
+            prefix: "--net-chop-threshold"
+    additional_report_columns:
+        type:
+            - "null"
+            - type: enum
+              symbols: ["sample_name"]
+        inputBinding:
+            prefix: "-a"
+    fasta_size:
+        type: int?
+        inputBinding:
+            prefix: "-s"
+    exclude_nas:
+        type: boolean?
+        inputBinding:
+            prefix: "--exclude-NAs"
+    n_threads:
+        type: int?
+        inputBinding:
+            prefix: "--n-threads"
+        default: 8
+outputs:
+    mhc_i_all_epitopes:
+        type: File?
+        outputBinding:
+            glob: "MHC_Class_I/$(inputs.sample_name).all_epitopes.tsv"
+    mhc_i_filtered_epitopes:
+        type: File?
+        outputBinding:
+            glob: "MHC_Class_I/$(inputs.sample_name).filtered.tsv"
+    mhc_ii_all_epitopes:
+        type: File?
+        outputBinding:
+            glob: "MHC_Class_II/$(inputs.sample_name).all_epitopes.tsv"
+    mhc_ii_filtered_epitopes:
+        type: File?
+        outputBinding:
+            glob: "MHC_Class_II/$(inputs.sample_name).filtered.tsv"
+    combined_all_epitopes:
+        type: File?
+        outputBinding:
+            glob: "combined/$(inputs.sample_name).all_epitopes.tsv"
+    combined_filtered_epitopes:
+        type: File?
+        outputBinding:
+            glob: "combined/$(inputs.sample_name).filtered.tsv"

--- a/definitions/tools/pvacbind.cwl
+++ b/definitions/tools/pvacbind.cwl
@@ -23,7 +23,7 @@ requirements:
       dockerPull: "griffithlab/pvactools:1.5.0"
     - class: ResourceRequirement
       ramMin: 16000
-      coresMin: 8
+      coresMin: $(inputs.n_threads)
 inputs:
     input_vcf:
         type: File

--- a/definitions/tools/pvacbind.cwl
+++ b/definitions/tools/pvacbind.cwl
@@ -2,7 +2,7 @@
 
 cwlVersion: v1.0
 class: CommandLineTool
-label: "run pVACseq"
+label: "run pVACbind"
 
 baseCommand: [
     "ln", "-s"

--- a/definitions/tools/pvacbind.cwl
+++ b/definitions/tools/pvacbind.cwl
@@ -20,7 +20,7 @@ arguments: [
 requirements:
     - class: ShellCommandRequirement
     - class: DockerRequirement
-      dockerPull: "griffithlab/pvactools:1.5.0"
+      dockerPull: "griffithlab/pvactools:1.5.1"
     - class: ResourceRequirement
       ramMin: 16000
       coresMin: $(inputs.n_threads)

--- a/definitions/tools/pvacfuse.cwl
+++ b/definitions/tools/pvacfuse.cwl
@@ -24,7 +24,7 @@ requirements:
       dockerPull: "griffithlab/pvactools:1.5.0"
     - class: ResourceRequirement
       ramMin: 16000
-      coresMin: 8
+      coresMin: $(inputs.n_threads)
 inputs:
     input_file:
         type:

--- a/definitions/tools/pvacfuse.cwl
+++ b/definitions/tools/pvacfuse.cwl
@@ -21,7 +21,7 @@ arguments: [
 requirements:
     - class: ShellCommandRequirement
     - class: DockerRequirement
-      dockerPull: "griffithlab/pvactools:1.5.0"
+      dockerPull: "griffithlab/pvactools:1.5.1"
     - class: ResourceRequirement
       ramMin: 16000
       coresMin: $(inputs.n_threads)

--- a/definitions/tools/pvacfuse.cwl
+++ b/definitions/tools/pvacfuse.cwl
@@ -21,13 +21,15 @@ arguments: [
 requirements:
     - class: ShellCommandRequirement
     - class: DockerRequirement
-      dockerPull: "griffithlab/pvactools:1.4.4"
+      dockerPull: "griffithlab/pvactools:1.5.0"
     - class: ResourceRequirement
       ramMin: 16000
       coresMin: 8
 inputs:
     input_file:
-        type: File
+        type:
+            - File
+            - Directory
         inputBinding:
             position: 1
     sample_name:

--- a/definitions/tools/pvacseq.cwl
+++ b/definitions/tools/pvacseq.cwl
@@ -24,7 +24,7 @@ requirements:
       dockerPull: "griffithlab/pvactools:1.5.0"
     - class: ResourceRequirement
       ramMin: 16000
-      coresMin: 8
+      coresMin: $(inputs.n_threads)
 inputs:
     input_vcf:
         type: File

--- a/definitions/tools/pvacseq.cwl
+++ b/definitions/tools/pvacseq.cwl
@@ -21,7 +21,7 @@ arguments: [
 requirements:
     - class: ShellCommandRequirement
     - class: DockerRequirement
-      dockerPull: "griffithlab/pvactools:1.4.4"
+      dockerPull: "griffithlab/pvactools:1.5.0"
     - class: ResourceRequirement
       ramMin: 16000
       coresMin: 8

--- a/definitions/tools/pvacseq.cwl
+++ b/definitions/tools/pvacseq.cwl
@@ -21,7 +21,7 @@ arguments: [
 requirements:
     - class: ShellCommandRequirement
     - class: DockerRequirement
-      dockerPull: "griffithlab/pvactools:1.5.0"
+      dockerPull: "griffithlab/pvactools:1.5.1"
     - class: ResourceRequirement
       ramMin: 16000
       coresMin: $(inputs.n_threads)

--- a/definitions/tools/pvacvector.cwl
+++ b/definitions/tools/pvacvector.cwl
@@ -24,7 +24,7 @@ requirements:
       dockerPull: "griffithlab/pvactools:1.5.0"
     - class: ResourceRequirement
       ramMin: 16000
-      coresMin: 8
+      coresMin: $(inputs.n_threads)
 inputs:
     input_file:
         type: File

--- a/definitions/tools/pvacvector.cwl
+++ b/definitions/tools/pvacvector.cwl
@@ -21,7 +21,7 @@ arguments: [
 requirements:
     - class: ShellCommandRequirement
     - class: DockerRequirement
-      dockerPull: "griffithlab/pvactools:1.4.4"
+      dockerPull: "griffithlab/pvactools:1.5.0"
     - class: ResourceRequirement
       ramMin: 16000
       coresMin: 8

--- a/definitions/tools/pvacvector.cwl
+++ b/definitions/tools/pvacvector.cwl
@@ -21,7 +21,7 @@ arguments: [
 requirements:
     - class: ShellCommandRequirement
     - class: DockerRequirement
-      dockerPull: "griffithlab/pvactools:1.5.0"
+      dockerPull: "griffithlab/pvactools:1.5.1"
     - class: ResourceRequirement
       ramMin: 16000
       coresMin: $(inputs.n_threads)


### PR DESCRIPTION
This version adds AGFusion support to pVACfuse. AGFusion output is a directory, hence we now accept both `File` and `Directory` `type` for the `input_file`. 1.5.0 also adds a new tool, pVACbind, so this PR adds a CWL for it.