### PR TITLE
Remove bigwig generation from WGS QC process.

### DIFF
--- a/definitions/pipelines/alignment_wgs.cwl
+++ b/definitions/pipelines/alignment_wgs.cwl
@@ -93,9 +93,6 @@ outputs:
     summary_hs_metrics:
         type: File[]
         outputSource: qc/summary_hs_metrics
-    bamcoverage_bigwig:
-        type: File
-        outputSource: qc/bamcoverage_bigwig
 steps:
     alignment:
         run: ../subworkflows/sequence_to_bqsr.cwl
@@ -120,4 +117,4 @@ steps:
             per_base_intervals: per_base_intervals
             per_target_intervals: per_target_intervals
             summary_intervals: summary_intervals
-        out: [insert_size_metrics, insert_size_histogram, alignment_summary_metrics, gc_bias_metrics, gc_bias_metrics_chart, gc_bias_metrics_summary, wgs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth, per_base_coverage_metrics, per_base_hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, summary_hs_metrics, bamcoverage_bigwig]
+        out: [insert_size_metrics, insert_size_histogram, alignment_summary_metrics, gc_bias_metrics, gc_bias_metrics_chart, gc_bias_metrics_summary, wgs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth, per_base_coverage_metrics, per_base_hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, summary_hs_metrics]

--- a/definitions/pipelines/chipseq.cwl
+++ b/definitions/pipelines/chipseq.cwl
@@ -99,9 +99,6 @@ outputs:
     summary_hs_metrics:
         type: File[]
         outputSource: qc/summary_hs_metrics
-    bamcoverage_bigwig:
-        type: File
-        outputSource: qc/bamcoverage_bigwig
     tag_directory:
         type: Directory
         outputSource: homer_tag_directory/tag_directory
@@ -144,4 +141,4 @@ steps:
             per_base_intervals: per_base_intervals
             per_target_intervals: per_target_intervals
             summary_intervals: summary_intervals
-        out: [insert_size_metrics, insert_size_histogram, alignment_summary_metrics, gc_bias_metrics, gc_bias_metrics_chart, gc_bias_metrics_summary, wgs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth, per_base_coverage_metrics, per_base_hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, summary_hs_metrics, bamcoverage_bigwig]
+        out: [insert_size_metrics, insert_size_histogram, alignment_summary_metrics, gc_bias_metrics, gc_bias_metrics_chart, gc_bias_metrics_summary, wgs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth, per_base_coverage_metrics, per_base_hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, summary_hs_metrics]

--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -200,9 +200,6 @@ outputs:
     summary_hs_metrics:
         type: File[]
         outputSource: alignment_and_qc/summary_hs_metrics
-    bamcoverage_bigwig:
-        type: File
-        outputSource: alignment_and_qc/bamcoverage_bigwig
     cn_diagram:
         type: File?
         outputSource: sv_detect_variants/cn_diagram
@@ -282,7 +279,7 @@ steps:
             per_target_intervals: per_target_intervals
             summary_intervals: summary_intervals
         out:
-            [bam, mark_duplicates_metrics, insert_size_metrics, insert_size_histogram, alignment_summary_metrics, gc_bias_metrics, gc_bias_metrics_chart, gc_bias_metrics_summary, wgs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth, per_base_coverage_metrics, per_base_hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, summary_hs_metrics, bamcoverage_bigwig]
+            [bam, mark_duplicates_metrics, insert_size_metrics, insert_size_histogram, alignment_summary_metrics, gc_bias_metrics, gc_bias_metrics_chart, gc_bias_metrics_summary, wgs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth, per_base_coverage_metrics, per_base_hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, summary_hs_metrics]
     extract_freemix:
         in:
             verify_bam_id_metrics: alignment_and_qc/verify_bam_id_metrics

--- a/definitions/pipelines/tumor_only_wgs.cwl
+++ b/definitions/pipelines/tumor_only_wgs.cwl
@@ -145,9 +145,6 @@ outputs:
     summary_hs_metrics:
         type: File[]
         outputSource: alignment_and_qc/summary_hs_metrics
-    bamcoverage_bigwig:
-        type: File
-        outputSource: alignment_and_qc/bamcoverage_bigwig
 steps:
     alignment_and_qc:
         run: alignment_wgs.cwl
@@ -166,7 +163,7 @@ steps:
             per_target_intervals: per_target_intervals
             summary_intervals: summary_intervals
         out:
-            [bam, mark_duplicates_metrics, insert_size_metrics, insert_size_histogram, alignment_summary_metrics, gc_bias_metrics, gc_bias_metrics_chart, gc_bias_metrics_summary, wgs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth, per_base_coverage_metrics, per_base_hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, summary_hs_metrics, bamcoverage_bigwig]
+            [bam, mark_duplicates_metrics, insert_size_metrics, insert_size_histogram, alignment_summary_metrics, gc_bias_metrics, gc_bias_metrics_chart, gc_bias_metrics_summary, wgs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth, per_base_coverage_metrics, per_base_hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, summary_hs_metrics]
     detect_variants:
         run: tumor_only_detect_variants.cwl
         in:

--- a/definitions/subworkflows/qc_wgs.cwl
+++ b/definitions/subworkflows/qc_wgs.cwl
@@ -78,9 +78,6 @@ outputs:
     summary_hs_metrics:
         type: File[]
         outputSource: collect_hs_metrics/summary_hs_metrics
-    bamcoverage_bigwig:
-        type: File
-        outputSource: deeptools_bamcoverage/outfile
 steps:
     collect_insert_size_metrics:
         run: ../tools/collect_insert_size_metrics.cwl
@@ -138,10 +135,3 @@ steps:
             summary_intervals: summary_intervals
         out:
             [per_base_coverage_metrics, per_base_hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, summary_hs_metrics]
-    deeptools_bamcoverage:
-        run: ../tools/deeptools_bamcoverage.cwl
-        in:
-            bam: bam
-            min_mapping_quality: minimum_mapping_quality
-        out:
-            [outfile]


### PR DESCRIPTION
The tool is still left in place for now, in case anyone wants to use it for something else.