### PR TITLE
Cnvkit merge segments for vcf export

### DIFF
--- a/definitions/subworkflows/cnvkit_single_sample.cwl
+++ b/definitions/subworkflows/cnvkit_single_sample.cwl
@@ -24,6 +24,11 @@ inputs:
         type: File
     cnvkit_vcf_name:
         type: string?
+    segment_filter:
+        type:
+          - "null"
+          - type: enum
+            symbols: ["ampdel", "ci", "cn", "sem"]
 outputs:
     cn_diagram:
         type: File?
@@ -64,6 +69,7 @@ steps:
     cns_to_vcf:
         run: ../tools/cnvkit_vcf_export.cwl
         in:
+            segment_filter: segment_filter
             cns_file: cnvkit_main/tumor_segmented_ratios
             male_reference: male_reference
             cnr_file: cnvkit_main/tumor_bin_level_ratios

--- a/definitions/subworkflows/cnvkit_single_sample.cwl
+++ b/definitions/subworkflows/cnvkit_single_sample.cwl
@@ -78,6 +78,5 @@ steps:
                             return inputs.tumor_bam.nameroot + ".cnvkit.vcf"
                         }   
                     }
-            tumor_bam: tumor_bam
         out:
             [cnvkit_vcf]

--- a/definitions/tools/cnvkit_vcf_export.cwl
+++ b/definitions/tools/cnvkit_vcf_export.cwl
@@ -9,7 +9,7 @@ requirements:
       dockerPull: etal/cnvkit:0.9.5
     - class: ShellCommandRequirement
     - class: ResourceRequirement
-      ramMin: 4000
+      ramMin: 8000
     - class: StepInputExpressionRequirement
     - class: InlineJavascriptRequirement
 baseCommand: ["/usr/bin/python", "/usr/local/bin/cnvkit.py", "call"]

--- a/definitions/tools/cnvkit_vcf_export.cwl
+++ b/definitions/tools/cnvkit_vcf_export.cwl
@@ -34,7 +34,7 @@ inputs:
         inputBinding:
             position: -2
     male_reference:
-        type: boolean
+        type: boolean?
         default: false
         inputBinding:
             position: 1

--- a/definitions/tools/cnvkit_vcf_export.cwl
+++ b/definitions/tools/cnvkit_vcf_export.cwl
@@ -20,6 +20,15 @@ arguments: [
     "/usr/bin/python", "/usr/local/bin/cnvkit.py", "export", "vcf", "adjusted.tumor.cns"
 ]
 inputs:
+    segment_filter:
+        type:
+          - "null"
+          - type: enum
+            symbols: ["ampdel", "ci", "cn", "sem"]
+        inputBinding:
+            position: -3
+            prefix: "--filter"
+        doc: "method for filtering/merging neighboring copy number segments"
     cns_file:
         type: File
         inputBinding:


### PR DESCRIPTION
This adds an optional input to the cnvkit vcf caller/exporter to perform filtering(and merging) options provided by cnvkit. The main option I want to use is `cn` which will merge neighboring called segments that have the same copy number. Without this option you could get multiple segments, that should be called a single event, exported as multiple events in the final vcf file. 

During my tests the job would be killed because it would exceed the original 4gb limit. I upped the ram requirement to 8gb and my tests were able to succeed. 

This PR will close issue #752. 