### PR TITLE
Add duphold tool

### DIFF
--- a/definitions/tools/duphold.cwl
+++ b/definitions/tools/duphold.cwl
@@ -8,7 +8,7 @@ arguments: ["--threads", "$(runtime.cores)"]
 
 requirements:
     - class: ResourceRequirement
-      ramMin: 4000
+      ramMin: 10000
     - class: DockerRequirement
       dockerPull: "mgibio/duphold-cwl:0.1.4"
 

--- a/definitions/tools/duphold.cwl
+++ b/definitions/tools/duphold.cwl
@@ -1,0 +1,53 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+
+baseCommand: "/usr/bin/duphold"
+arguments: ["--threads", "$(runtime.cores)"]
+
+requirements:
+    - class: ResourceRequirement
+      ramMin: 4000
+    - class: DockerRequirement
+      dockerPull: "mgibio/duphold-cwl:0.1.4"
+
+inputs:
+    bam:
+        type: File
+        inputBinding:
+            position: 1
+            prefix: "--bam"
+        doc: "aligned bam/cram file"
+    output_vcf_name:
+        type: string?
+        default: "duphold_annotated.vcf"
+        inputBinding:
+            position: 4
+            prefix: "--output"
+        doc: "output vcf file name"
+    reference:
+        type: string
+        inputBinding:
+            position: 2
+            prefix: "--fasta"
+        doc: "reference used to align bam"
+    snps_vcf:
+        type: File?
+        inputBinding:
+            position: 3
+            prefix: "--snp"
+        doc: "snps vcf file to annotate hom/het variant counts within sv"
+    sv_vcf:
+        type: File
+        inputBinding:
+            position: 4
+            prefix: "--vcf"
+        doc: "sv vcf file to annotate"
+
+outputs:
+    annotated_sv_vcf:
+        type: File
+        outputBinding:
+            glob: $(inputs.output_vcf_name)
+

--- a/definitions/tools/duphold.cwl
+++ b/definitions/tools/duphold.cwl
@@ -23,25 +23,25 @@ inputs:
         type: string?
         default: "duphold_annotated.vcf"
         inputBinding:
-            position: 4
+            position: 2
             prefix: "--output"
         doc: "output vcf file name"
     reference:
         type: string
         inputBinding:
-            position: 2
+            position: 3
             prefix: "--fasta"
         doc: "reference used to align bam"
     snps_vcf:
         type: File?
         inputBinding:
-            position: 3
+            position: 4
             prefix: "--snp"
         doc: "snps vcf file to annotate hom/het variant counts within sv"
     sv_vcf:
         type: File
         inputBinding:
-            position: 4
+            position: 5
             prefix: "--vcf"
         doc: "sv vcf file to annotate"
 


### PR DESCRIPTION
This cwl adds a tool for annotating SVs with [duphold](https://github.com/brentp/duphold). Providing coverage information for called deletions and duplications.
I added the threads option because the tool defaults to 4 threads while we default to 1 thread on the cluster.
First step in closing issue #761 