### PR TITLE
support non interleaved fastqs

### DIFF
--- a/definitions/tools/fastq_align_and_tag.cwl
+++ b/definitions/tools/fastq_align_and_tag.cwl
@@ -25,7 +25,7 @@ requirements:
             REFERENCE="$4"
             NTHREADS="$5"
 
-            /usr/local/bin/bwa mem -K 100000000 -t "$NTHREADS" -Y -p -R "$READGROUP" "$REFERENCE" "$FASTQ1" "$FASTQ2" | /usr/local/bin/samblaster -a --addMateTags | /opt/samtools/bin/samtools view -b -S /dev/stdin
+            /usr/local/bin/bwa mem -K 100000000 -t "$NTHREADS" -Y -R "$READGROUP" "$REFERENCE" "$FASTQ1" "$FASTQ2" | /usr/local/bin/samblaster -a --addMateTags | /opt/samtools/bin/samtools view -b -S /dev/stdin
 stdout: "refAlign.bam"
 arguments:
     - position: 5

--- a/definitions/tools/sequence_align_and_tag.cwl
+++ b/definitions/tools/sequence_align_and_tag.cwl
@@ -49,7 +49,7 @@ requirements:
             done
 
             if [[ "$MODE" == 'fastq' ]]; then
-                /usr/local/bin/bwa mem -K 100000000 -t "$NTHREADS" -Y -P -R "$READGROUP" "$REFERENCE" "$FASTQ1" "$FASTQ2" | /usr/local/bin/samblaster -a --addMateTags | /opt/samtools/bin/samtools view -b -S /dev/stdin
+                /usr/local/bin/bwa mem -K 100000000 -t "$NTHREADS" -Y -R "$READGROUP" "$REFERENCE" "$FASTQ1" "$FASTQ2" | /usr/local/bin/samblaster -a --addMateTags | /opt/samtools/bin/samtools view -b -S /dev/stdin
             fi
             if [[ "$MODE" == 'bam' ]]; then
                 /usr/bin/java -Xmx4g -jar /opt/picard/picard.jar SamToFastq I="$BAM" INTERLEAVE=true INCLUDE_NON_PF_READS=true FASTQ=/dev/stdout | /usr/local/bin/bwa mem -K 100000000 -t "$NTHREADS" -Y -p -R "$READGROUP" "$REFERENCE" /dev/stdin | /usr/local/bin/samblaster -a --addMateTags | /opt/samtools/bin/samtools view -b -S /dev/stdin

--- a/definitions/tools/sequence_align_and_tag.cwl
+++ b/definitions/tools/sequence_align_and_tag.cwl
@@ -49,7 +49,7 @@ requirements:
             done
 
             if [[ "$MODE" == 'fastq' ]]; then
-                /usr/local/bin/bwa mem -K 100000000 -t "$NTHREADS" -Y -p -R "$READGROUP" "$REFERENCE" "$FASTQ1" "$FASTQ2" | /usr/local/bin/samblaster -a --addMateTags | /opt/samtools/bin/samtools view -b -S /dev/stdin
+                /usr/local/bin/bwa mem -K 100000000 -t "$NTHREADS" -Y -P -R "$READGROUP" "$REFERENCE" "$FASTQ1" "$FASTQ2" | /usr/local/bin/samblaster -a --addMateTags | /opt/samtools/bin/samtools view -b -S /dev/stdin
             fi
             if [[ "$MODE" == 'bam' ]]; then
                 /usr/bin/java -Xmx4g -jar /opt/picard/picard.jar SamToFastq I="$BAM" INTERLEAVE=true INCLUDE_NON_PF_READS=true FASTQ=/dev/stdout | /usr/local/bin/bwa mem -K 100000000 -t "$NTHREADS" -Y -p -R "$READGROUP" "$REFERENCE" /dev/stdin | /usr/local/bin/samblaster -a --addMateTags | /opt/samtools/bin/samtools view -b -S /dev/stdin


### PR DESCRIPTION
The `-p` option is used for a single interleaved fastq file which gives this warning when aligning with 2 fastq files
```
[W::main_mem] when '-p' is in use, the second query file is ignored.
```
This doesn't cause the alignment step to fail. Downstream steps fail if they require paired end alignments.
The `-P` option should allow the 2 paired end fastq files to be aligned correctly. Manually rerunning this step with `-P` on one of my builds to confirm this works.