### PR TITLE
Immuno workflow bugfixes

### DIFF
--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -51,8 +51,6 @@ inputs:
         type: File
     ribosomal_intervals:
         type: File
-    reference_transcriptome:
-        type: File
 
     #somatic inputs
     reference: string
@@ -306,24 +304,6 @@ outputs:
     chart:
         type: File
         outputSource: rnaseq/chart
-    fusion_evidence:
-        type: File
-        outputSource: rnaseq/fusion_evidence
-    unfiltered_fusion_seqs:
-        type: File
-        outputSource: rnaseq/unfiltered_fusion_seqs
-    unfiltered_fusions_json:
-        type: File
-        outputSource: rnaseq/unfiltered_fusions_json
-    filtered_fusion_seqs:
-        type: File
-        outputSource: rnaseq/filtered_fusion_seqs
-    filtered_fusions_json:
-        type: File
-        outputSource: rnaseq/filtered_fusions_json
-    final_fusion_calls:
-        type: File
-        outputSource: rnaseq/final_fusion_calls
 
     tumor_cram:
         type: File
@@ -654,11 +634,10 @@ steps:
             strand: strand
             refFlat: refFlat
             ribosomal_intervals: ribosomal_intervals
-            reference_transcriptome: reference_transcriptome
             species: vep_ensembl_species
             assembly: vep_ensembl_assembly
         out:
-            [final_bam, stringtie_transcript_gtf, stringtie_gene_expression_tsv, transcript_abundance_tsv, transcript_abundance_h5, gene_abundance, metrics, chart, fusion_evidence, unfiltered_fusion_seqs, unfiltered_fusions_json, filtered_fusion_seqs, filtered_fusions_json, final_fusion_calls]
+            [final_bam, stringtie_transcript_gtf, stringtie_gene_expression_tsv, transcript_abundance_tsv, transcript_abundance_h5, gene_abundance, metrics, chart, fusion_evidence]
     somatic:
         run: somatic_exome.cwl
         in:

--- a/definitions/pipelines/rnaseq.cwl
+++ b/definitions/pipelines/rnaseq.cwl
@@ -49,8 +49,6 @@ inputs:
         type: File
     ribosomal_intervals:
         type: File
-    reference_transcriptome:
-        type: File
     species:
         type: string
         doc: 'the species being analyzed, such as homo_sapiens or mus_musculus'
@@ -86,21 +84,6 @@ outputs:
     fusion_evidence:
         type: File
         outputSource: kallisto/fusion_evidence
-    unfiltered_fusion_seqs:
-        type: File
-        outputSource: pizzly/unfiltered_fusion_seqs
-    unfiltered_fusions_json:
-        type: File
-        outputSource: pizzly/unfiltered_fusions_json
-    filtered_fusion_seqs:
-        type: File
-        outputSource: pizzly/filtered_fusion_seqs
-    filtered_fusions_json:
-        type: File
-        outputSource: pizzly/filtered_fusions_json
-    final_fusion_calls:
-        type: File
-        outputSource: grolar/parsed_fusion_calls
 steps:
     bam_to_trimmed_fastq_and_hisat_alignments:
         run: ../subworkflows/bam_to_trimmed_fastq_and_hisat_alignments.cwl
@@ -172,26 +155,3 @@ steps:
             bam: index_bam/indexed_bam
         out:
             [metrics, chart]
-    get_index_kmer_size:
-        run: ../tools/kmer_size_from_index.cwl
-        in: 
-            kallisto_index: kallisto_index
-        out:
-            [kmer_length]
-    pizzly:
-        run: ../tools/pizzly.cwl
-        in:
-            kallisto_kmer_size: get_index_kmer_size/kmer_length
-            transcriptome_annotations: reference_annotation
-            reference_transcriptome: reference_transcriptome
-            fusion_evidence: kallisto/fusion_evidence
-        out:
-            [unfiltered_fusion_seqs, unfiltered_fusions_json, filtered_fusion_seqs, filtered_fusions_json]
-    grolar:
-        run: ../tools/grolar.cwl
-        in:
-            pizzly_calls: pizzly/filtered_fusions_json
-            species: species
-            assembly: assembly
-        out:
-            [parsed_fusion_calls]

--- a/definitions/tools/grolar.cwl
+++ b/definitions/tools/grolar.cwl
@@ -100,7 +100,7 @@ requirements:
            
              if(length(output) < 1){
                print("No fusions exist in pizzly input. Creating empty output file")
-               file.create(paste0(JSON_file, "_fusions_filt_sorted.simple.txt"))
+               file.create(paste0(basename(JSON_file), "_fusions_filt_sorted.txt"))
                quit(status=0)
              }
            

--- a/definitions/tools/mutect.cwl
+++ b/definitions/tools/mutect.cwl
@@ -24,7 +24,7 @@ requirements:
             /gatk/gatk Mutect2 -O $1 -R $2 -I $3 -tumor $TUMOR -I $4 -normal $NORMAL -L $5 #Running Mutect2.
             gunzip mutect.vcf.gz #Unzipping the Mutect2 output vcf file to alter the header names.
             grep "^##" mutect.vcf >mutect.final.vcf #Extracting all the lines above #CHROM in the vcf to a new output vcf.
-            grep "^#CHROM" mutect.vcf | sed "s/\t$TUMOR/\tTUMOR/g; s/\t$NORMAL/\tNORMAL/g" >> mutect.final.vcf #Concatenating the #CHROM line with substituted sample headers to the output vcf.
+            grep "^#CHROM" mutect.vcf | sed "s/\<$TUMOR\>/TUMOR/g; s/\<$NORMAL\>/NORMAL/g" >> mutect.final.vcf #Concatenating the #CHROM line with substituted sample headers to the output vcf.
             grep -v "^#" mutect.vcf >> mutect.final.vcf #Concatenating the sites to the output vcf.
             bgzip mutect.final.vcf #Bzipping the final output vcf.
             tabix mutect.final.vcf.gz #Indexing the bzipped output vcf.


### PR DESCRIPTION
This PR contains 2 small updates meant to fix bugs encountered while testing the workflow with new data. Grolar was updated to generate its output file in the correct location if there is no data for it to parse, and the mutect sample renaming logic was updated to account for tumor/normal pairs where the samples have similar names (in this case, HCC1395 and HCC1395_BL, respectively).