### PR TITLE
switch to total alt abundance filtering for sv read filtering

### DIFF
--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -112,12 +112,10 @@ inputs:
         type: boolean
     merge_min_sv_size:
         type: int
-    sv_filter_paired_percentage:
+    sv_alt_abundance_percentage:
         type: double?
     sv_filter_paired_count:
         type: int?
-    sv_filter_split_percentage:
-        type: double?
     sv_filter_split_count:
         type: int?
     cnv_filter_deletion_depth:
@@ -358,9 +356,8 @@ steps:
             merge_estimate_sv_distance: merge_estimate_sv_distance
             merge_min_sv_size: merge_min_sv_size
             snps_vcf: detect_variants/final_vcf
-            sv_paired_percentage: sv_filter_paired_percentage
+            sv_alt_abundance_percentage: sv_alt_abundance_percentage
             sv_paired_count: sv_filter_paired_count
-            sv_split_percentage: sv_filter_split_percentage
             sv_split_count: sv_filter_split_count
             genome_build: vep_ensembl_assembly
         out: 

--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -356,7 +356,7 @@ steps:
             merge_estimate_sv_distance: merge_estimate_sv_distance
             merge_min_sv_size: merge_min_sv_size
             snps_vcf: detect_variants/final_vcf
-            sv_alt_abundance_percentage: sv_alt_abundance_percentage
+            sv_alt_abundance_percentage: sv_filter_alt_abundance_percentage
             sv_paired_count: sv_filter_paired_count
             sv_split_count: sv_filter_split_count
             genome_build: vep_ensembl_assembly

--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -112,7 +112,7 @@ inputs:
         type: boolean
     merge_min_sv_size:
         type: int
-    sv_alt_abundance_percentage:
+    sv_filter_alt_abundance_percentage:
         type: double?
     sv_filter_paired_count:
         type: int?

--- a/definitions/subworkflows/single_sample_sv_callers.cwl
+++ b/definitions/subworkflows/single_sample_sv_callers.cwl
@@ -58,12 +58,10 @@ inputs:
         type: File?
     genome_build:
         type: string
-    sv_paired_percentage:
+    sv_alt_abundance_percentage:
         type: double?
     sv_paired_count:
         type: int?
-    sv_split_percentage:
-        type: double?
     sv_split_count:
         type: int?
     cnv_deletion_depth:
@@ -213,13 +211,12 @@ steps:
     run_manta_filter:
         run: ../tools/filter_sv_vcf_read_support.cwl
         in:
+            abundance_percentage: sv_alt_abundance_percentage
             input_vcf: run_manta/tumor_only_variants
             output_vcf_name:
                 default: "filtered_manta.vcf"
             paired_count: sv_paired_count
-            paired_percentage: sv_paired_percentage
             split_count: sv_split_count
-            split_percentage: sv_split_percentage
             vcf_source:
                 default: "manta"
         out:
@@ -237,13 +234,12 @@ steps:
     run_smoove_filter:
         run: ../tools/filter_sv_vcf_read_support.cwl
         in:
+            abundance_percentage: sv_alt_abundance_percentage
             input_vcf: run_smoove/output_vcf
             output_vcf_name:
                 default: "filtered_smoove.vcf"
             paired_count: sv_paired_count
-            paired_percentage: sv_paired_percentage
             split_count: sv_split_count
-            split_percentage: sv_split_percentage
             vcf_source:
                 default: "smoove"
         out:

--- a/definitions/tools/filter_sv_vcf_read_support.cwl
+++ b/definitions/tools/filter_sv_vcf_read_support.cwl
@@ -39,7 +39,7 @@ requirements:
 inputs:
     abundance_percentage:
         type: double?
-        default: 0.2
+        default: 0.1
         inputBinding:
             position: 1
         doc: "required alternate read abundance percentage to pass"

--- a/definitions/tools/filter_sv_vcf_read_support.cwl
+++ b/definitions/tools/filter_sv_vcf_read_support.cwl
@@ -15,21 +15,20 @@ requirements:
         entry: |
           #!/bin/bash
           set -eou pipefail
-          
-          input_vcf="$1"
-          output_vcf="$2"
-          paired_count="$3"
-          paired_perc="$4"
+
+          abundance="$1"
+          input_vcf="$2"
+          output_vcf="$3"
+          paired_count="$4"
           split_count="$5"
-          split_perc="$6"
-          vcf_source="$7"
+          vcf_source="$6"
 
           if [ "$vcf_source" == "smoove" ]; then
             echo "Running filter for smoove vcf"
-            filter_expression="(AS >= $split_count && (AS / (RS+AS) >= $split_perc)) && (AP >= $paired_count && (AP / (AP+RP) >= $paired_perc))"
+            filter_expression="((AS >= $split_count) && (AP >= $paired_count) && ((AP+AS) / (AP+RP+AS+RS) >= $abundance))"
           elif [ "$vcf_source" ==  "manta" ]; then
             echo "Running filter for manta vcf"
-            filter_expression="(SR[0:*]=\".\" || (SR[0:1] >= $split_count && (SR[0:1] / (SR[0:0]+SR[0:1]) >= $split_perc))) && (PR[0:1] >= $paired_count && (PR[0:1] / (PR[0:0]+PR[0:1]) >= $paired_perc))"
+            filter_expression="((SR[0:*]=\".\" || (SR[0:1] >= $split_count)) && (PR[0:1] >= $paired_count) && ((SR[0:*]=\".\" && (PR[0:1] / (PR[0:0]+PR[0:1]) >= $abundance))|| ((SR[0:1]+PR[0:1]) / (SR[0:0]+SR[0:1]+PR[0:1]+PR[0:0]) >= $abundance)))"
           else
             echo "vcf source: '$vcf_source' is not supported for SV filtering"
             exit 1
@@ -38,47 +37,41 @@ requirements:
           /opt/bcftools/bin/bcftools filter "$input_vcf" -o "$output_vcf" -i "$filter_expression"
 
 inputs:
+    abundance_percentage:
+        type: double?
+        default: 0.2
+        inputBinding:
+            position: 1
+        doc: "required alternate read abundance percentage to pass"
     input_vcf:
         type: File
         inputBinding:
-            position: 1
+            position: 2
         doc: "vcf file to filter"
     output_vcf_name:
         type: string?
         default: "filtered_sv.vcf"
         inputBinding:
-            position: 2
+            position: 3
         doc: "output vcf file name"
     paired_count:
         type: int?
         default: 2
         inputBinding:
-            position: 3
-        doc: "number of alternate paired reads support needed to pass"
-    paired_percentage:
-        type: double?
-        default: 0.2
-        inputBinding:
             position: 4
-        doc: "required alternate paired read abundance percentage to pass"
+        doc: "number of alternate paired reads support needed to pass"
     split_count:
         type: int?
         default: 2
         inputBinding:
             position: 5
         doc: "if present in variant, number of alternate split reads support needed to pass"
-    split_percentage:
-        type: double?
-        default: 0.2
-        inputBinding:
-            position: 6
-        doc: "if present in variant, required alternate split read abundance percentage to pass"
     vcf_source:
         type:
           - type: enum
             symbols: ["manta", "smoove"]
         inputBinding:
-          position: 7
+          position: 6
         doc: "source caller of the vcf input file"
 
 outputs:


### PR DESCRIPTION
This pr modifies the paired/split read filtering for SVs by switching to a total alt abundance filter instead of paired alt abundance AND split alt abundance. 
Previously you could have a call with 10 split alt, 0 split ref, 2 paired alt, and 4 paired ref which would be filtered out because the paired alt abundance wouldn't meet the default 20% abundance requirement. 
With this new total alt abundance the call would pass
(10+2)/(10+0+2+4) = 75% 

Will need to wait till PR #756 is merged because this modifies the inputs.