### PR TITLE
make bqsr interval input optional

### DIFF
--- a/definitions/subworkflows/sequence_to_bqsr.cwl
+++ b/definitions/subworkflows/sequence_to_bqsr.cwl
@@ -15,7 +15,7 @@ inputs:
     unaligned:
         type: ../types/sequence_data.yml#sequence_data[]
     bqsr_intervals:
-        type: string[]
+        type: string[]?
     reference:
         type: string
     dbsnp_vcf:


### PR DESCRIPTION
Cromwell fails to run if the bqsr interval is not provided in the input for alignment workflows.
Cromwell thinks the bqsr interval input is necessary because the sub workflow has it as required even though the above pipeline has it as optional and the tool called has a default value. 