### PR TITLE
wgs_fixes

### DIFF
--- a/definitions/tools/mutect.cwl
+++ b/definitions/tools/mutect.cwl
@@ -25,9 +25,9 @@ requirements:
             gunzip mutect.vcf.gz #Unzipping the Mutect2 output vcf file to alter the header names.
             grep "^##" mutect.vcf >mutect.final.vcf #Extracting all the lines above #CHROM in the vcf to a new output vcf.
             grep "^#CHROM" mutect.vcf | sed "s/\<$TUMOR\>/TUMOR/g; s/\<$NORMAL\>/NORMAL/g" >> mutect.final.vcf #Concatenating the #CHROM line with substituted sample headers to the output vcf.
-            perl -nae 'print $_ unless $_ =~ /^#/' mutect.vcf >> mutect.final.vcf #Concatenating the sites to the output vcf. Changed grep to perl because grep throws a rc of 1 if the output is null.
-            bgzip mutect.final.vcf #Bzipping the final output vcf.
-            tabix mutect.final.vcf.gz #Indexing the bzipped output vcf.
+            /usr/bin/perl -nae 'print $_ unless $_ =~ /^#/' mutect.vcf >> mutect.final.vcf #Concatenating the sites to the output vcf. Changed grep to perl because grep throws a rc of 1 if the output is null.
+            /usr/bin/bgzip mutect.final.vcf #Bzipping the final output vcf.
+            /usr/bin/tabix mutect.final.vcf.gz #Indexing the bzipped output vcf.
             mv mutect.vcf.gz.stats mutect.final.vcf.gz.stats #Renaming the .stats file to match the name conversion of the final output vcf.
             /gatk/gatk FilterMutectCalls -R $2 -V mutect.final.vcf.gz -O mutect.final.filtered.vcf.gz #Running FilterMutectCalls on the output vcf.
 

--- a/definitions/tools/vcf_sanitize.cwl
+++ b/definitions/tools/vcf_sanitize.cwl
@@ -31,7 +31,7 @@ requirements:
                 cat "$1" | perl -a -F'\t' -ne 'print $_ if $_ =~ /^#/ || $F[3] !~ /[^ACTGNactgn]/' | sed -e "s/ALT_F1R2/ALTF1R2/g;s/ALT_F2R1/ALTF2R1/g;s/REF_F1R2/REFF1R2/g;s/REF_F2R1/REFF2R1/g" >$outbase.sanitized.vcf
             fi
             /opt/htslib/bin/bgzip $outbase.sanitized.vcf
-            tabix -p vcf $outbase.sanitized.vcf.gz
+            /usr/bin/tabix -p vcf $outbase.sanitized.vcf.gz
 inputs:
     vcf:
         type: File


### PR DESCRIPTION
 
1. mutect.cwl
2. vcf_sanitize.cwl
both of them were dying since tabix, perl, bgzip did not have full paths. 
This PR fixes this issue. 
