### PR TITLE
Sv changes to wgs pipeline

### DIFF
--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -112,12 +112,10 @@ inputs:
         type: boolean
     merge_min_sv_size:
         type: int
-    sv_filter_paired_percentage:
+    sv_filter_alt_abundance_percentage:
         type: double?
     sv_filter_paired_count:
         type: int?
-    sv_filter_split_percentage:
-        type: double?
     sv_filter_split_count:
         type: int?
     cnv_filter_deletion_depth:
@@ -130,6 +128,8 @@ inputs:
          type: string[]?
     vep_to_table_fields:
          type: string[]?
+    cnv_filter_min_size:
+         type: int?
 outputs:
     cram:
         type: File
@@ -251,18 +251,33 @@ outputs:
     smoove_output_variants:
         type: File
         outputSource: sv_detect_variants/smoove_output_variants
-    merged_sv_vcf:
-        type: File
-        outputSource: sv_detect_variants/merged_sv_vcf
     final_tsv:
         type: File
         outputSource: detect_variants/final_tsv
-    merged_annotated_sv_tsvs:
+    cnvkit_filtered_vcf:
         type: File
-        outputSource: sv_detect_variants/merged_annotated_tsv
-    filtered_sv_vcfs:
-        type: File[]
-        outputSource: sv_detect_variants/filtered_sv_vcfs
+        outputSource: sv_detect_variants/cnvkit_filtered_vcf
+    cnvnator_filtered_vcf:
+        type: File
+        outputSource: sv_detect_variants/cnvnator_filtered_vcf
+    manta_filtered_vcf:
+        type: File
+        outputSource: sv_detect_variants/manta_filtered_vcf
+    smoove_filtered_vcf:
+        type: File
+        outputSource: sv_detect_variants/smoove_filtered_vcf
+    survivor_merged_vcf:
+        type: File
+        outputSource: sv_detect_variants/survivor_merged_vcf
+    survivor_merged_annotated_tsv:
+        type: File
+        outputSource: sv_detect_variants/survivor_merged_annotated_tsv
+    bcftools_merged_vcf:
+        type: File
+        outputSource: sv_detect_variants/bcftools_merged_vcf
+    bcftools_merged_annotated_tsv:
+        type: File
+        outputSource: sv_detect_variants/bcftools_merged_annotated_tsv
 steps:
     alignment_and_qc:
         run: wgs_alignment.cwl
@@ -347,6 +362,7 @@ steps:
             cnvkit_vcf_name: cnvkit_vcf_name
             cnv_deletion_depth: cnv_filter_deletion_depth
             cnv_duplication_depth: cnv_filter_duplication_depth
+            cnv_filter_min_size: cnv_filter_min_size
             manta_call_regions: manta_call_regions
             manta_non_wgs: manta_non_wgs
             manta_output_contigs: manta_output_contigs
@@ -358,13 +374,12 @@ steps:
             merge_estimate_sv_distance: merge_estimate_sv_distance
             merge_min_sv_size: merge_min_sv_size
             snps_vcf: detect_variants/final_vcf
-            sv_paired_percentage: sv_filter_paired_percentage
+            sv_alt_abundance_percentage: sv_filter_alt_abundance_percentage
             sv_paired_count: sv_filter_paired_count
-            sv_split_percentage: sv_filter_split_percentage
             sv_split_count: sv_filter_split_count
             genome_build: vep_ensembl_assembly
         out: 
-           [cn_diagram, cn_scatter_plot, tumor_antitarget_coverage, tumor_target_coverage, tumor_bin_level_ratios, tumor_segmented_ratios, cnvkit_vcf, cnvnator_cn_file, cnvnator_root, cnvnator_vcf, manta_diploid_variants, manta_somatic_variants, manta_all_candidates, manta_small_candidates, manta_tumor_only_variants, smoove_output_variants, merged_sv_vcf, merged_annotated_tsv, filtered_sv_vcfs]
+           [cn_diagram, cn_scatter_plot, tumor_antitarget_coverage, tumor_target_coverage, tumor_bin_level_ratios, tumor_segmented_ratios, cnvkit_vcf, cnvnator_cn_file, cnvnator_root, cnvnator_vcf, manta_diploid_variants, manta_somatic_variants, manta_all_candidates, manta_small_candidates, manta_tumor_only_variants, smoove_output_variants, cnvkit_filtered_vcf, cnvnator_filtered_vcf, manta_filtered_vcf, smoove_filtered_vcf, survivor_merged_vcf, survivor_merged_annotated_tsv, bcftools_merged_vcf, bcftools_merged_annotated_tsv]
     bam_to_cram:
         run: ../tools/bam_to_cram.cwl
         in:

--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -278,6 +278,9 @@ outputs:
     bcftools_merged_annotated_tsv:
         type: File
         outputSource: sv_detect_variants/bcftools_merged_annotated_tsv
+    bcftools_merged_filtered_annotated_tsv:
+        type: File
+        outputSource: sv_detect_variants/bcftools_merged_filtered_annotated_tsv
 steps:
     alignment_and_qc:
         run: wgs_alignment.cwl
@@ -379,7 +382,7 @@ steps:
             sv_split_count: sv_filter_split_count
             genome_build: vep_ensembl_assembly
         out: 
-           [cn_diagram, cn_scatter_plot, tumor_antitarget_coverage, tumor_target_coverage, tumor_bin_level_ratios, tumor_segmented_ratios, cnvkit_vcf, cnvnator_cn_file, cnvnator_root, cnvnator_vcf, manta_diploid_variants, manta_somatic_variants, manta_all_candidates, manta_small_candidates, manta_tumor_only_variants, smoove_output_variants, cnvkit_filtered_vcf, cnvnator_filtered_vcf, manta_filtered_vcf, smoove_filtered_vcf, survivor_merged_vcf, survivor_merged_annotated_tsv, bcftools_merged_vcf, bcftools_merged_annotated_tsv]
+           [cn_diagram, cn_scatter_plot, tumor_antitarget_coverage, tumor_target_coverage, tumor_bin_level_ratios, tumor_segmented_ratios, cnvkit_vcf, cnvnator_cn_file, cnvnator_root, cnvnator_vcf, manta_diploid_variants, manta_somatic_variants, manta_all_candidates, manta_small_candidates, manta_tumor_only_variants, smoove_output_variants, cnvkit_filtered_vcf, cnvnator_filtered_vcf, manta_filtered_vcf, smoove_filtered_vcf, survivor_merged_vcf, survivor_merged_annotated_tsv, bcftools_merged_vcf, bcftools_merged_annotated_tsv, bcftools_merged_filtered_annotated_tsv]
     bam_to_cram:
         run: ../tools/bam_to_cram.cwl
         in:

--- a/definitions/subworkflows/cnvkit_single_sample.cwl
+++ b/definitions/subworkflows/cnvkit_single_sample.cwl
@@ -24,6 +24,7 @@ inputs:
         type: File
     cnvkit_vcf_name:
         type: string?
+        default: "cnvkit.vcf"
     segment_filter:
         type:
           - "null"
@@ -73,16 +74,6 @@ steps:
             cns_file: cnvkit_main/tumor_segmented_ratios
             male_reference: male_reference
             cnr_file: cnvkit_main/tumor_bin_level_ratios
-            output_name: 
-                source: cnvkit_vcf_name
-                valueFrom: |
-                    ${  
-                        if(inputs.output_name) {
-                            return inputs.output_name;
-                        }   
-                        else {
-                            return inputs.tumor_bam.nameroot + ".cnvkit.vcf"
-                        }   
-                    }
+            output_name: cnvkit_vcf_name
         out:
             [cnvkit_vcf]

--- a/definitions/subworkflows/merge_svs.cwl
+++ b/definitions/subworkflows/merge_svs.cwl
@@ -37,6 +37,9 @@ outputs:
     bcftools_merged_annotated_tsv:
         type: File
         outputSource: bcftools_annotate_variants/sv_variants_tsv
+    bcftools_merged_filtered_annotated_tsv:
+       type: File
+       outputSource: bcftools_annotsv_filter/filtered_tsv
     survivor_merged_sv_vcf:
         type: File
         outputSource: survivor_bgzip_merged_sv_vcf/bgzipped_file
@@ -100,6 +103,14 @@ steps:
                 valueFrom: ${ return [ self ]; }
         out:
             [sv_variants_tsv]
+    bcftools_annotsv_filter:
+        run: ../tools/annotsv_filter.cwl
+        in:
+            annotsv_tsv: bcftools_annotate_variants/sv_variants_tsv
+            filtering_frequency:
+                default: "0.05"
+        out:
+            [filtered_tsv]
     bcftools_bgzip_merged_sv_vcf:
         run: ../tools/bgzip.cwl
         in:

--- a/definitions/subworkflows/merge_svs.cwl
+++ b/definitions/subworkflows/merge_svs.cwl
@@ -4,6 +4,7 @@ cwlVersion: v1.0
 class: Workflow
 label: "Merge, annotate, and generate a TSV for SVs"
 requirements:
+    - class: ScatterFeatureRequirement
     - class: SubworkflowFeatureRequirement
     - class: StepInputExpressionRequirement
     - class: InlineJavascriptRequirement
@@ -30,14 +31,20 @@ inputs:
     sv_vcfs:
         type: File[]
 outputs:
-    merged_sv_vcf:
+    bcftools_merged_sv_vcf:
         type: File
-        outputSource: bgzip_merged_sv_vcf/bgzipped_file
-    merged_annotated_tsv:
+        outputSource: bcftools_bgzip_merged_sv_vcf/bgzipped_file
+    bcftools_merged_annotated_tsv:
         type: File
-        outputSource: annotate_variants/sv_variants_tsv
+        outputSource: bcftools_annotate_variants/sv_variants_tsv
+    survivor_merged_sv_vcf:
+        type: File
+        outputSource: survivor_bgzip_merged_sv_vcf/bgzipped_file
+    survivor_merged_annotated_tsv:
+        type: File
+        outputSource: survivor_annotate_variants/sv_variants_tsv
 steps:
-    merge_sv_vcfs:
+    survivor_merge_sv_vcfs:
         run: ../tools/survivor.cwl
         in: 
             vcfs: sv_vcfs
@@ -47,22 +54,55 @@ steps:
             same_strand: same_strand
             estimate_sv_distance: estimate_sv_distance
             minimum_sv_size: minimum_sv_size
-            cohort_name: cohort_name
+            cohort_name:
+                default: "SURVIVOR-sv-merged.vcf"
         out:
             [merged_vcf]
-    annotate_variants:
+    survivor_annotate_variants:
         run: ../tools/annotsv.cwl
         in:
             genome_build: genome_build
-            input_vcf: merge_sv_vcfs/merged_vcf
+            input_vcf: survivor_merge_sv_vcfs/merged_vcf
+            output_tsv_name:
+                default: "SURVIVOR-merged-AnnotSV.tsv"
             snps_vcf:
                 source: [snps_vcf]
                 valueFrom: ${ return [ self ]; }
         out:
             [sv_variants_tsv]
-    bgzip_merged_sv_vcf:
+    survivor_bgzip_merged_sv_vcf:
         run: ../tools/bgzip.cwl
         in:
-            file: merge_sv_vcfs/merged_vcf
+            file: survivor_merge_sv_vcfs/merged_vcf
+        out:
+            [bgzipped_file]
+    bcftools_merge_sv_vcfs:
+        run: ../tools/bcftools_merge.cwl
+        in:
+            merge_method:
+                default: "none"
+            output_type:
+                default: "v"
+            output_vcf_name:
+                default: "bcftools-sv-merged.vcf"
+            vcfs: sv_vcfs
+        out:
+            [merged_sv_vcf]
+    bcftools_annotate_variants:
+        run: ../tools/annotsv.cwl
+        in:
+            genome_build: genome_build
+            input_vcf: bcftools_merge_sv_vcfs/merged_sv_vcf
+            output_tsv_name:
+                default: "bcftools-merged-AnnotSV.tsv"
+            snps_vcf:
+                source: [snps_vcf]
+                valueFrom: ${ return [ self ]; }
+        out:
+            [sv_variants_tsv]
+    bcftools_bgzip_merged_sv_vcf:
+        run: ../tools/bgzip.cwl
+        in:
+            file: bcftools_merge_sv_vcfs/merged_sv_vcf
         out:
             [bgzipped_file]

--- a/definitions/subworkflows/single_sample_sv_callers.cwl
+++ b/definitions/subworkflows/single_sample_sv_callers.cwl
@@ -144,6 +144,9 @@ outputs:
     bcftools_merged_annotated_tsv:
         type: File
         outputSource: run_merge/bcftools_merged_annotated_tsv
+    bcftools_merged_filtered_annotated_tsv:
+        type: File
+        outputSource: run_merge/bcftools_merged_filtered_annotated_tsv
 steps:
     run_cnvkit:
         run: cnvkit_single_sample.cwl
@@ -292,4 +295,4 @@ steps:
                 source: [run_cnvkit_filter/filtered_vcf, run_cnvnator_filter/filtered_vcf, run_manta_filter/filtered_vcf, run_smoove_filter/filtered_vcf]
                 linkMerge: merge_flattened
         out:
-            [bcftools_merged_sv_vcf, bcftools_merged_annotated_tsv, survivor_merged_sv_vcf, survivor_merged_annotated_tsv]
+            [bcftools_merged_sv_vcf, bcftools_merged_annotated_tsv, bcftools_merged_filtered_annotated_tsv, survivor_merged_sv_vcf, survivor_merged_annotated_tsv]

--- a/definitions/subworkflows/sv_depth_caller_filter.cwl
+++ b/definitions/subworkflows/sv_depth_caller_filter.cwl
@@ -1,0 +1,58 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+label: "Filter single sample sv vcf from depth callers(cnvkit/cnvnator)"
+
+inputs:
+    deletion_depth:
+        type: double?
+    duplication_depth:
+        type: double?
+    reference:
+        type: string
+    min_sv_size:
+        type: int?
+    output_vcf_name:
+        type: string?
+    sv_vcf:
+        type: File
+    vcf_source:
+        type:
+          - type: enum
+            symbols: ["cnvkit", "cnvnator"]
+outputs:
+    filtered_vcf:
+        type: File
+        outputSource: filtered_vcf_index/indexed_vcf
+steps:
+    size_filter:
+        run: ../tools/filter_sv_vcf_size.cwl
+        in:
+            input_vcf: sv_vcf
+            size_method:
+                default: "min_len"
+            sv_size: min_sv_size
+        out:
+            [filtered_sv_vcf]
+    depth_filter:
+        run: ../tools/filter_sv_vcf_depth.cwl
+        in:
+            input_vcf: size_filter/filtered_sv_vcf
+            deletion_depth: deletion_depth
+            duplication_depth: duplication_depth
+            output_vcf_name: output_vcf_name
+            vcf_source: vcf_source
+        out:
+            [filtered_sv_vcf]
+    filtered_vcf_bgzip:
+        run: ../tools/bgzip.cwl
+        in:
+            file: depth_filter/filtered_sv_vcf
+        out: [bgzipped_file]
+    filtered_vcf_index:
+        run: ../tools/index_vcf.cwl
+        in:
+            vcf: filtered_vcf_bgzip/bgzipped_file
+        out:
+            [indexed_vcf]

--- a/definitions/subworkflows/sv_paired_read_caller_filter.cwl
+++ b/definitions/subworkflows/sv_paired_read_caller_filter.cwl
@@ -1,0 +1,77 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+label: "Filter single sample sv vcf from paired read callers(Manta/Smoove)"
+
+inputs:
+    abundance_percentage:
+        type: double?
+    bam:
+        type: File
+    deletion_depth:
+        type: double?
+    duplication_depth:
+        type: double?
+    output_vcf_name:
+        type: string?
+    reference:
+        type: string
+    snps_vcf:
+        type: File?
+    sv_paired_count:
+        type: int?
+    sv_split_count:
+        type: int?
+    sv_vcf:
+        type: File
+    vcf_source:
+        type:
+          - type: enum
+            symbols: ["manta", "smoove"]
+outputs:
+    filtered_vcf:
+        type: File
+        outputSource: filtered_vcf_index/indexed_vcf
+steps:
+    read_support_filter:
+        run: ../tools/filter_sv_vcf_read_support.cwl
+        in:
+            abundance_percentage: abundance_percentage
+            input_vcf: sv_vcf
+            paired_count: sv_paired_count
+            split_count: sv_split_count
+            vcf_source: vcf_source
+        out:
+            [filtered_sv_vcf]
+    duphold_annotate:
+        run: ../tools/duphold.cwl
+        in:
+            bam: bam
+            reference: reference
+            snps_vcf: snps_vcf
+            sv_vcf: read_support_filter/filtered_sv_vcf
+        out:
+            [annotated_sv_vcf]
+    depth_filter:
+        run: ../tools/filter_sv_vcf_depth.cwl
+        in:
+            input_vcf: duphold_annotate/annotated_sv_vcf
+            deletion_depth: deletion_depth
+            duplication_depth: duplication_depth
+            output_vcf_name: output_vcf_name
+            vcf_source:
+                default: "duphold"
+        out:
+            [filtered_sv_vcf]
+    filtered_vcf_bgzip:
+        run: ../tools/bgzip.cwl
+        in:
+            file: depth_filter/filtered_sv_vcf
+        out: [bgzipped_file]
+    filtered_vcf_index:
+        run: ../tools/index_vcf.cwl
+        in:
+            vcf: filtered_vcf_bgzip/bgzipped_file
+        out:
+            [indexed_vcf]

--- a/definitions/tools/annotsv_filter.cwl
+++ b/definitions/tools/annotsv_filter.cwl
@@ -1,0 +1,89 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: "filter AnnotSV tsv output generated from a bcftools merged vcf"
+
+baseCommand: ["python3", "AnnotSV_filter.py"]
+
+requirements:
+    - class: DockerRequirement
+      dockerPull: "python:3"
+    - class: ResourceRequirement
+      ramMin: 4000
+    - class: InitialWorkDirRequirement
+      listing:
+      - entryname: "AnnotSV_filter.py"
+        entry: |
+            import argparse
+            import csv
+            import sys
+
+            parser = argparse.ArgumentParser()
+            parser.add_argument('--input', '-i', dest="input", help='input AnnotSV tsv file', required=True, action="store")
+            parser.add_argument('--output', '-o', dest="output", help='output tsv file name', required=True, action="store")
+            parser.add_argument('--filtering_frequency', dest="filtering_frequency", help="frequency to filter with", action="store", type=float, default="0.05")
+            parser.add_argument('--all-CDS', dest="CDS", help="Do not require a positive CoDing Sequence overlap", action="store_true")
+            parser.add_argument('--ignore-pass-filter', dest="filter", help="Do not require calls to have a PASS filter", action="store_true")
+
+            args = parser.parse_args()
+            input_file_name  = args.input
+            output_file_name = args.output
+            filtering_frequency = args.filtering_frequency
+            all_cds = args.CDS
+            ignore_pass_filter = args.filter
+
+            with open(input_file_name, 'r') as file_in, open(output_file_name, 'w') as file_out:
+                file_in = csv.DictReader(file_in, delimiter='\t')
+                file_out = csv.DictWriter(file_out, fieldnames=file_in.fieldnames, delimiter='\t')
+                file_out.writeheader()
+                total_sv_count = 0
+                pass_sv_count = 0
+                for row in file_in:
+                    total_sv_count += 1
+                    if(row['AnnotSV type'] == 'split' \
+                        and (row['FILTER'] == 'PASS' or ignore_pass_filter) \
+                        and (int(row['CDS length']) > 0 or all_cds) \
+                        and float(row['IMH_AF']) < filtering_frequency
+                        and float(row['1000g_max_AF']) < filtering_frequency
+                        and not(float(row['DGV_LOSS_Frequency']) > filtering_frequency and 'DEL' in row['SV type']) 
+                        and not(float(row['DGV_GAIN_Frequency']) < filtering_frequency and ('DUP' in row['SV type'] or 'INS' in row['SV type']))
+                        and not(('Manta' in row['ID'] and 'IMPRECISE' in row['INFO']) or (row['QUAL'] != '.' and 'IMPRECISE' in row['INFO'])) ):
+                        file_out.writerow(row)
+                        pass_sv_count += 1
+                print("total sv count:",total_sv_count)
+                print("total sv passed count:",pass_sv_count)
+
+inputs:
+    all_CDS:
+        type: boolean?
+        inputBinding:
+            position: 1
+            prefix: "--all-CDS"
+    annotsv_tsv:
+        type: File
+        inputBinding:
+            position: 2
+            prefix: "--input"
+    filtering_frequency:
+        type: double?
+        inputBinding:
+            position: 3
+            prefix: "--filtering_frequency"
+    ignore_pass_filter:
+        type: boolean?
+        inputBinding:
+            position: 4
+            prefix: "--ignore-pass-filter"
+    output_tsv_name:
+        type: string?
+        default: "filtered-bcftools-merged-AnnotSV.tsv"
+        inputBinding:
+            position: 5
+            prefix: "--output"
+
+outputs:
+    filtered_tsv:
+        type: File
+        outputBinding:
+            glob: $(inputs.output_tsv_name)

--- a/definitions/tools/cnvnator.cwl
+++ b/definitions/tools/cnvnator.cwl
@@ -34,15 +34,15 @@ requirements:
           awk 'BEGIN { CHROM="" } { if ($1~"^>") CHROM=substr($1,2); print $0 > "FASTA_CHRS/"CHROM".fa" }' "$REFERENCE"
                     
           # extract read mapping from input bam(single sample)
-          cnvnator -root "${SAMPLE}.root" -tree "$BAM" -chrom "$CHROMOSOMES"
+          cnvnator -root "${SAMPLE}.root" -tree "$BAM" -chrom $CHROMOSOMES
           # generate read depth histogram
-          cnvnator -root "${SAMPLE}.root" -his "${BIN_SIZE}" -d FASTA_CHRS/ -chrom "$CHROMOSOMES"
+          cnvnator -root "${SAMPLE}.root" -his "${BIN_SIZE}" -d FASTA_CHRS/ -chrom $CHROMOSOMES
           # calculate statistics
-          cnvnator -root "${SAMPLE}.root" -stat "${BIN_SIZE}" -chrom "$CHROMOSOMES"
+          cnvnator -root "${SAMPLE}.root" -stat "${BIN_SIZE}" -chrom $CHROMOSOMES
           # read depth signal partitioning
-          cnvnator -root "${SAMPLE}.root" -partition "${BIN_SIZE}" -chrom "$CHROMOSOMES"
+          cnvnator -root "${SAMPLE}.root" -partition "${BIN_SIZE}" -chrom $CHROMOSOMES
           # cnv calling
-          cnvnator -root "${SAMPLE}.root" -call "${BIN_SIZE}" -chrom "$CHROMOSOMES" > "${SAMPLE}.CNVnator.cn"
+          cnvnator -root "${SAMPLE}.root" -call "${BIN_SIZE}" -chrom $CHROMOSOMES > "${SAMPLE}.CNVnator.cn"
 
           # convert to vcf
           cnvnator2VCF.pl -reference "$REFERENCE" "${SAMPLE}.CNVnator.cn" FASTA_CHRS/ >  "${SAMPLE}.CNVnator.vcf"

--- a/definitions/tools/duphold.cwl
+++ b/definitions/tools/duphold.cwl
@@ -10,7 +10,7 @@ requirements:
     - class: ResourceRequirement
       ramMin: 10000
     - class: DockerRequirement
-      dockerPull: "mgibio/duphold-cwl:0.1.4"
+      dockerPull: "mgibio/duphold-cwl:0.1.5"
 
 inputs:
     bam:


### PR DESCRIPTION
This changes a few things and ended up being a bigger PR than I expected. 
- cnvkit subworkflow
  make default vcf name. previous tumor.nameroot expression does not work unless tumor bam is passed into the tool. Even though the tool itself doesn't use the input.
- remove the quotes around the CHROMOSOMES variable in the cnvnator shell script 
  was causing the input chromosomes to be parsed as a single chromosome 'chr1 chr2 chr3 ...' instead of 'chr1' 'chr2' 'chr3' ...
- update duphold docker image version 
  previous version had an issue where some manta duplications were not being annotated and then were being filtered out because they had no annotation.
- add bcftools sv merging and annotating with AnnotSV into the merge svs subworkflow
- move depth based sv caller filtering to a subworkflow
- move split/paired based sv caller filtering to a subworkflow
  still does the split/paired filtering
  added duphold annotating and filtering duplications and deletions based on expected coverage 
- add inputs/outputs to germline wgs pipeline
  add min sv size input to top workflow. Some users would like to remove the small variants called by the copy number callers and some do not.
- This PR also include changes from PR #775 