### PR TITLE
Start testing using Python3 instead.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
-python: 2.7
+python: 3.7
 install:
     - pip install --upgrade pip
     - pip install 'setuptools>=18.5'
     - pip install 'cwltool==1.0.20181217162649'
-    - pip install 'ruamel.yaml==0.14.2'
+    - pip install 'ruamel.yaml==0.15.77'
 script: find . -name '*.cwl' | xargs -n 1 cwltool --validate


### PR DESCRIPTION
Python 2.7 is EOL at the end of the year, so let's be ready for the future!