### PR TITLE
Parameterize custom vep annotations with custom type

### DIFF
--- a/definitions/pipelines/aml_trio_cle.cwl
+++ b/definitions/pipelines/aml_trio_cle.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/vep_custom_annotation.yml
     - class: SubworkflowFeatureRequirement
     - class: StepInputExpressionRequirement
 inputs:
@@ -142,12 +143,11 @@ inputs:
         doc: "ensembl species - Must be present in the cache directory. Examples: homo_sapiens or mus_musculus"
     somalier_vcf:
         type: File
-    custom_gnomad_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
-    custom_clinvar_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
+    vep_custom_annotations:
+        type:
+            - "null"
+            - type: array
+              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
     germline_tsv_prefix:
         type: string?
         default: 'germline_variants'
@@ -460,8 +460,7 @@ steps:
             variants_to_table_fields: variants_to_table_fields
             variants_to_table_genotype_fields: variants_to_table_genotype_fields
             vep_to_table_fields: vep_to_table_fields
-            custom_gnomad_vcf: custom_gnomad_vcf
-            custom_clinvar_vcf: custom_clinvar_vcf
+            vep_custom_annotations: vep_custom_annotations
         out:
             [mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv]
     add_disclaimer_to_tumor_final_tsv:
@@ -544,9 +543,8 @@ steps:
             vep_ensembl_species: vep_ensembl_species
             synonyms_file: synonyms_file
             annotate_coding_only: germline_coding_only
-            custom_gnomad_vcf: custom_gnomad_vcf
+            vep_custom_annotations: vep_custom_annotations
             limit_variant_intervals: variant_reporting_intervals
-            custom_clinvar_vcf: custom_clinvar_vcf
             variants_to_table_fields: germline_variants_to_table_fields
             variants_to_table_genotype_fields: germline_variants_to_table_genotype_fields
             vep_to_table_fields: germline_vep_to_table_fields

--- a/definitions/pipelines/aml_trio_cle.cwl
+++ b/definitions/pipelines/aml_trio_cle.cwl
@@ -144,11 +144,8 @@ inputs:
     somalier_vcf:
         type: File
     vep_custom_annotations:
-        type:
-            - "null"
-            - type: array
-              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              label: "custom type, check types directory for input format"
+        type: ../types/vep_custom_annotation.yml#vep_custom_annotation[]
+        doc: "custom type, check types directory for input format"
     germline_tsv_prefix:
         type: string?
         default: 'germline_variants'

--- a/definitions/pipelines/aml_trio_cle.cwl
+++ b/definitions/pipelines/aml_trio_cle.cwl
@@ -148,7 +148,7 @@ inputs:
             - "null"
             - type: array
               items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              doc: "custom type, check types directory for input format"
+              label: "custom type, check types directory for input format"
     germline_tsv_prefix:
         type: string?
         default: 'germline_variants'

--- a/definitions/pipelines/aml_trio_cle.cwl
+++ b/definitions/pipelines/aml_trio_cle.cwl
@@ -148,6 +148,7 @@ inputs:
             - "null"
             - type: array
               items: ../types/vep_custom_annotation.yml#vep_custom_annotation
+              doc: "custom type, check types directory for input format"
     germline_tsv_prefix:
         type: string?
         default: 'germline_variants'

--- a/definitions/pipelines/aml_trio_cle_gathered.cwl
+++ b/definitions/pipelines/aml_trio_cle_gathered.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/vep_custom_annotation.yml
     - class: SubworkflowFeatureRequirement
     - class: StepInputExpressionRequirement
 inputs:
@@ -140,12 +141,12 @@ inputs:
     vep_to_table_fields:
         type: string[]
         default: [HGVSc,HGVSp]
-    custom_gnomad_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
-    custom_clinvar_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
+    vep_custom_annotations:
+        type:
+            - "null"
+            - type: array
+              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
+              doc: "custom type, check types directory for input format"
     germline_tsv_prefix:
         type: string?
         default: 'germline_variants'
@@ -221,8 +222,7 @@ steps:
             variants_to_table_fields: variants_to_table_fields
             variants_to_table_genotype_fields: variants_to_table_genotype_fields
             vep_to_table_fields: vep_to_table_fields
-            custom_gnomad_vcf: custom_gnomad_vcf
-            custom_clinvar_vcf: custom_clinvar_vcf
+            vep_custom_annotations: vep_custom_annotations
             somalier_vcf: somalier_vcf
             germline_tsv_prefix: germline_tsv_prefix
             germline_variants_to_table_fields: germline_variants_to_table_fields

--- a/definitions/pipelines/aml_trio_cle_gathered.cwl
+++ b/definitions/pipelines/aml_trio_cle_gathered.cwl
@@ -142,11 +142,8 @@ inputs:
         type: string[]
         default: [HGVSc,HGVSp]
     vep_custom_annotations:
-        type:
-            - "null"
-            - type: array
-              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              label: "custom type, check types directory for input format"
+        type: ../types/vep_custom_annotation.yml#vep_custom_annotation[]
+        doc: "custom type, check types directory for input format"
     germline_tsv_prefix:
         type: string?
         default: 'germline_variants'

--- a/definitions/pipelines/aml_trio_cle_gathered.cwl
+++ b/definitions/pipelines/aml_trio_cle_gathered.cwl
@@ -146,7 +146,7 @@ inputs:
             - "null"
             - type: array
               items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              doc: "custom type, check types directory for input format"
+              label: "custom type, check types directory for input format"
     germline_tsv_prefix:
         type: string?
         default: 'germline_variants'

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -105,6 +105,7 @@ inputs:
             - "null"
             - type: array
               items: ../types/vep_custom_annotation.yml#vep_custom_annotation
+              doc: "custom type, check types directory for input format"
 outputs:
     mutect_unfiltered_vcf:
         type: File

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -101,11 +101,8 @@ inputs:
         type: string[]?
         default: [HGVSc,HGVSp]
     vep_custom_annotations:
-        type:
-            - "null"
-            - type: array
-              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              label: "custom type, check types directory for input format"
+        type: ../types/vep_custom_annotation.yml#vep_custom_annotation[]
+        doc: "custom type, check types directory for input format"
 outputs:
     mutect_unfiltered_vcf:
         type: File

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -338,6 +338,19 @@ steps:
             tumor_bam: tumor_bam
             do_cle_vcf_filter: cle_vcf_filter
             reference: reference
+            gnomad_field_name:
+              source: vep_custom_annotations
+              valueFrom: |
+                ${
+                   if  (typeof self !== 'undefined'){
+                        for(var i=0; i<self.length; i++){
+                            if(self[i].annotation.gnomad_filter){
+                                return(self[i].annotation.name + '_AF');
+                            }
+                        }
+                        return('gnomAD_AF');
+                    }
+                }
         out: 
             [filtered_vcf]
     annotated_filter_bgzip:

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -342,14 +342,14 @@ steps:
               source: vep_custom_annotations
               valueFrom: |
                 ${
-                   if  (typeof self !== 'undefined'){
+                   if(self){
                         for(var i=0; i<self.length; i++){
                             if(self[i].annotation.gnomad_filter){
                                 return(self[i].annotation.name + '_AF');
                             }
                         }
-                        return('gnomAD_AF');
                     }
+                    return('gnomAD_AF');
                 }
         out: 
             [filtered_vcf]

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -5,6 +5,9 @@ class: Workflow
 label: "Detect Variants workflow"
 requirements:
     - class: SubworkflowFeatureRequirement
+    - class: SchemaDefRequirement
+      types:
+          - $import: ../types/vep_custom_annotation.yml
 inputs:
     reference:
         type: string
@@ -97,12 +100,11 @@ inputs:
     vep_to_table_fields:
         type: string[]?
         default: [HGVSc,HGVSp]
-    custom_gnomad_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
-    custom_clinvar_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
+    vep_custom_annotations:
+        type:
+            - "null"
+            - type: array
+              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
 outputs:
     mutect_unfiltered_vcf:
         type: File
@@ -264,9 +266,8 @@ steps:
             synonyms_file: synonyms_file
             coding_only: annotate_coding_only
             reference: reference
-            custom_gnomad_vcf: custom_gnomad_vcf
             pick: vep_pick
-            custom_clinvar_vcf: custom_clinvar_vcf
+            custom_annotations: vep_custom_annotations
             plugins: vep_plugins
         out:
             [annotated_vcf, vep_summary]

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -105,7 +105,7 @@ inputs:
             - "null"
             - type: array
               items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              doc: "custom type, check types directory for input format"
+              label: "custom type, check types directory for input format"
 outputs:
     mutect_unfiltered_vcf:
         type: File

--- a/definitions/pipelines/detect_variants_wgs.cwl
+++ b/definitions/pipelines/detect_variants_wgs.cwl
@@ -101,11 +101,8 @@ inputs:
         type: string[]?
         default: [HGVSc,HGVSp]
     vep_custom_annotations:
-        type:
-            - "null"
-            - type: array
-              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              label: "custom type, check types directory for input format"
+        type: ../types/vep_custom_annotation.yml#vep_custom_annotation[]
+        doc: "custom type, check types directory for input format"
 outputs:
     mutect_unfiltered_vcf:
         type: File

--- a/definitions/pipelines/germline_exome.cwl
+++ b/definitions/pipelines/germline_exome.cwl
@@ -77,6 +77,7 @@ inputs:
             - "null"
             - type: array
               items: ../types/vep_custom_annotation.yml#vep_custom_annotation
+              doc: "custom type, check types directory for input format"
     variants_to_table_fields:
          type: string[]?
     variants_to_table_genotype_fields:

--- a/definitions/pipelines/germline_exome.cwl
+++ b/definitions/pipelines/germline_exome.cwl
@@ -73,11 +73,8 @@ inputs:
     qc_minimum_base_quality:
         type: int?
     vep_custom_annotations:
-        type:
-            - "null"
-            - type: array
-              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              label: "custom type, check types directory for input format"
+        type: ../types/vep_custom_annotation.yml#vep_custom_annotation[]
+        doc: "custom type, check types directory for input format"
     variants_to_table_fields:
          type: string[]?
     variants_to_table_genotype_fields:

--- a/definitions/pipelines/germline_exome.cwl
+++ b/definitions/pipelines/germline_exome.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/vep_custom_annotation.yml
     - class: SubworkflowFeatureRequirement
 inputs:
     reference: string
@@ -67,16 +68,15 @@ inputs:
         type: File?
     annotate_coding_only:
         type: boolean?
-    custom_gnomad_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
     qc_minimum_mapping_quality:
         type: int?
     qc_minimum_base_quality:
         type: int?
-    custom_clinvar_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
+    vep_custom_annotations:
+        type:
+            - "null"
+            - type: array
+              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
     variants_to_table_fields:
          type: string[]?
     variants_to_table_genotype_fields:
@@ -206,14 +206,13 @@ steps:
             vep_cache_dir: vep_cache_dir
             synonyms_file: synonyms_file
             annotate_coding_only: annotate_coding_only
-            custom_gnomad_vcf: custom_gnomad_vcf
             limit_variant_intervals: target_intervals
-            custom_clinvar_vcf: custom_clinvar_vcf
             vep_ensembl_assembly: vep_ensembl_assembly
             vep_ensembl_version: vep_ensembl_version
             vep_ensembl_species: vep_ensembl_species
             vep_plugins: vep_plugins
             vep_to_table_fields: vep_to_table_fields
+            vep_custom_annotations: vep_custom_annotations
             variants_to_table_fields: variants_to_table_fields
             variants_to_table_genotype_fields: variants_to_table_genotype_fields
         out:

--- a/definitions/pipelines/germline_exome.cwl
+++ b/definitions/pipelines/germline_exome.cwl
@@ -77,7 +77,7 @@ inputs:
             - "null"
             - type: array
               items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              doc: "custom type, check types directory for input format"
+              label: "custom type, check types directory for input format"
     variants_to_table_fields:
          type: string[]?
     variants_to_table_genotype_fields:

--- a/definitions/pipelines/germline_exome_hla_typing.cwl
+++ b/definitions/pipelines/germline_exome_hla_typing.cwl
@@ -70,7 +70,7 @@ inputs:
             - "null"
             - type: array
               items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              doc: "custom type, check types directory for input format"
+              label: "custom type, check types directory for input format"
     qc_minimum_mapping_quality:
         type: int?
     qc_minimum_base_quality:

--- a/definitions/pipelines/germline_exome_hla_typing.cwl
+++ b/definitions/pipelines/germline_exome_hla_typing.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/vep_custom_annotation.yml
     - class: SubworkflowFeatureRequirement
 inputs:
     reference: string
@@ -64,16 +65,16 @@ inputs:
         type: File?
     annotate_coding_only:
         type: boolean?
-    custom_gnomad_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
+    vep_custom_annotations:
+        type:
+            - "null"
+            - type: array
+              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
+              doc: "custom type, check types directory for input format"
     qc_minimum_mapping_quality:
         type: int?
     qc_minimum_base_quality:
         type: int?
-    custom_clinvar_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
     optitype_name:
         type: string?
 outputs:
@@ -169,10 +170,9 @@ steps:
             vep_ensembl_species: vep_ensembl_species
             synonyms_file: synonyms_file
             annotate_coding_only: annotate_coding_only
-            custom_gnomad_vcf: custom_gnomad_vcf
+            vep_custom_annotations: vep_custom_annotations
             qc_minimum_mapping_quality: qc_minimum_mapping_quality
             qc_minimum_base_quality: qc_minimum_base_quality
-            custom_clinvar_vcf: custom_clinvar_vcf
         out:
             [cram, mark_duplicates_metrics, insert_size_metrics, insert_size_histogram, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, summary_hs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth, gvcf, final_vcf, coding_vcf, limited_vcf, vep_summary]
     optitype:

--- a/definitions/pipelines/germline_exome_hla_typing.cwl
+++ b/definitions/pipelines/germline_exome_hla_typing.cwl
@@ -66,11 +66,8 @@ inputs:
     annotate_coding_only:
         type: boolean?
     vep_custom_annotations:
-        type:
-            - "null"
-            - type: array
-              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              label: "custom type, check types directory for input format"
+        type: ../types/vep_custom_annotation.yml#vep_custom_annotation[]
+        doc: "custom type, check types directory for input format"
     qc_minimum_mapping_quality:
         type: int?
     qc_minimum_base_quality:

--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -77,6 +77,7 @@ inputs:
             - "null"
             - type: array
               items: ../types/vep_custom_annotation.yml#vep_custom_annotation
+              doc: "custom type, check types directory for input format"
     cnvkit_diagram:
         type: boolean?
     cnvkit_drop_low_coverage: 

--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -77,7 +77,7 @@ inputs:
             - "null"
             - type: array
               items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              doc: "custom type, check types directory for input format"
+              label: "custom type, check types directory for input format"
     cnvkit_diagram:
         type: boolean?
     cnvkit_drop_low_coverage: 

--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -73,11 +73,8 @@ inputs:
     summary_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
     vep_custom_annotations:
-        type:
-            - "null"
-            - type: array
-              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              label: "custom type, check types directory for input format"
+        type: ../types/vep_custom_annotation.yml#vep_custom_annotation[]
+        doc: "custom type, check types directory for input format"
     cnvkit_diagram:
         type: boolean?
     cnvkit_drop_low_coverage: 

--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/vep_custom_annotation.yml
     - class: SubworkflowFeatureRequirement
 inputs:
     reference: string
@@ -59,9 +60,6 @@ inputs:
         type: File?
     annotate_coding_only:
         type: boolean?
-    custom_gnomad_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
     bqsr_intervals:
         type: string[]?
     minimum_mapping_quality:
@@ -74,9 +72,11 @@ inputs:
         type: ../types/labelled_file.yml#labelled_file[]
     summary_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
-    custom_clinvar_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
+    vep_custom_annotations:
+        type:
+            - "null"
+            - type: array
+              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
     cnvkit_diagram:
         type: boolean?
     cnvkit_drop_low_coverage: 
@@ -336,9 +336,8 @@ steps:
             vep_cache_dir: vep_cache_dir
             synonyms_file: synonyms_file
             annotate_coding_only: annotate_coding_only
-            custom_gnomad_vcf: custom_gnomad_vcf
             limit_variant_intervals: variant_reporting_intervals
-            custom_clinvar_vcf: custom_clinvar_vcf
+            vep_custom_annotations: vep_custom_annotations
             vep_ensembl_assembly: vep_ensembl_assembly
             vep_ensembl_version: vep_ensembl_version
             vep_ensembl_species: vep_ensembl_species

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/vep_custom_annotation.yml
     - class: SubworkflowFeatureRequirement
 inputs:
     #rnaseq inputs
@@ -171,12 +172,12 @@ inputs:
     vep_to_table_fields:
         type: string[]
         default: [HGVSc,HGVSp]
-    custom_gnomad_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
-    custom_clinvar_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
+    vep_custom_annotations:
+        type:
+            - "null"
+            - type: array
+              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
+              doc: "custom type, check types directory for input format"
     manta_call_regions:
         type: File?
         secondaryFiles: [.tbi]
@@ -686,8 +687,7 @@ steps:
             variants_to_table_fields: variants_to_table_fields
             variants_to_table_genotype_fields: variants_to_table_genotype_fields
             vep_to_table_fields: vep_to_table_fields
-            custom_gnomad_vcf: custom_gnomad_vcf
-            custom_clinvar_vcf: custom_clinvar_vcf
+            vep_custom_annotations: vep_custom_annotations
             manta_call_regions: manta_call_regions
             manta_non_wgs: manta_non_wgs
             manta_output_contigs: manta_output_contigs

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -714,6 +714,7 @@ steps:
             vep_ensembl_assembly: vep_ensembl_assembly
             vep_ensembl_version: vep_ensembl_version
             vep_ensembl_species: vep_ensembl_species
+            vep_custom_annotations: vep_custom_annotations
             synonyms_file: synonyms_file
             annotate_coding_only: annotate_coding_only
             qc_minimum_mapping_quality: qc_minimum_mapping_quality

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -719,10 +719,8 @@ steps:
             vep_ensembl_species: vep_ensembl_species
             synonyms_file: synonyms_file
             annotate_coding_only: annotate_coding_only
-            custom_gnomad_vcf: custom_gnomad_vcf
             qc_minimum_mapping_quality: qc_minimum_mapping_quality
             qc_minimum_base_quality: qc_minimum_base_quality
-            custom_clinvar_vcf: custom_clinvar_vcf
             optitype_name: optitype_name
         out:
             [cram,mark_duplicates_metrics,insert_size_metrics,insert_size_histogram,alignment_summary_metrics,hs_metrics,per_target_coverage_metrics,per_target_hs_metrics,per_base_coverage_metrics,per_base_hs_metrics,summary_hs_metrics,flagstats,verify_bam_id_metrics,verify_bam_id_depth,gvcf,final_vcf,coding_vcf,limited_vcf,vep_summary,optitype_tsv,optitype_plot]

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -173,11 +173,8 @@ inputs:
         type: string[]
         default: [HGVSc,HGVSp]
     vep_custom_annotations:
-        type:
-            - "null"
-            - type: array
-              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              label: "custom type, check types directory for input format"
+        type: ../types/vep_custom_annotation.yml#vep_custom_annotation[]
+        doc: "custom type, check types directory for input format"
     manta_call_regions:
         type: File?
         secondaryFiles: [.tbi]

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -177,7 +177,7 @@ inputs:
             - "null"
             - type: array
               items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              doc: "custom type, check types directory for input format"
+              label: "custom type, check types directory for input format"
     manta_call_regions:
         type: File?
         secondaryFiles: [.tbi]

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/vep_custom_annotation.yml
     - class: SubworkflowFeatureRequirement
     - class: StepInputExpressionRequirement
 inputs:
@@ -129,12 +130,11 @@ inputs:
     vep_to_table_fields:
         type: string[]
         default: [HGVSc,HGVSp]
-    custom_gnomad_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
-    custom_clinvar_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
+    vep_custom_annotations:
+        type:
+            - "null"
+            - type: array
+              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
     manta_call_regions:
         type: File?
         secondaryFiles: [.tbi]
@@ -431,8 +431,7 @@ steps:
             variants_to_table_fields: variants_to_table_fields
             variants_to_table_genotype_fields: variants_to_table_genotype_fields
             vep_to_table_fields: vep_to_table_fields
-            custom_gnomad_vcf: custom_gnomad_vcf
-            custom_clinvar_vcf: custom_clinvar_vcf
+            vep_custom_annotations: vep_custom_annotations
         out:
             [mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv]
     cnvkit:

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -135,7 +135,7 @@ inputs:
             - "null"
             - type: array
               items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              doc: "custom type, check types directory for input format"
+              label: "custom type, check types directory for input format"
     manta_call_regions:
         type: File?
         secondaryFiles: [.tbi]

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -131,11 +131,8 @@ inputs:
         type: string[]
         default: [HGVSc,HGVSp]
     vep_custom_annotations:
-        type:
-            - "null"
-            - type: array
-              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              label: "custom type, check types directory for input format"
+        type: ../types/vep_custom_annotation.yml#vep_custom_annotation[]
+        doc: "custom type, check types directory for input format"
     manta_call_regions:
         type: File?
         secondaryFiles: [.tbi]

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -135,6 +135,7 @@ inputs:
             - "null"
             - type: array
               items: ../types/vep_custom_annotation.yml#vep_custom_annotation
+              doc: "custom type, check types directory for input format"
     manta_call_regions:
         type: File?
         secondaryFiles: [.tbi]

--- a/definitions/pipelines/somatic_exome_cle.cwl
+++ b/definitions/pipelines/somatic_exome_cle.cwl
@@ -125,6 +125,7 @@ inputs:
             - "null"
             - type: array
               items: ../types/vep_custom_annotation.yml#vep_custom_annotation
+              doc: "custom type, check types directory for input format"
     somalier_vcf:
         type: File
     disclaimer_text:

--- a/definitions/pipelines/somatic_exome_cle.cwl
+++ b/definitions/pipelines/somatic_exome_cle.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/vep_custom_annotation.yml
     - class: SubworkflowFeatureRequirement
     - class: StepInputExpressionRequirement
 inputs:
@@ -119,12 +120,11 @@ inputs:
     vep_to_table_fields:
         type: string[]
         default: [HGVSc,HGVSp]
-    custom_gnomad_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
-    custom_clinvar_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
+    vep_custom_annotations:
+        type:
+            - "null"
+            - type: array
+              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
     somalier_vcf:
         type: File
     disclaimer_text:
@@ -366,8 +366,7 @@ steps:
             variants_to_table_fields: variants_to_table_fields
             variants_to_table_genotype_fields: variants_to_table_genotype_fields
             vep_to_table_fields: vep_to_table_fields
-            custom_gnomad_vcf: custom_gnomad_vcf
-            custom_clinvar_vcf: custom_clinvar_vcf
+            vep_custom_annotations: vep_custom_annotations
         out:
             [mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv]
     add_disclaimer_to_final_tsv:

--- a/definitions/pipelines/somatic_exome_cle.cwl
+++ b/definitions/pipelines/somatic_exome_cle.cwl
@@ -125,7 +125,7 @@ inputs:
             - "null"
             - type: array
               items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              doc: "custom type, check types directory for input format"
+              label: "custom type, check types directory for input format"
     somalier_vcf:
         type: File
     disclaimer_text:

--- a/definitions/pipelines/somatic_exome_cle.cwl
+++ b/definitions/pipelines/somatic_exome_cle.cwl
@@ -121,11 +121,8 @@ inputs:
         type: string[]
         default: [HGVSc,HGVSp]
     vep_custom_annotations:
-        type:
-            - "null"
-            - type: array
-              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              label: "custom type, check types directory for input format"
+        type: ../types/vep_custom_annotation.yml#vep_custom_annotation[]
+        doc: "custom type, check types directory for input format"
     somalier_vcf:
         type: File
     disclaimer_text:

--- a/definitions/pipelines/somatic_exome_cle_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_cle_gathered.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/vep_custom_annotation.yml
     - class: SubworkflowFeatureRequirement
     - class: StepInputExpressionRequirement
 inputs:
@@ -121,9 +122,12 @@ inputs:
     vep_to_table_fields:
         type: string[]
         default: [HGVSc,HGVSp]
-    custom_gnomad_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
+    vep_custom_annotations:
+        type:
+            - "null"
+            - type: array
+              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
+              doc: "custom type, check types directory for input format"
     output_dir: 
         type: string
     somalier_vcf:
@@ -180,7 +184,7 @@ steps:
             variants_to_table_fields: variants_to_table_fields
             variants_to_table_genotype_fields: variants_to_table_genotype_fields
             vep_to_table_fields: vep_to_table_fields
-            custom_gnomad_vcf: custom_gnomad_vcf
+            vep_custom_annotations: vep_custom_annotations
             somalier_vcf: somalier_vcf
             disclaimer_version: disclaimer_version
         out:

--- a/definitions/pipelines/somatic_exome_cle_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_cle_gathered.cwl
@@ -123,11 +123,8 @@ inputs:
         type: string[]
         default: [HGVSc,HGVSp]
     vep_custom_annotations:
-        type:
-            - "null"
-            - type: array
-              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              label: "custom type, check types directory for input format"
+        type: ../types/vep_custom_annotation.yml#vep_custom_annotation[]
+        doc: "custom type, check types directory for input format"
     output_dir: 
         type: string
     somalier_vcf:

--- a/definitions/pipelines/somatic_exome_cle_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_cle_gathered.cwl
@@ -127,7 +127,7 @@ inputs:
             - "null"
             - type: array
               items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              doc: "custom type, check types directory for input format"
+              label: "custom type, check types directory for input format"
     output_dir: 
         type: string
     somalier_vcf:

--- a/definitions/pipelines/somatic_exome_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_gathered.cwl
@@ -132,11 +132,8 @@ inputs:
         type: string[]
         default: [HGVSc,HGVSp]
     vep_custom_annotations:
-        type:
-            - "null"
-            - type: array
-              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              label: "custom type, check types directory for input format"
+        type: ../types/vep_custom_annotation.yml#vep_custom_annotation[]
+        doc: "custom type, check types directory for input format"
     output_dir: 
         type: string
     somalier_vcf:

--- a/definitions/pipelines/somatic_exome_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_gathered.cwl
@@ -136,7 +136,7 @@ inputs:
             - "null"
             - type: array
               items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              doc: "custom type, check types directory for input format"
+              label: "custom type, check types directory for input format"
     output_dir: 
         type: string
     somalier_vcf:

--- a/definitions/pipelines/somatic_exome_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_gathered.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/vep_custom_annotation.yml
     - class: SubworkflowFeatureRequirement
     - class: StepInputExpressionRequirement
 inputs:
@@ -130,9 +131,12 @@ inputs:
     vep_to_table_fields:
         type: string[]
         default: [HGVSc,HGVSp]
-    custom_gnomad_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
+    vep_custom_annotations:
+        type:
+            - "null"
+            - type: array
+              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
+              doc: "custom type, check types directory for input format"
     output_dir: 
         type: string
     somalier_vcf:
@@ -190,7 +194,7 @@ steps:
             variants_to_table_fields: variants_to_table_fields
             variants_to_table_genotype_fields: variants_to_table_genotype_fields
             vep_to_table_fields: vep_to_table_fields
-            custom_gnomad_vcf: custom_gnomad_vcf
+            vep_custom_annotations: vep_custom_annotations
             somalier_vcf: somalier_vcf
         out:
             [tumor_cram, tumor_mark_duplicates_metrics, tumor_insert_size_metrics, tumor_alignment_summary_metrics, tumor_hs_metrics, tumor_per_target_coverage_metrics, tumor_per_base_coverage_metrics, tumor_per_base_hs_metrics, tumor_summary_hs_metrics, tumor_flagstats, tumor_verify_bam_id_metrics, tumor_verify_bam_id_depth, normal_cram, normal_mark_duplicates_metrics, normal_insert_size_metrics, normal_alignment_summary_metrics, normal_hs_metrics, normal_per_target_coverage_metrics, normal_per_target_hs_metrics, normal_per_base_coverage_metrics, normal_per_base_hs_metrics, normal_summary_hs_metrics, normal_flagstats, normal_verify_bam_id_metrics, normal_verify_bam_id_depth, mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv, somalier_concordance_metrics, somalier_concordance_statistics]

--- a/definitions/pipelines/somatic_wgs.cwl
+++ b/definitions/pipelines/somatic_wgs.cwl
@@ -131,11 +131,8 @@ inputs:
         type: string[]
         default: [HGVSc,HGVSp]
     vep_custom_annotations:
-        type:
-            - "null"
-            - type: array
-              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              label: "custom type, check types directory for input format"
+        type: ../types/vep_custom_annotation.yml#vep_custom_annotation[]
+        doc: "custom type, check types directory for input format"
     manta_call_regions:
         type: File?
         secondaryFiles: [.tbi]

--- a/definitions/pipelines/somatic_wgs.cwl
+++ b/definitions/pipelines/somatic_wgs.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/vep_custom_annotation.yml
     - class: SubworkflowFeatureRequirement
     - class: StepInputExpressionRequirement
 inputs:
@@ -129,12 +130,12 @@ inputs:
     vep_to_table_fields:
         type: string[]
         default: [HGVSc,HGVSp]
-    custom_gnomad_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
-    custom_clinvar_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
+    vep_custom_annotations:
+        type:
+            - "null"
+            - type: array
+              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
+              label: "custom type, check types directory for input format"
     manta_call_regions:
         type: File?
         secondaryFiles: [.tbi]
@@ -418,8 +419,7 @@ steps:
             variants_to_table_fields: variants_to_table_fields
             variants_to_table_genotype_fields: variants_to_table_genotype_fields
             vep_to_table_fields: vep_to_table_fields
-            custom_gnomad_vcf: custom_gnomad_vcf
-            custom_clinvar_vcf: custom_clinvar_vcf
+            vep_custom_annotations: vep_custom_annotations
         out:
             [mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv]
     manta: 

--- a/definitions/pipelines/tumor_only_detect_variants.cwl
+++ b/definitions/pipelines/tumor_only_detect_variants.cwl
@@ -79,7 +79,7 @@ inputs:
             - "null"
             - type: array
               items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              doc: "custom type, check types directory for input format"
+              label: "custom type, check types directory for input format"
     readcount_minimum_mapping_quality:
         type: int?
     readcount_minimum_base_quality:

--- a/definitions/pipelines/tumor_only_detect_variants.cwl
+++ b/definitions/pipelines/tumor_only_detect_variants.cwl
@@ -75,11 +75,8 @@ inputs:
         type: File
         secondaryFiles: [.tbi]
     vep_custom_annotations:
-        type:
-            - "null"
-            - type: array
-              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              label: "custom type, check types directory for input format"
+        type: ../types/vep_custom_annotation.yml#vep_custom_annotation[]
+        doc: "custom type, check types directory for input format"
     readcount_minimum_mapping_quality:
         type: int?
     readcount_minimum_base_quality:

--- a/definitions/pipelines/tumor_only_detect_variants.cwl
+++ b/definitions/pipelines/tumor_only_detect_variants.cwl
@@ -7,6 +7,9 @@ requirements:
     - class: SubworkflowFeatureRequirement
     - class: StepInputExpressionRequirement
     - class: InlineJavascriptRequirement
+    - class: SchemaDefRequirement
+      types:
+          - $import: ../types/vep_custom_annotation.yml
 inputs:
     reference:
         type: string
@@ -71,9 +74,11 @@ inputs:
     docm_vcf:
         type: File
         secondaryFiles: [.tbi]
-    custom_gnomad_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
+    vep_custom_annotations:
+        type:
+            - "null"
+            - type: array
+              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
     readcount_minimum_mapping_quality:
         type: int?
     readcount_minimum_base_quality:
@@ -152,7 +157,7 @@ steps:
             synonyms_file: synonyms_file
             coding_only: annotate_coding_only
             reference: reference
-            custom_gnomad_vcf: custom_gnomad_vcf
+            custom_annotations: vep_custom_annotations
             pick: vep_pick
             ensembl_assembly: vep_ensembl_assembly
             ensembl_version: vep_ensembl_version
@@ -199,10 +204,21 @@ steps:
         out:
             [filtered_vcf]
     af_filter:
-        run: ../tools/filter_vcf_gnomADe_allele_freq.cwl
+        run: ../tools/filter_vcf_custom_allele_freq.cwl
         in:
             vcf: hard_filter/filtered_vcf
             maximum_population_allele_frequency: maximum_population_allele_frequency
+            field_name:
+              source: vep_custom_annotations
+              valueFrom: | 
+                ${
+                    for(var i=0; i<self.length; i++){
+                        if(self[i].annotation.gnomad_filter){ 
+                            return(self[i].annotation.name + '_AF');
+                        }
+                    }
+                    return('gnomAD_AF');
+                }
         out:
             [filtered_vcf]
     coding_variant_filter:

--- a/definitions/pipelines/tumor_only_detect_variants.cwl
+++ b/definitions/pipelines/tumor_only_detect_variants.cwl
@@ -79,6 +79,7 @@ inputs:
             - "null"
             - type: array
               items: ../types/vep_custom_annotation.yml#vep_custom_annotation
+              doc: "custom type, check types directory for input format"
     readcount_minimum_mapping_quality:
         type: int?
     readcount_minimum_base_quality:

--- a/definitions/pipelines/tumor_only_detect_variants.cwl
+++ b/definitions/pipelines/tumor_only_detect_variants.cwl
@@ -212,9 +212,11 @@ steps:
               source: vep_custom_annotations
               valueFrom: | 
                 ${
-                    for(var i=0; i<self.length; i++){
-                        if(self[i].annotation.gnomad_filter){ 
-                            return(self[i].annotation.name + '_AF');
+                    if(self){
+                        for(var i=0; i<self.length; i++){
+                            if(self[i].annotation.gnomad_filter){
+                                return(self[i].annotation.name + '_AF');
+                            }
                         }
                     }
                     return('gnomAD_AF');

--- a/definitions/pipelines/tumor_only_exome.cwl
+++ b/definitions/pipelines/tumor_only_exome.cwl
@@ -98,6 +98,7 @@ inputs:
             - "null"
             - type: array
               items: ../types/vep_custom_annotation.yml#vep_custom_annotation
+              doc: "custom type, check types directory for input format"
     qc_minimum_mapping_quality:
         type: int?
     qc_minimum_base_quality:

--- a/definitions/pipelines/tumor_only_exome.cwl
+++ b/definitions/pipelines/tumor_only_exome.cwl
@@ -98,7 +98,7 @@ inputs:
             - "null"
             - type: array
               items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              doc: "custom type, check types directory for input format"
+              label: "custom type, check types directory for input format"
     qc_minimum_mapping_quality:
         type: int?
     qc_minimum_base_quality:

--- a/definitions/pipelines/tumor_only_exome.cwl
+++ b/definitions/pipelines/tumor_only_exome.cwl
@@ -94,11 +94,8 @@ inputs:
         type: File
         secondaryFiles: [.tbi]
     vep_custom_annotations:
-        type:
-            - "null"
-            - type: array
-              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              label: "custom type, check types directory for input format"
+        type: ../types/vep_custom_annotation.yml#vep_custom_annotation[]
+        doc: "custom type, check types directory for input format"
     qc_minimum_mapping_quality:
         type: int?
     qc_minimum_base_quality:

--- a/definitions/pipelines/tumor_only_exome.cwl
+++ b/definitions/pipelines/tumor_only_exome.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/vep_custom_annotation.yml
     - class: SubworkflowFeatureRequirement
 inputs:
     reference: string
@@ -92,9 +93,11 @@ inputs:
     docm_vcf:
         type: File
         secondaryFiles: [.tbi]
-    custom_gnomad_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
+    vep_custom_annotations:
+        type:
+            - "null"
+            - type: array
+              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
     qc_minimum_mapping_quality:
         type: int?
     qc_minimum_base_quality:
@@ -217,7 +220,7 @@ steps:
             vep_to_table_fields: vep_to_table_fields
             sample_name: sample_name
             docm_vcf: docm_vcf
-            custom_gnomad_vcf: custom_gnomad_vcf
+            vep_custom_annotations: vep_custom_annotations
             readcount_minimum_mapping_quality: readcount_minimum_mapping_quality
             readcount_minimum_base_quality: readcount_minimum_base_quality
         out:

--- a/definitions/pipelines/tumor_only_wgs.cwl
+++ b/definitions/pipelines/tumor_only_wgs.cwl
@@ -59,6 +59,7 @@ inputs:
             - "null"
             - type: array
               items: ../types/vep_custom_annotation.yml#vep_custom_annotation
+              doc: "custom type, check types directory for input format"
     readcount_minimum_mapping_quality:
         type: int?
     readcount_minimum_base_quality:

--- a/definitions/pipelines/tumor_only_wgs.cwl
+++ b/definitions/pipelines/tumor_only_wgs.cwl
@@ -55,11 +55,8 @@ inputs:
     docm_vcf:
         type: File
     vep_custom_annotations:
-        type:
-            - "null"
-            - type: array
-              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              label: "custom type, check types directory for input format"
+        type: ../types/vep_custom_annotation.yml#vep_custom_annotation[]
+        doc: "custom type, check types directory for input format"
     readcount_minimum_mapping_quality:
         type: int?
     readcount_minimum_base_quality:

--- a/definitions/pipelines/tumor_only_wgs.cwl
+++ b/definitions/pipelines/tumor_only_wgs.cwl
@@ -59,7 +59,7 @@ inputs:
             - "null"
             - type: array
               items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              doc: "custom type, check types directory for input format"
+              label: "custom type, check types directory for input format"
     readcount_minimum_mapping_quality:
         type: int?
     readcount_minimum_base_quality:

--- a/definitions/pipelines/tumor_only_wgs.cwl
+++ b/definitions/pipelines/tumor_only_wgs.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/vep_custom_annotation.yml
     - class: SubworkflowFeatureRequirement
 inputs:
     reference: string
@@ -53,9 +54,11 @@ inputs:
         type: string
     docm_vcf:
         type: File
-    custom_gnomad_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
+    vep_custom_annotations:
+        type:
+            - "null"
+            - type: array
+              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
     readcount_minimum_mapping_quality:
         type: int?
     readcount_minimum_base_quality:
@@ -187,7 +190,7 @@ steps:
             #vep_to_table_fields:
             sample_name: sample_name
             docm_vcf: docm_vcf
-            custom_gnomad_vcf: custom_gnomad_vcf
+            vep_custom_annotations: vep_custom_annotations
             readcount_minimum_mapping_quality: readcount_minimum_mapping_quality
             readcount_minimum_base_quality: readcount_minimum_base_quality
         out:

--- a/definitions/subworkflows/filter_vcf.cwl
+++ b/definitions/subworkflows/filter_vcf.cwl
@@ -13,6 +13,8 @@ inputs:
         type: float
     filter_gnomADe_maximum_population_allele_frequency:
         type: float
+    gnomad_field_name:
+        type: string
     tumor_bam: 
         type: File
         secondaryFiles: [.bai]
@@ -32,10 +34,11 @@ outputs:
         outputSource: set_final_vcf_name/replacement
 steps:
     filter_vcf_gnomADe_allele_freq:
-        run: ../tools/filter_vcf_gnomADe_allele_freq.cwl
+        run: ../tools/filter_vcf_custom_allele_freq.cwl
         in:
             vcf: vcf
             maximum_population_allele_frequency: filter_gnomADe_maximum_population_allele_frequency
+            field_name: gnomad_field_name
         out:
             [filtered_vcf]
     filter_vcf_mapq0:

--- a/definitions/subworkflows/germline_detect_variants.cwl
+++ b/definitions/subworkflows/germline_detect_variants.cwl
@@ -5,6 +5,9 @@ class: Workflow
 label: "exome alignment and germline variant detection"
 requirements:
     - class: SubworkflowFeatureRequirement
+    - class: SchemaDefRequirement
+      types:
+          - $import: ../types/vep_custom_annotation.yml
 inputs:
     reference:
         type: string
@@ -40,14 +43,13 @@ inputs:
         type: File?
     annotate_coding_only:
         type: boolean?
-    custom_gnomad_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
+    vep_custom_annotations:
+        type:
+            - "null"
+            - type: array
+              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
     limit_variant_intervals:
         type: File
-    custom_clinvar_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
     variants_to_table_fields:
         type: string[]?
         default: ['CHROM','POS','ID','REF','ALT']
@@ -110,8 +112,7 @@ steps:
             synonyms_file: synonyms_file
             coding_only: annotate_coding_only
             reference: reference
-            custom_gnomad_vcf: custom_gnomad_vcf
-            custom_clinvar_vcf: custom_clinvar_vcf
+            custom_annotations: vep_custom_annotations
             plugins: vep_plugins
         out:
             [annotated_vcf, vep_summary]

--- a/definitions/subworkflows/germline_detect_variants.cwl
+++ b/definitions/subworkflows/germline_detect_variants.cwl
@@ -48,6 +48,7 @@ inputs:
             - "null"
             - type: array
               items: ../types/vep_custom_annotation.yml#vep_custom_annotation
+              doc: "custom type, check types directory for input format"
     limit_variant_intervals:
         type: File
     variants_to_table_fields:

--- a/definitions/subworkflows/germline_detect_variants.cwl
+++ b/definitions/subworkflows/germline_detect_variants.cwl
@@ -48,7 +48,7 @@ inputs:
             - "null"
             - type: array
               items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              doc: "custom type, check types directory for input format"
+              label: "custom type, check types directory for input format"
     limit_variant_intervals:
         type: File
     variants_to_table_fields:

--- a/definitions/subworkflows/germline_detect_variants.cwl
+++ b/definitions/subworkflows/germline_detect_variants.cwl
@@ -44,11 +44,8 @@ inputs:
     annotate_coding_only:
         type: boolean?
     vep_custom_annotations:
-        type:
-            - "null"
-            - type: array
-              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              label: "custom type, check types directory for input format"
+        type: ../types/vep_custom_annotation.yml#vep_custom_annotation[]
+        doc: "custom type, check types directory for input format"
     limit_variant_intervals:
         type: File
     variants_to_table_fields:

--- a/definitions/tools/filter_vcf_custom_allele_freq.cwl
+++ b/definitions/tools/filter_vcf_custom_allele_freq.cwl
@@ -1,0 +1,45 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: "gnomADe_AF filter"
+baseCommand: ["/usr/bin/perl", "/usr/bin/vcf_check.pl"]
+requirements:
+    - class: InlineJavascriptRequirement
+    - class: DockerRequirement
+      dockerPull: "mgibio/vep_helper-cwl:1.0.0"
+    - class: ResourceRequirement
+      ramMin: 4000
+arguments:
+    [{ valueFrom: $(inputs.vcf.path) },
+    { valueFrom: $(runtime.outdir)/annotated.af_filtered.vcf },
+    "/usr/bin/perl", "/opt/vep/src/ensembl-vep/filter_vep",
+    "--format", "vcf",
+    "-o", { valueFrom: $(runtime.outdir)/annotated.af_filtered.vcf }]
+inputs:
+    vcf:
+        type: File
+        inputBinding:
+            prefix: "-i"
+            position: 1
+    maximum_population_allele_frequency:
+        type: float
+        inputBinding:
+            valueFrom: |
+                ${
+                    return [
+                        "--filter",
+                        [
+                            inputs.field_name, "<", inputs.maximum_population_allele_frequency,
+                            "or not", inputs.field_name
+                        ].join(" ")
+                    ]
+                }
+            position: 2
+    field_name:
+        type: string
+outputs:
+    filtered_vcf:
+        type: File
+        outputBinding:
+            glob: "annotated.af_filtered.vcf"

--- a/definitions/tools/vep.cwl
+++ b/definitions/tools/vep.cwl
@@ -62,7 +62,7 @@ inputs:
             - "null"
             - type: array
               items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              doc: "custom type, check types directory for input format"
+              label: "custom type, check types directory for input format"
               inputBinding:
                   valueFrom: |
                        ${

--- a/definitions/tools/vep.cwl
+++ b/definitions/tools/vep.cwl
@@ -58,12 +58,9 @@ inputs:
             separate: false
             position: 7
     custom_annotations:
-        type:
-            - "null"
-            - type: array
-              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
-              label: "custom type, check types directory for input format"
-              inputBinding:
+        type: ../types/vep_custom_annotation.yml#vep_custom_annotation[]
+        doc: "custom type, check types directory for input format"
+        inputBinding:
                   valueFrom: |
                        ${
                            return [self.annotation.check_existing ? '--check_existing' : '',

--- a/definitions/tools/vep.cwl
+++ b/definitions/tools/vep.cwl
@@ -6,6 +6,9 @@ label: "Ensembl Variant Effect Predictor"
 baseCommand: ["/usr/bin/perl", "-I", "/opt/lib/perl/VEP/Plugins", "/usr/bin/variant_effect_predictor.pl"]
 requirements:
     - class: InlineJavascriptRequirement
+    - class: SchemaDefRequirement
+      types:
+          - $import: ../types/vep_custom_annotation.yml
     - class: ResourceRequirement
       coresMin: 4
       ramMin: 64000
@@ -54,40 +57,31 @@ inputs:
             prefix: '--'
             separate: false
             position: 7
-    custom_gnomad_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
-        inputBinding:
-            valueFrom: |
-                ${
-                    if (inputs.custom_gnomad_vcf) {
-                        return ['--check_existing', '--custom', inputs.custom_gnomad_vcf.path + ',gnomADe,vcf,exact,0,AF,AF_AFR,AF_AMR,AF_ASJ,AF_EAS,AF_FIN,AF_NFE,AF_OTH,AF_SAS']
-                    }
-                    else {
-                        return []
-                    }
-                }
-            position: 6
-    custom_clinvar_vcf:
-        type: File?
-        secondaryFiles: [.tbi]
-        inputBinding:
-            valueFrom: |
-                ${
-                    if (inputs.custom_clinvar_vcf) {
-                        return ["--custom", inputs.custom_clinvar_vcf.path + ",clinvar,vcf,exact,0,CLINSIGN,PHENOTYPE,SCORE,RCVACC,TESTEDINGTR,PHENOTYPELIST,NUMSUBMIT,GUIDELINES"]
-
-                    }
-                    else {
-                        return []
-                    }
-                }
-            position: 7
+    custom_annotations:
+        type:
+            - "null"
+            - type: array
+              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
+              inputBinding:
+                  valueFrom: |
+                       ${
+                           return [self.annotation.check_existing ? '--check_existing' : '',
+                             '--custom',
+                             [self.annotation.file.path,
+                             self.annotation.name,
+                             self.annotation.data_format,
+                             self.method,
+                             self.force_report_coordinates ? 1 : 0,
+                             self.annotation.vcf_fields ? self.annotation.vcf_fields : ''
+                             ].filter(String).join(',')
+                           ].filter(String)
+                       }
+                  position: 6
     reference:
         type: string?
         inputBinding:
             prefix: "--fasta" 
-            position: 8
+            position: 7
     plugins:
         type:
             type: array
@@ -95,30 +89,30 @@ inputs:
             inputBinding:
                 prefix: "--plugin"
         inputBinding:
-            position: 9
+            position: 8
     everything:
         type: boolean?
         default: true
         inputBinding:
             prefix: "--everything"
-            position: 10
+            position: 9
     ensembl_assembly:
         type: string
         inputBinding:
             prefix: "--assembly"
-            position: 11
+            position: 10
         doc: "genome assembly to use in vep. Examples: 'GRCh38' or 'GRCm38'"
     ensembl_version:
         type: string
         inputBinding:
             prefix: "--cache_version"
-            position: 12
+            position: 11
         doc: "ensembl version - Must be present in the cache directory. Example: '95'"
     ensembl_species:
         type: string
         inputBinding:
             prefix: "--species"
-            position: 13
+            position: 12
         doc: "ensembl species - Must be present in the cache directory. Examples: 'homo_sapiens' or 'mus_musculus'"
 outputs:
     annotated_vcf:

--- a/definitions/tools/vep.cwl
+++ b/definitions/tools/vep.cwl
@@ -58,9 +58,12 @@ inputs:
             separate: false
             position: 7
     custom_annotations:
-        type: ../types/vep_custom_annotation.yml#vep_custom_annotation[]
-        doc: "custom type, check types directory for input format"
-        inputBinding:
+        type:
+            - "null"
+            - type: array
+              items: ../types/vep_custom_annotation.yml#vep_custom_annotation
+              label: "custom type, check types directory for input format"
+              inputBinding:
                   valueFrom: |
                        ${
                            return [self.annotation.check_existing ? '--check_existing' : '',

--- a/definitions/tools/vep.cwl
+++ b/definitions/tools/vep.cwl
@@ -62,6 +62,7 @@ inputs:
             - "null"
             - type: array
               items: ../types/vep_custom_annotation.yml#vep_custom_annotation
+              doc: "custom type, check types directory for input format"
               inputBinding:
                   valueFrom: |
                        ${

--- a/definitions/types/vep_custom_annotation.yml
+++ b/definitions/types/vep_custom_annotation.yml
@@ -1,0 +1,31 @@
+type: record
+name: vep_custom_annotation
+label: custom annotation file to be used by vep
+fields:
+    force_report_coordinates:
+        type: boolean
+    method:
+        type:
+            - type: enum
+              symbols: ['exact','overlap']
+    annotation:
+        type:
+            type: record
+            name: info
+            fields:
+              file:
+                  type: File
+              data_format:
+                type:
+                    type: enum
+                    name: 'format'
+                    symbols: ['bed','gff','gtf','vcf','bigwig']
+              name:
+                  type: string
+              vcf_fields:
+                  type: string[]?
+              gnomad_filter:
+                  type: boolean?
+              check_existing:
+                  type: boolean
+

--- a/definitions/types/vep_custom_annotation.yml
+++ b/definitions/types/vep_custom_annotation.yml
@@ -4,10 +4,12 @@ label: custom annotation file to be used by vep
 fields:
     force_report_coordinates:
         type: boolean
+        label: 'Force report the overlapping coordinates of custom feature instead of based on the exact coordinates'
     method:
         type:
             - type: enum
               symbols: ['exact','overlap']
+              label: 'Require exact or overlap to annotate variants'
     annotation:
         type:
             type: record
@@ -15,17 +17,23 @@ fields:
             fields:
               file:
                   type: File
+                  label: 'File to be used for annotation, include index file'
               data_format:
                 type:
                     type: enum
                     name: 'format'
                     symbols: ['bed','gff','gtf','vcf','bigwig']
+                    label: 'Annotation file type'
               name:
                   type: string
+                  label: 'Used as key for new VEP annotation'
               vcf_fields:
                   type: string[]?
+                  label: 'List of VCF fields to annotate'
               gnomad_filter:
                   type: boolean?
+                  label: 'Use this annotation for gnomad filtering?'
               check_existing:
                   type: boolean
+                  label: 'Identify known variants colocated with input variant'
 

--- a/example_data/cle_aml_trio_template.yaml
+++ b/example_data/cle_aml_trio_template.yaml
@@ -28,12 +28,31 @@ bqsr_intervals:
 cosmic_vcf:
   class: File
   path: /gscmnt/gc2560/core/build_merged_alignments/detect-variants--linus2112.gsc.wustl.edu-jwalker-774-52fa2dadc4ba4b6490abe0701907d394/snvs.hq.vcf.gz
-custom_clinvar_vcf:
-  class: File
-  path: /gscmnt/gc2560/core/custom_clinvar_vcf/v20181028/custom.vcf.gz
-custom_gnomad_vcf:
-  class: File
-  path: /gscmnt/gc2560/core/model_data/genome-db-ensembl-gnomad/2dd4b53431674786b760adad60a29273/fixed_b38_exome.vcf.gz
+vep_custom_annotations:
+- method: 'exact'
+  force_report_coordinates: true
+  annotation:
+    file:
+      class: File
+      path: exome_workflow/chr17_test_gnomADe.vcf.gz
+      secondaryFiles: [{class: File, path: exome_workflow/chr17_test_gnomADe.vcf.gz.tbi}]
+    data_format: 'vcf'
+    name: 'gnomADe'
+    vcf_fields: ['AF','AF_AFR','AF_AMR','AF_ASJ','AF_EAS','AF_FIN','AF_NFE','AF_OTH','AF_SAS']
+    gnomad_filter: true
+    check_existing: true
+- method: 'exact'
+  force_report_coordinates: true
+  annotation:
+    file:
+      class: File
+      path: /gscmnt/gc2560/core/custom_clinvar_vcf/v20181028/custom.vcf.gz
+      secondaryFiles: [{class: File, path: /gscmnt/gc2560/core/custom_clinvar_vcf/v20181028/custom.vcf.gz.tbi}]
+    data_format: 'vcf'
+    name: 'clinvar'
+    vcf_fields: ['CLINSIGN','PHENOTYPE','SCORE','RCVACC','TESTEDINGTR','PHENOTYPELIST','NUMSUBMIT','GUIDELINES']
+    gnomad_filter: false
+    check_existing: false
 dbsnp_vcf:
   class: File
   path: /gscmnt/gc2560/core/build_merged_alignments/detect-variants--linus2112.gsc.wustl.edu-jwalker-19443-e48c595a620a432c93e8dd29e4af64f2/snvs.hq.vcf.gz

--- a/example_data/detect_variants/detect_variants.yaml
+++ b/example_data/detect_variants/detect_variants.yaml
@@ -8,9 +8,6 @@ normal_bam:
 interval_list:
   class: File
   path: ../exome_workflow/chr17_test_genes.interval_list
-custom_gnomad_vcf:
-  class: File
-  path: ../exome_workflow/chr17_test_gnomADe.vcf.gz
 dbsnp_vcf:
   class: File
   path: ../exome_workflow/chr17_test_dbsnp.vcf.gz
@@ -40,3 +37,16 @@ hgvs_annotation: true
 variants_to_table_fields: [CHROM,POS,ID,REF,ALT,set,AC,AF]
 variants_to_table_genotype_fields: [GT,AD]
 vep_to_table_fields: [HGVSc,HGVSp]
+vep_custom_annotations:
+- method: 'exact'
+  force_report_coordinates: true
+  annotation:
+    file:
+      class: File
+      path: exome_workflow/chr17_test_gnomADe.vcf.gz
+      secondaryFiles: [{class: File, path: exome_workflow/chr17_test_gnomADe.vcf.gz.tbi}]
+    data_format: 'vcf'
+    name: 'gnomADe'
+    vcf_fields: ['AF','AF_AFR','AF_AMR','AF_ASJ','AF_EAS','AF_FIN','AF_NFE','AF_OTH','AF_SAS']
+    gnomad_filter: true
+    check_existing: true

--- a/example_data/detect_variants/vep.yaml
+++ b/example_data/detect_variants/vep.yaml
@@ -8,6 +8,16 @@ synonyms_file:
 reference: /gscmnt/gc2764/cad/HCC1395/arvados/refseq/GRCh38DH/GRCh38_full_analysis_set_plus_decoy_hla.fa
 hgvs: true
 coding_only: true
-custom_gnomad_vcf:
-    class: File
-    path: /gscmnt/gc2560/core/model_data/genome-db-ensembl-gnomad/2dd4b53431674786b760adad60a29273/gnomad.exomes.r2.0.1.sites.GRCh38.noVEP.vcf.gz
+vep_custom_annotations:
+- method: 'exact'
+  force_report_coordinates: true
+  annotation:
+    file:
+      class: File
+      path: /gscmnt/gc2560/core/model_data/genome-db-ensembl-gnomad/2dd4b53431674786b760adad60a29273/gnomad.exomes.r2.0.1.sites.GRCh38.noVEP.vcf.gz
+      secondaryFiles: [{class: File, path: /gscmnt/gc2560/core/model_data/genome-db-ensembl-gnomad/2dd4b53431674786b760adad60a29273/gnomad.exomes.r2.0.1.sites.GRCh38.noVEP.vcf.gz.tbi}]
+    data_format: 'vcf'
+    name: 'gnomADe'
+    vcf_fields: ['AF','AF_AFR','AF_AMR','AF_ASJ','AF_EAS','AF_FIN','AF_NFE','AF_OTH','AF_SAS']
+    gnomad_filter: true
+    check_existing: true

--- a/example_data/exome_workflow.yaml
+++ b/example_data/exome_workflow.yaml
@@ -4,9 +4,6 @@ bait_intervals:
   path: exome_workflow/chr17_test_bait.interval_list
 bqsr_intervals:
 - chr17
-custom_gnomad_vcf:
-  class: File
-  path: exome_workflow/chr17_test_gnomADe.vcf.gz
 dbsnp_vcf:
   class: File
   path: exome_workflow/chr17_test_dbsnp.vcf.gz
@@ -60,3 +57,16 @@ varscan_min_var_freq: 0.02
 varscan_p_value: 0.99
 varscan_strand_filter: 0
 vep_cache_dir: /gscmnt/gc2764/cad/jgarza/cancer-genomics-workflow/example_data/exome_workflow
+vep_custom_annotations:
+- method: 'exact'
+  force_report_coordinates: true
+  annotation:
+    file:
+      class: File
+      path: exome_workflow/chr17_test_gnomADe.vcf.gz
+      secondaryFiles: [{class: File, path: exome_workflow/chr17_test_gnomADe.vcf.gz.tbi}]
+    data_format: 'vcf'
+    name: 'gnomADe'
+    vcf_fields: ['AF','AF_AFR','AF_AMR','AF_ASJ','AF_EAS','AF_FIN','AF_NFE','AF_OTH','AF_SAS']
+    gnomad_filter: true
+    check_existing: true

--- a/example_data/germline_exome.yaml
+++ b/example_data/germline_exome.yaml
@@ -4,9 +4,6 @@ bait_intervals:
   path: exome_workflow/chr17_test_bait.interval_list
 bqsr_intervals:
 - chr17
-custom_gnomad_vcf:
-  class: File
-  path: exome_workflow/chr17_test_gnomADe.vcf.gz
 dbsnp_vcf:
   class: File
   path: exome_workflow/chr17_test_dbsnp.vcf.gz
@@ -61,3 +58,16 @@ target_intervals:
   class: File
   path: exome_workflow/chr17_test_target.interval_list
 vep_cache_dir: "/gscmnt/gc2764/cad/jgarza/shared/exome_workflow"
+vep_custom_annotations:
+- method: 'exact'
+  force_report_coordinates: true
+  annotation:
+    file:
+      class: File
+      path: exome_workflow/chr17_test_gnomADe.vcf.gz
+      secondaryFiles: [{class: File, path: exome_workflow/chr17_test_gnomADe.vcf.gz.tbi}]
+    data_format: 'vcf'
+    name: 'gnomADe'
+    vcf_fields: ['AF','AF_AFR','AF_AMR','AF_ASJ','AF_EAS','AF_FIN','AF_NFE','AF_OTH','AF_SAS']
+    gnomad_filter: true
+    check_existing: true

--- a/example_data/germline_wgs.yaml
+++ b/example_data/germline_wgs.yaml
@@ -1,8 +1,5 @@
 ---
 bqsr_intervals: ["chr17"]
-custom_gnomad_vcf:
-  class: File
-  path: exome_workflow/chr17_test_gnomADe.vcf.gz
 dbsnp_vcf:
   class: File
   path: exome_workflow/chr17_test_dbsnp.vcf.gz
@@ -47,4 +44,16 @@ variant_reporting_intervals:
     class: File
     path: exome_workflow/chr17_test_genes.interval_list
 vep_cache_dir: /gscmnt/gc2764/cad/jgarza/shared/exome_workflow
-
+vep_custom_annotations:
+- method: 'exact'
+  force_report_coordinates: true
+  annotation:
+    file:
+      class: File
+      path: exome_workflow/chr17_test_gnomADe.vcf.gz
+      secondaryFiles: [{class: File, path: exome_workflow/chr17_test_gnomADe.vcf.gz.tbi}]
+    data_format: 'vcf'
+    name: 'gnomADe'
+    vcf_fields: ['AF','AF_AFR','AF_AMR','AF_ASJ','AF_EAS','AF_FIN','AF_NFE','AF_OTH','AF_SAS']
+    gnomad_filter: true
+    check_existing: true

--- a/example_data/somatic_exome.yaml
+++ b/example_data/somatic_exome.yaml
@@ -24,9 +24,6 @@ normal_sequence:
         class: File
         path: exome_workflow/2895499399.bam
     readgroup: "@RG\tID:2895499399\tPU:H7HY2CCXX.4.TGACCACG\tSM:H_NJ-HCC1395-HCC1395_BL\tLB:H_NJ-HCC1395-HCC1395_BL-lg21-lib1\tPL:Illumina\tCN:WUGSC"
-custom_gnomad_vcf:
-  class: File
-  path: exome_workflow/chr17_test_gnomADe.vcf.gz
 dbsnp_vcf:
   class: File
   path: exome_workflow/chr17_test_dbsnp.vcf.gz
@@ -74,6 +71,19 @@ varscan_min_var_freq: 0.02
 varscan_p_value: 0.99
 varscan_strand_filter: 0
 vep_cache_dir: "/gscmnt/gc2560/core/cwl/inputs/VEP_cache/"
+vep_custom_annotations:
+- method: 'exact'
+  force_report_coordinates: true
+  annotation:
+    file:
+      class: File
+      path: exome_workflow/chr17_test_gnomADe.vcf.gz
+      secondaryFiles: [{class: File, path: exome_workflow/chr17_test_gnomADe.vcf.gz.tbi}]
+    data_format: 'vcf'
+    name: 'gnomADe'
+    vcf_fields: ['AF','AF_AFR','AF_AMR','AF_ASJ','AF_EAS','AF_FIN','AF_NFE','AF_OTH','AF_SAS']
+    gnomad_filter: true
+    check_existing: true
 vep_ensembl_assembly: GRCh38
 vep_ensembl_version: 95
 vep_ensembl_species: homo_sapiens

--- a/example_data/somatic_wgs.yaml
+++ b/example_data/somatic_wgs.yaml
@@ -42,12 +42,31 @@ vep_cache_dir: /gscmnt/gc2560/core/cwl/inputs/VEP_cache/
 synonyms_file:
   class: File
   path: /gscmnt/gc2560/core/model_data/2887491634/build50f99e75d14340ffb5b7d21b03887637/chromAlias.ensembl.txt
-custom_gnomad_vcf:
-  class: File
-  path: /gscmnt/gc2560/core/model_data/genome-db-ensembl-gnomad/2dd4b53431674786b760adad60a29273/fixed_b38_genome.vcf.gz
-custom_clinvar_vcf:
-  class: File
-  path: /gscmnt/gc2560/core/custom_clinvar_vcf/v20181028/custom.vcf.gz
+vep_custom_annotations:
+- method: 'exact'
+  force_report_coordinates: true
+  annotation:
+    file:
+      class: File
+      path: /gscmnt/gc2560/core/model_data/genome-db-ensembl-gnomad/2dd4b53431674786b760adad60a29273/fixed_b38_genome.vcf.gz
+      secondaryFiles: [{class: File, path: /gscmnt/gc2560/core/model_data/genome-db-ensembl-gnomad/2dd4b53431674786b760adad60a29273/fixed_b38_genome.vcf.gz.tbi}]
+    data_format: 'vcf'
+    name: 'gnomADe'
+    vcf_fields: ['AF','AF_AFR','AF_AMR','AF_ASJ','AF_EAS','AF_FIN','AF_NFE','AF_OTH','AF_SAS']
+    gnomad_filter: true
+    check_existing: true
+- method: 'exact'
+  force_report_coordinates: true
+  annotation:
+    file:
+      class: File
+      path: /gscmnt/gc2560/core/custom_clinvar_vcf/v20181028/custom.vcf.gz
+      secondaryFiles: [{class: File, path: /gscmnt/gc2560/core/custom_clinvar_vcf/v20181028/custom.vcf.gz.tbi}]
+    data_format: 'vcf'
+    name: 'clinvar'
+    vcf_fields: ['CLINSIGN','PHENOTYPE','SCORE','RCVACC','TESTEDINGTR','PHENOTYPELIST','NUMSUBMIT','GUIDELINES']
+    gnomad_filter: false
+    check_existing: false
 mutect_artifact_detection_mode: false
 somalier_vcf: "/gscmnt/gc2560/core/annotation_data/concordance_snps/GRC-human-build38_gnomad_exome_common_snps.vcf"
 vep_ensembl_assembly: GRCh38


### PR DESCRIPTION
This adds a new vep custom annotation type. Plan is to have this replace the individual inputs used with clinvar and gnomad vcfs and provide more customization to the pipelines. So when new versions of databases come out we can quickly add them to the pipelines.
I have gotten the `tumor_only_detect_variants.cwl` pipeline, which includes VEP annotation and gnomad filtering, to successfully complete. 

- To support the other file types I had to add the `.filter(String)` in the javascript parsing to remove the trailing comma.(non vcf input files do not have vcf fields as inputs!)
- for the somatic pipelines that do gnomad filtering, this assumes that you are adding the `AF` field and setting the gnomde_filtering field as true. and will then be filtering based on the `${annotation_name}_AF` (and if no gnomad input is provided defaults to VEP added gnomad frequencies)
- unsure how to provide the secondary files. the different data formats have different index files. I
 got around this by specifying the index file as a secondary file in the inputs 
an example input.yam for using the new VEP annotation type
```
vep_custom_annotations:
- method: 'exact'
  force_report_coordinates: true
  annotation:
    file:
      class: File
      path: gnomad-lite.genomes.r3.0.sites.vcf.gz
      secondaryFiles: [{class: File, path: gnomad-lite.genomes.r3.0.sites.vcf.gz.tbi}]
    data_format: 'vcf'
    name: 'gnomadw'
    vcf_fields: ['AF','AF_afr','AF_amr','AF_asj','AF_eas','AF_fin','AF_nfe','AF_oth','AF_sas']
    gnomad_filter: true
    check_existing: true
```