### PR TITLE
Let reference input be either a string or a FIle

### DIFF
--- a/definitions/pipelines/alignment_exome.cwl
+++ b/definitions/pipelines/alignment_exome.cwl
@@ -10,7 +10,11 @@ requirements:
           - $import: ../types/sequence_data.yml
     - class: SubworkflowFeatureRequirement
 inputs:
-    reference: string
+    reference:
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
     mills:

--- a/definitions/pipelines/alignment_exome_mouse.cwl
+++ b/definitions/pipelines/alignment_exome_mouse.cwl
@@ -9,7 +9,11 @@ requirements:
           - $import: ../types/labelled_file.yml
     - class: SubworkflowFeatureRequirement
 inputs:
-    reference: string
+    reference:
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     bams:
         type: File[]
     readgroups:

--- a/definitions/pipelines/alignment_umi_duplex.cwl
+++ b/definitions/pipelines/alignment_umi_duplex.cwl
@@ -22,7 +22,10 @@ inputs:
     read_structure:
         type: string[]
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     target_intervals:
        type: File?
 outputs:

--- a/definitions/pipelines/alignment_umi_molecular.cwl
+++ b/definitions/pipelines/alignment_umi_molecular.cwl
@@ -22,7 +22,10 @@ inputs:
     read_structure:
         type: string[]
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     target_intervals:
        type: File?
 outputs:

--- a/definitions/pipelines/alignment_wgs.cwl
+++ b/definitions/pipelines/alignment_wgs.cwl
@@ -10,7 +10,11 @@ requirements:
           - $import: ../types/sequence_data.yml
     - class: SubworkflowFeatureRequirement
 inputs:
-    reference: string
+    reference:
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
     mills:

--- a/definitions/pipelines/chipseq.cwl
+++ b/definitions/pipelines/chipseq.cwl
@@ -11,7 +11,11 @@ requirements:
     - class: SubworkflowFeatureRequirement
     - class: StepInputExpressionRequirement
 inputs:
-    reference: string
+    reference:
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     final_name:
         type: string?
     chipseq_sequence:

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -10,7 +10,10 @@ requirements:
           - $import: ../types/vep_custom_annotation.yml
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict, .index]
     tumor_bam:
         type: File
         secondaryFiles: [.bai,^.bai]

--- a/definitions/pipelines/detect_variants_mouse.cwl
+++ b/definitions/pipelines/detect_variants_mouse.cwl
@@ -7,7 +7,10 @@ requirements:
     - class: SubworkflowFeatureRequirement
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict, .index]
     tumor_bam:
         type: File
         secondaryFiles: [.bai,^.bai]

--- a/definitions/pipelines/germline_exome.cwl
+++ b/definitions/pipelines/germline_exome.cwl
@@ -11,7 +11,11 @@ requirements:
           - $import: ../types/vep_custom_annotation.yml
     - class: SubworkflowFeatureRequirement
 inputs:
-    reference: string
+    reference:
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa, .index]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
     mills:

--- a/definitions/pipelines/germline_exome_hla_typing.cwl
+++ b/definitions/pipelines/germline_exome_hla_typing.cwl
@@ -11,7 +11,11 @@ requirements:
           - $import: ../types/vep_custom_annotation.yml
     - class: SubworkflowFeatureRequirement
 inputs:
-    reference: string
+    reference:
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa, .index]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
     mills:

--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -11,7 +11,11 @@ requirements:
           - $import: ../types/vep_custom_annotation.yml
     - class: SubworkflowFeatureRequirement
 inputs:
-    reference: string
+    reference:
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa, .index]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
     mills:

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -54,7 +54,12 @@ inputs:
         type: File
 
     #somatic inputs
-    reference: string
+    reference:
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa, .index]
+
     tumor_sequence:
         type: ../types/sequence_data.yml#sequence_data[]
     tumor_name:

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -12,7 +12,11 @@ requirements:
     - class: SubworkflowFeatureRequirement
     - class: StepInputExpressionRequirement
 inputs:
-    reference: string
+    reference:
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa, .index]
     tumor_sequence:
         type: ../types/sequence_data.yml#sequence_data[]
     tumor_name:

--- a/definitions/pipelines/somatic_exome_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_gathered.cwl
@@ -12,7 +12,11 @@ requirements:
     - class: SubworkflowFeatureRequirement
     - class: StepInputExpressionRequirement
 inputs:
-    reference: string
+    reference:
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa, .index]
     tumor_sequence:
         type: ../types/sequence_data.yml#sequence_data[]
     tumor_cram_name:

--- a/definitions/pipelines/somatic_exome_mouse.cwl
+++ b/definitions/pipelines/somatic_exome_mouse.cwl
@@ -10,7 +10,11 @@ requirements:
     - class: SubworkflowFeatureRequirement
     - class: StepInputExpressionRequirement
 inputs:
-    reference: string
+    reference:
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa, .index]
     tumor_bams:
         type: File[]
     tumor_readgroups:

--- a/definitions/pipelines/tumor_only_detect_variants.cwl
+++ b/definitions/pipelines/tumor_only_detect_variants.cwl
@@ -12,7 +12,10 @@ requirements:
           - $import: ../types/vep_custom_annotation.yml
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict, .index]
     bam:
         type: File
         secondaryFiles: [^.bai,.bai]

--- a/definitions/pipelines/tumor_only_exome.cwl
+++ b/definitions/pipelines/tumor_only_exome.cwl
@@ -11,7 +11,11 @@ requirements:
           - $import: ../types/vep_custom_annotation.yml
     - class: SubworkflowFeatureRequirement
 inputs:
-    reference: string
+    reference:
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa, .index]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
     mills:

--- a/definitions/pipelines/tumor_only_wgs.cwl
+++ b/definitions/pipelines/tumor_only_wgs.cwl
@@ -11,7 +11,11 @@ requirements:
           - $import: ../types/vep_custom_annotation.yml
     - class: SubworkflowFeatureRequirement
 inputs:
-    reference: string
+    reference:
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa, .index]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
     mills:

--- a/definitions/subworkflows/align.cwl
+++ b/definitions/subworkflows/align.cwl
@@ -11,7 +11,10 @@ inputs:
     bam:
         type: File
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     readgroup:
         type: string
 outputs:

--- a/definitions/subworkflows/align_sort_markdup.cwl
+++ b/definitions/subworkflows/align_sort_markdup.cwl
@@ -14,7 +14,10 @@ inputs:
     readgroups:
         type: string[]
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     final_name:
         type: string?
         default: 'final.bam'

--- a/definitions/subworkflows/bam_readcount.cwl
+++ b/definitions/subworkflows/bam_readcount.cwl
@@ -12,7 +12,10 @@ inputs:
     sample:
         type: string
     reference_fasta:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
     bam:
         type: File
         secondaryFiles: [.bai]

--- a/definitions/subworkflows/docm_cle.cwl
+++ b/definitions/subworkflows/docm_cle.cwl
@@ -7,7 +7,10 @@ requirements:
     - class: SubworkflowFeatureRequirement
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
     tumor_bam:
         type: File
         secondaryFiles: [^.bai]

--- a/definitions/subworkflows/docm_germline.cwl
+++ b/definitions/subworkflows/docm_germline.cwl
@@ -7,7 +7,10 @@ requirements:
     - class: SubworkflowFeatureRequirement
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
     bam:
         type: File
         secondaryFiles: [^.bai]

--- a/definitions/subworkflows/duplex_alignment.cwl
+++ b/definitions/subworkflows/duplex_alignment.cwl
@@ -14,7 +14,10 @@ inputs:
     read_structure:
         type: string[]
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     target_intervals:
        type: File?
     min_reads:

--- a/definitions/subworkflows/filter_vcf.cwl
+++ b/definitions/subworkflows/filter_vcf.cwl
@@ -23,7 +23,10 @@ inputs:
     filter_somatic_llr_threshold:
         type: float
     reference: 
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
     filter_minimum_depth:
         type: int
     sample_names:

--- a/definitions/subworkflows/filter_vcf_mouse.cwl
+++ b/definitions/subworkflows/filter_vcf_mouse.cwl
@@ -19,7 +19,10 @@ inputs:
     filter_somatic_llr_threshold:
         type: float
     reference: 
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
     filter_minimum_depth:
         type: int
     sample_names:

--- a/definitions/subworkflows/fp_filter.cwl
+++ b/definitions/subworkflows/fp_filter.cwl
@@ -10,7 +10,10 @@ inputs:
         type: File
         secondaryFiles: [.bai,^.bai]
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
     vcf:
         type: File
         secondaryFiles: [.tbi]

--- a/definitions/subworkflows/gatk_haplotypecaller_iterator.cwl
+++ b/definitions/subworkflows/gatk_haplotypecaller_iterator.cwl
@@ -8,7 +8,10 @@ requirements:
     - class: ScatterFeatureRequirement
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
     bam:
         type: File
         secondaryFiles: [^.bai]

--- a/definitions/subworkflows/germline_detect_variants.cwl
+++ b/definitions/subworkflows/germline_detect_variants.cwl
@@ -10,7 +10,10 @@ requirements:
           - $import: ../types/vep_custom_annotation.yml
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict, .index]
     bam:
         type: File
     emit_reference_confidence:

--- a/definitions/subworkflows/germline_filter_vcf.cwl
+++ b/definitions/subworkflows/germline_filter_vcf.cwl
@@ -16,7 +16,10 @@ inputs:
     limit_variant_intervals:
         type: File
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
 outputs: 
     filtered_vcf:
         type: File

--- a/definitions/subworkflows/hs_metrics.cwl
+++ b/definitions/subworkflows/hs_metrics.cwl
@@ -23,7 +23,10 @@ inputs:
     per_target_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
     summary_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
 outputs:

--- a/definitions/subworkflows/molecular_alignment.cwl
+++ b/definitions/subworkflows/molecular_alignment.cwl
@@ -14,7 +14,10 @@ inputs:
     read_structure:
         type: string[]
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     target_intervals:
        type: File?
     min_reads:

--- a/definitions/subworkflows/mutect.cwl
+++ b/definitions/subworkflows/mutect.cwl
@@ -10,7 +10,10 @@ requirements:
     - class: StepInputExpressionRequirement
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
     tumor_bam:
         type: File
         secondaryFiles: [^.bai]

--- a/definitions/subworkflows/phase_vcf.cwl
+++ b/definitions/subworkflows/phase_vcf.cwl
@@ -13,7 +13,10 @@ inputs:
     germline_vcf:
         type: File
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
     reference_dict:
         type: File
     bam:

--- a/definitions/subworkflows/pindel.cwl
+++ b/definitions/subworkflows/pindel.cwl
@@ -10,7 +10,10 @@ requirements:
     - class: StepInputExpressionRequirement
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
     tumor_bam:
         type: File
         secondaryFiles: [^.bai]

--- a/definitions/subworkflows/pindel_cat.cwl
+++ b/definitions/subworkflows/pindel_cat.cwl
@@ -8,7 +8,10 @@ requirements:
     - class: MultipleInputFeatureRequirement
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
     tumor_bam:
         type: File
         secondaryFiles: ["^.bai"]

--- a/definitions/subworkflows/pvacseq.cwl
+++ b/definitions/subworkflows/pvacseq.cwl
@@ -19,7 +19,10 @@ inputs:
         type: File
         secondaryFiles: ['.bai']
     reference_fasta:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
     readcount_minimum_base_quality:
         type: int?
     readcount_minimum_mapping_quality:

--- a/definitions/subworkflows/qc_exome.cwl
+++ b/definitions/subworkflows/qc_exome.cwl
@@ -14,7 +14,10 @@ inputs:
         type: File
         secondaryFiles: [^.bai]
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
     bait_intervals:
         type: File
     target_intervals:

--- a/definitions/subworkflows/qc_exome_no_verify_bam.cwl
+++ b/definitions/subworkflows/qc_exome_no_verify_bam.cwl
@@ -13,7 +13,10 @@ inputs:
         type: File
         secondaryFiles: [^.bai]
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
     bait_intervals:
         type: File
     target_intervals:

--- a/definitions/subworkflows/qc_wgs.cwl
+++ b/definitions/subworkflows/qc_wgs.cwl
@@ -16,7 +16,10 @@ inputs:
         type: File
         secondaryFiles: [^.bai]
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
     intervals:
         type: File
     omni_vcf:

--- a/definitions/subworkflows/sequence_align_and_tag_adapter.cwl
+++ b/definitions/subworkflows/sequence_align_and_tag_adapter.cwl
@@ -16,7 +16,10 @@ inputs:
         type: ../types/sequence_data.yml#sequence_data
         doc: "the unaligned sequence data with readgroup information"
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.amb, .ann, .bwt, .pac, .sa]
         doc: 'bwa-indexed reference file'
 outputs:
     aligned_bam:

--- a/definitions/subworkflows/sequence_to_bqsr.cwl
+++ b/definitions/subworkflows/sequence_to_bqsr.cwl
@@ -17,7 +17,10 @@ inputs:
     bqsr_intervals:
         type: string[]?
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     dbsnp_vcf:
         type: File
         secondaryFiles: [.tbi]

--- a/definitions/subworkflows/single_sample_sv_callers.cwl
+++ b/definitions/subworkflows/single_sample_sv_callers.cwl
@@ -14,7 +14,10 @@ inputs:
         type: File
         secondaryFiles: [.bai,^.bai]
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict, .index]
 
     cnvkit_diagram:
         type: boolean?

--- a/definitions/subworkflows/strelka_and_post_processing.cwl
+++ b/definitions/subworkflows/strelka_and_post_processing.cwl
@@ -16,7 +16,10 @@ inputs:
         type: File
         secondaryFiles: [.bai,^.bai]
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
     interval_list:
         type: File
     exome_mode:

--- a/definitions/subworkflows/umi_alignment.cwl
+++ b/definitions/subworkflows/umi_alignment.cwl
@@ -10,7 +10,11 @@ inputs:
         type: File
     read_structure:
         type: string[]
-    reference: string
+    reference:
+        type:
+            - string
+            - File
+        secondaryFiles: [.amb, .ann, .bwt, .pac, .sa]
 outputs:
     aligned_bam:
         type: File

--- a/definitions/subworkflows/varscan.cwl
+++ b/definitions/subworkflows/varscan.cwl
@@ -5,7 +5,10 @@ class: Workflow
 label: "varscan somatic workflow"
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
     tumor_bam:
         type: File
         secondaryFiles: [^.bai]

--- a/definitions/subworkflows/varscan_germline.cwl
+++ b/definitions/subworkflows/varscan_germline.cwl
@@ -9,7 +9,10 @@ requirements:
     - class: StepInputExpressionRequirement
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
     bam:
         type: File
         secondaryFiles: [.bai, ^.bai]

--- a/definitions/subworkflows/varscan_pre_and_post_processing.cwl
+++ b/definitions/subworkflows/varscan_pre_and_post_processing.cwl
@@ -9,7 +9,10 @@ requirements:
     - class: StepInputExpressionRequirement
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
     tumor_bam:
         type: File
         secondaryFiles: [^.bai]

--- a/definitions/tools/align_and_tag.cwl
+++ b/definitions/tools/align_and_tag.cwl
@@ -25,7 +25,10 @@ inputs:
         inputBinding:
             position: 2
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.amb, .ann, .bwt, .pac, .sa]
         inputBinding:
             position: 3
 outputs:

--- a/definitions/tools/apply_bqsr.cwl
+++ b/definitions/tools/apply_bqsr.cwl
@@ -19,7 +19,10 @@ requirements:
       dockerPull: "mgibio/gatk-cwl:3.6.0"
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "-R"
             position: 1

--- a/definitions/tools/bam_readcount.cwl
+++ b/definitions/tools/bam_readcount.cwl
@@ -26,7 +26,10 @@ inputs:
         inputBinding:
             position: -7
     reference_fasta:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             position: -6
     bam:

--- a/definitions/tools/bam_to_cram.cwl
+++ b/definitions/tools/bam_to_cram.cwl
@@ -12,7 +12,10 @@ requirements:
 stdout: "$(inputs.bam.nameroot).cram"
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "-T"
             position: 1

--- a/definitions/tools/bqsr.cwl
+++ b/definitions/tools/bqsr.cwl
@@ -18,7 +18,10 @@ requirements:
       dockerPull: "mgibio/gatk-cwl:3.6.0"
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "-R"
             position: 2

--- a/definitions/tools/clip_overlap.cwl
+++ b/definitions/tools/clip_overlap.cwl
@@ -19,7 +19,10 @@ inputs:
         inputBinding:
             prefix: "--input"
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "--ref"
 outputs:

--- a/definitions/tools/cnvkit_batch.cwl
+++ b/definitions/tools/cnvkit_batch.cwl
@@ -29,7 +29,11 @@ inputs:
             position: 3
             prefix: "--targets"
     reference:
-        type: string?
+        type:
+            - "null"
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             position: 4
             prefix: "--fasta"

--- a/definitions/tools/collect_alignment_summary_metrics.cwl
+++ b/definitions/tools/collect_alignment_summary_metrics.cwl
@@ -18,7 +18,10 @@ inputs:
             prefix: "INPUT="
         secondaryFiles: [^.bai]
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "REFERENCE_SEQUENCE="
     metric_accumulation_level:

--- a/definitions/tools/collect_gc_bias_metrics.cwl
+++ b/definitions/tools/collect_gc_bias_metrics.cwl
@@ -23,7 +23,10 @@ inputs:
             prefix: "I="
         secondaryFiles: [^.bai]
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "R="
     metric_accumulation_level:

--- a/definitions/tools/collect_hs_metrics.cwl
+++ b/definitions/tools/collect_hs_metrics.cwl
@@ -19,7 +19,10 @@ inputs:
             prefix: "I="
         secondaryFiles: [^.bai]
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "R="
     metric_accumulation_level:

--- a/definitions/tools/collect_insert_size_metrics.cwl
+++ b/definitions/tools/collect_insert_size_metrics.cwl
@@ -19,7 +19,10 @@ inputs:
             prefix: "I="
         secondaryFiles: [^.bai]
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "REFERENCE_SEQUENCE="
     metric_accumulation_level:

--- a/definitions/tools/collect_wgs_metrics.cwl
+++ b/definitions/tools/collect_wgs_metrics.cwl
@@ -21,7 +21,10 @@ inputs:
             prefix: "I="
         secondaryFiles: [^.bai]
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "R="
     intervals:

--- a/definitions/tools/combine_variants.cwl
+++ b/definitions/tools/combine_variants.cwl
@@ -16,7 +16,10 @@ arguments:
      "-o", { valueFrom: $(runtime.outdir)/combined.vcf.gz }]
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "-R"
             position: 1

--- a/definitions/tools/concordance.cwl
+++ b/definitions/tools/concordance.cwl
@@ -19,7 +19,10 @@ inputs:
             prefix: "-s"
             position: 1
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "-f"
             position: 2

--- a/definitions/tools/docm_add_variants.cwl
+++ b/definitions/tools/docm_add_variants.cwl
@@ -17,7 +17,10 @@ arguments:
      "-o", { valueFrom: $(runtime.outdir)/merged.vcf.gz }]
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "-R"
             position: 1

--- a/definitions/tools/docm_gatk_haplotype_caller.cwl
+++ b/definitions/tools/docm_gatk_haplotype_caller.cwl
@@ -14,7 +14,10 @@ arguments:
     "-o", { valueFrom: $(runtime.outdir)/docm_raw_variants.vcf }]
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "-R"
             position: 1

--- a/definitions/tools/filter_consensus.cwl
+++ b/definitions/tools/filter_consensus.cwl
@@ -18,7 +18,10 @@ inputs:
         inputBinding:
             prefix: "--input"
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "--ref"
     min_reads:

--- a/definitions/tools/filter_vcf_mapq0.cwl
+++ b/definitions/tools/filter_vcf_mapq0.cwl
@@ -23,7 +23,10 @@ inputs:
             position: 2
         secondaryFiles: [.bai]
     reference: 
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             position: 3
     threshold: 

--- a/definitions/tools/filter_vcf_mapq0.cwl
+++ b/definitions/tools/filter_vcf_mapq0.cwl
@@ -23,15 +23,15 @@ inputs:
             position: 2
         secondaryFiles: [.bai]
     reference: 
-         type: string
-         inputBinding:
-             position: 3
+        type: string
+        inputBinding:
+            position: 3
     threshold: 
-         type: float
-         inputBinding:
-             position: 4
+        type: float
+        inputBinding:
+            position: 4
 outputs:
-     mapq0_filtered_vcf:
-         type: File
-         outputBinding:
-             glob: "mapq_filtered.vcf.gz"
+    mapq0_filtered_vcf:
+        type: File
+        outputBinding:
+            glob: "mapq_filtered.vcf.gz"

--- a/definitions/tools/fp_filter.cwl
+++ b/definitions/tools/fp_filter.cwl
@@ -16,7 +16,10 @@ arguments:
     "--output", { valueFrom: $(runtime.outdir)/$(inputs.output_vcf_basename).vcf }]
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "--reference"
             position: 1

--- a/definitions/tools/gatk_genotypegvcfs.cwl
+++ b/definitions/tools/gatk_genotypegvcfs.cwl
@@ -14,7 +14,10 @@ arguments:
     ["-o", 'genotype.vcf.gz']
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "-R"
             position: 1

--- a/definitions/tools/gatk_haplotype_caller.cwl
+++ b/definitions/tools/gatk_haplotype_caller.cwl
@@ -11,7 +11,10 @@ requirements:
       dockerPull: "mgibio/gatk-cwl:3.5.0"
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "-R"
             position: 1

--- a/definitions/tools/germline_combine_variants.cwl
+++ b/definitions/tools/germline_combine_variants.cwl
@@ -16,7 +16,10 @@ arguments:
      "-o", { valueFrom: $(runtime.outdir)/combined.vcf.gz }]
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "-R"
             position: 1

--- a/definitions/tools/manta_somatic.cwl
+++ b/definitions/tools/manta_somatic.cwl
@@ -34,7 +34,10 @@ inputs:
             prefix: "--tumorBam"
         secondaryFiles: ${if (self.nameext === ".bam") {return self.basename + ".bai"} else {return self.basename + ".crai"}}
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             position: -4
             prefix: "--referenceFasta"

--- a/definitions/tools/mark_duplicates_and_sort.val_test01.yaml
+++ b/definitions/tools/mark_duplicates_and_sort.val_test01.yaml
@@ -1,0 +1,3 @@
+bam:
+  class: File
+  path: ../../example_data/bisulfite/test1.bam

--- a/definitions/tools/mutect.cwl
+++ b/definitions/tools/mutect.cwl
@@ -37,7 +37,10 @@ arguments:
 
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             position: 2
     tumor_bam:

--- a/definitions/tools/normalize_variants.cwl
+++ b/definitions/tools/normalize_variants.cwl
@@ -13,7 +13,10 @@ arguments:
     ["-o", { valueFrom: $(runtime.outdir)/normalized.vcf.gz }]
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "-R"
             position: 1

--- a/definitions/tools/pindel.cwl
+++ b/definitions/tools/pindel.cwl
@@ -22,7 +22,10 @@ inputs:
         type: File
         secondaryFiles: ["^.bai"]
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "-f"
     chromosome:

--- a/definitions/tools/pindel2vcf.cwl
+++ b/definitions/tools/pindel2vcf.cwl
@@ -18,7 +18,10 @@ inputs:
         inputBinding:
             prefix: "-p"
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "-r"
     ref_name:

--- a/definitions/tools/pindel_somatic_filter.cwl
+++ b/definitions/tools/pindel_somatic_filter.cwl
@@ -16,7 +16,10 @@ requirements:
       dockerPull: mgibio/cle:v1.3.1
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
     pindel_output_summary:
         type: File
 outputs:

--- a/definitions/tools/pvacseq_combine_variants.cwl
+++ b/definitions/tools/pvacseq_combine_variants.cwl
@@ -15,7 +15,10 @@ arguments:
      "-o", { valueFrom: $(runtime.outdir)/combined_somatic_plus_germline.vcf }]
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "-R"
             position: 1

--- a/definitions/tools/read_backed_phasing.cwl
+++ b/definitions/tools/read_backed_phasing.cwl
@@ -15,7 +15,10 @@ arguments:
      "-o", { valueFrom: $(runtime.outdir)/phased.vcf }]
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "-R"
             position: 1

--- a/definitions/tools/realign.cwl
+++ b/definitions/tools/realign.cwl
@@ -19,7 +19,10 @@ inputs:
         inputBinding:
             position: 1
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.amb, .ann, .bwt, .pac, .sa]
         inputBinding:
             position: 2
 outputs:

--- a/definitions/tools/select_variants.cwl
+++ b/definitions/tools/select_variants.cwl
@@ -14,7 +14,10 @@ arguments:
     ["-o", { valueFrom: $(runtime.outdir)/$(inputs.output_vcf_basename).vcf.gz }]
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "-R"
             position: 1

--- a/definitions/tools/sequence_align_and_tag.cwl
+++ b/definitions/tools/sequence_align_and_tag.cwl
@@ -77,7 +77,10 @@ inputs:
         inputBinding:
             prefix: '-g'
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.amb, .ann, .bwt, .pac, .sa]
         inputBinding:
             position: 4
             prefix: '-r'

--- a/definitions/tools/set_filter_status.cwl
+++ b/definitions/tools/set_filter_status.cwl
@@ -28,7 +28,10 @@ inputs:
             position: 3
         secondaryFiles: [.tbi]
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "-R"
             position: 1

--- a/definitions/tools/smoove.cwl
+++ b/definitions/tools/smoove.cwl
@@ -30,7 +30,10 @@ inputs:
         default: "SV"
         doc: "Used for naming the output file"
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: --fasta
             position: 3

--- a/definitions/tools/strelka.cwl
+++ b/definitions/tools/strelka.cwl
@@ -29,7 +29,10 @@ inputs:
             position: 4
         secondaryFiles: [.bai,^.bai]
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: '--referenceFasta='
             separate: false

--- a/definitions/tools/umi_align.cwl
+++ b/definitions/tools/umi_align.cwl
@@ -19,7 +19,10 @@ inputs:
         inputBinding:
             position: 1
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.amb, .ann, .bwt, .pac, .sa]
         inputBinding:
             position: 2
 outputs:

--- a/definitions/tools/variants_to_table.cwl
+++ b/definitions/tools/variants_to_table.cwl
@@ -14,7 +14,10 @@ arguments:
     ["--allowMissingData", "-o", { valueFrom: $(runtime.outdir)/variants.tsv }]
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "-R"
             position: 1

--- a/definitions/tools/varscan_germline.cwl
+++ b/definitions/tools/varscan_germline.cwl
@@ -19,7 +19,10 @@ inputs:
             position: 1
         secondaryFiles: [^.bai]
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             position: 2
     strand_filter:

--- a/definitions/tools/varscan_somatic.cwl
+++ b/definitions/tools/varscan_somatic.cwl
@@ -21,7 +21,10 @@ inputs:
             position: 2
         secondaryFiles: [^.bai]
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             position: 3
     strand_filter:

--- a/definitions/tools/vep.cwl
+++ b/definitions/tools/vep.cwl
@@ -79,7 +79,11 @@ inputs:
                        }
                   position: 6
     reference:
-        type: string?
+        type:
+            - "null"
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict, .index]
         inputBinding:
             prefix: "--fasta" 
             position: 7


### PR DESCRIPTION
This is an updated version of the idea first presented in #682 (and potentially addresses #674).

I wanted to get this PR open, but we shouldn't merge this quite yet.  Using this version of the workflow requires a patch to Cromwell.  I have a change that makes it work as before when a `string` is supplied, but I'm still testing further changes to make Cromwell work correctly when a `File` is used instead.

