### PR TITLE
add bcftools merge cwl tool

### DIFF
--- a/definitions/tools/bcftools_merge.cwl
+++ b/definitions/tools/bcftools_merge.cwl
@@ -35,17 +35,26 @@ inputs:
             position: 3
             prefix: "--missing-to-ref"
         doc: "assume genotypes at missing sites are 0/0"
-    output_vcf_name:
-        type: string?
-        default: "bcftools_merged.vcf"
+    output_type:
+        type:
+            type: enum
+            symbols: ["b", "u", "z", "v"]
+        default: "z"
         inputBinding:
             position: 4
+            prefix: "--output-type"
+        doc: "output file format"
+    output_vcf_name:
+        type: string?
+        default: "bcftools_merged.vcf.gz"
+        inputBinding:
+            position: 5
             prefix: "--output"
         doc: "output vcf file name"
     vcfs:
         type: File[]
         inputBinding:
-            position: 5
+            position: 6
         doc: "input bgzipped tabix indexed vcfs to merge"
 
 outputs:

--- a/definitions/tools/bcftools_merge.cwl
+++ b/definitions/tools/bcftools_merge.cwl
@@ -1,0 +1,54 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+
+baseCommand: ["/opt/bcftools/bin/bcftools", "merge"]
+
+requirements:
+    - class: ResourceRequirement
+      ramMin: 4000
+    - class: DockerRequirement
+      dockerPull: "mgibio/bcftools-cwl:1.9"
+
+inputs:
+    force_merge:
+        type: boolean?
+        default: true
+        inputBinding:
+            position: 1
+            prefix: "--force-samples"
+        doc: "resolve duplicate sample names"
+    merge_method:
+        type: string?
+        default: "none"
+        inputBinding:
+            position: 2
+            prefix: "--merge"
+        doc: "method used to merge allow multiallelic indels/snps"
+    missing_ref:
+        type: boolean?
+        default: false
+        inputBinding:
+            position: 3
+            prefix: "--missing-to-ref"
+        doc: "assume genotypes at missing sites are 0/0"
+    output_vcf_name:
+        type: string?
+        default: "bcftools_merged.vcf"
+        inputBinding:
+            position: 4
+            prefix: "--output"
+        doc: "output vcf file name"
+    vcfs:
+        type: File[]
+        inputBinding:
+            position: 5
+        doc: "input bgzipped tabix indexed vcfs to merge"
+
+outputs:
+    merged_sv_vcf:
+        type: File
+        outputBinding:
+            glob: $(inputs.output_vcf_name)
+

--- a/definitions/tools/bcftools_merge.cwl
+++ b/definitions/tools/bcftools_merge.cwl
@@ -20,7 +20,9 @@ inputs:
             prefix: "--force-samples"
         doc: "resolve duplicate sample names"
     merge_method:
-        type: string?
+        type:
+            type: enum
+            symbols: ["none", "snps", "indels", "both", "all", "id"]
         default: "none"
         inputBinding:
             position: 2


### PR DESCRIPTION
This cwl tool allows an array of input vcfs to be merged together. input vcfs need to be bgzipped and tabix indexed. merge method `none` produces the best resulting vcf. using the method of `indels` or `both` causes the alternate field to get updated in a way where the variant has `alt1,alt2` which is not ideal for parsing downstream for SVs. The `indels` and `both methods also would only merge 2 calls if the variants have the same starting position and reference. With my testing only a very small number(~400 out of 32k) of variants from multiple callers fit this requirement and were being merged together.