### PR TITLE
adding default scatter count for mutect

### DIFF
--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -27,6 +27,7 @@ inputs:
         type: int?
     mutect_scatter_count:
         type: int?
+        default: 50
     varscan_strand_filter:
         type: int?
         default: 0


### PR DESCRIPTION
Since scatter_count is a required input to the mutect subworkflow, it needs to either be a required input here or have a default value.  I chose the latter and set a default scatter of 50, which is what we provide upstream in the exome workflow anyway