### PR TITLE
Remove sample renaming

### DIFF
--- a/definitions/pipelines/aml_trio_cle.cwl
+++ b/definitions/pipelines/aml_trio_cle.cwl
@@ -165,6 +165,10 @@ inputs:
         default: "#This laboratory developed test (LDT) was developed and its performance characteristics determined by the CLIA Licensed Environment laboratory at the McDonnell Genome Institute at Washington University (MGI-CLE, CLIA #26D2092546, CAP #9047655), Dr. David H. Spencer MD, PhD, FCAP, Medical Director. 4444 Forest Park Avenue, Rm 4127 St. Louis, Missouri 63108 (314) 286-1460 Fax: (314) 286-1810. The MGI-CLE laboratory is regulated under CLIA as certified to perform high-complexity testing. This test has not been cleared or approved by the FDA."
     disclaimer_version:
         type: string
+    tumor_sample_name:
+        type: string
+    normal_sample_name:
+        type: string
 outputs:
     tumor_cram:
         type: File
@@ -462,6 +466,8 @@ steps:
             vep_to_table_fields: vep_to_table_fields
             custom_gnomad_vcf: custom_gnomad_vcf
             custom_clinvar_vcf: custom_clinvar_vcf
+            tumor_sample_name: tumor_sample_name
+            normal_sample_name: normal_sample_name
         out:
             [mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv]
     add_disclaimer_to_tumor_final_tsv:
@@ -490,6 +496,8 @@ steps:
             normal_bam: normal_alignment_and_qc/bam
             region_file: pindel_region_file
             insert_size: pindel_insert_size
+            tumor_sample_name: tumor_sample_name
+            normal_sample_name: normal_sample_name
         out:
             [pindel_region_vcf]
     followup_bam_readcount:

--- a/definitions/pipelines/aml_trio_cle_gathered.cwl
+++ b/definitions/pipelines/aml_trio_cle_gathered.cwl
@@ -164,6 +164,10 @@ inputs:
         type: string
     disclaimer_version:
         type: string
+    tumor_sample_name:
+        type: string
+    normal_sample_name:
+        type: string
 outputs:
     final_outputs:
         type: string[]
@@ -229,6 +233,8 @@ steps:
             germline_variants_to_table_genotype_fields: germline_variants_to_table_genotype_fields
             germline_vep_to_table_fields: germline_vep_to_table_fields 
             disclaimer_version: disclaimer_version
+            tumor_sample_name: tumor_sample_name
+            normal_sample_name: normal_sample_name
         out:
             [tumor_cram, tumor_mark_duplicates_metrics, tumor_insert_size_metrics, tumor_alignment_summary_metrics, tumor_hs_metrics, tumor_summary_hs_metrics, tumor_flagstats, tumor_verify_bam_id_metrics, tumor_verify_bam_id_depth, normal_cram, normal_mark_duplicates_metrics, normal_insert_size_metrics, normal_alignment_summary_metrics, normal_hs_metrics, normal_summary_hs_metrics, normal_flagstats, normal_verify_bam_id_metrics, normal_verify_bam_id_depth, followup_cram, followup_mark_duplicates_metrics, followup_insert_size_metrics, followup_alignment_summary_metrics, followup_hs_metrics, followup_summary_hs_metrics, followup_flagstats, followup_verify_bam_id_metrics, followup_verify_bam_id_depth, mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, docm_filtered_vcf, pindel_region_vcf, tumor_final_vcf, tumor_final_filtered_vcf, tumor_final_tsv, tumor_vep_summary, germline_final_vcf, germline_coding_vcf, germline_limited_vcf, germline_final_tsv, alignment_stat_report, coverage_stat_report, full_variant_report, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv, followup_snv_bam_readcount_tsv, followup_indel_bam_readcount_tsv, somalier_concordance_metrics, somalier_concordance_statistics]
     gatherer:

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -207,6 +207,8 @@ steps:
             min_var_freq: varscan_min_var_freq
             p_value: varscan_p_value
             max_normal_freq: varscan_max_normal_freq
+            normal_sample_name: normal_sample_name
+            tumor_sample_name: tumor_sample_name
         out:
             [unfiltered_vcf, filtered_vcf]
     pindel:

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -104,7 +104,9 @@ inputs:
         type: File?
         secondaryFiles: [.tbi]
     tumor_sample_name:
-        type: string?
+        type: string
+    normal_sample_name:
+        type: string
 outputs:
     mutect_unfiltered_vcf:
         type: File
@@ -189,6 +191,8 @@ steps:
             interval_list: interval_list
             exome_mode: strelka_exome_mode
             cpu_reserved: strelka_cpu_reserved
+            normal_sample_name: normal_sample_name
+            tumor_sample_name: tumor_sample_name
         out:
             [unfiltered_vcf, filtered_vcf]
     varscan:

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -103,6 +103,8 @@ inputs:
     custom_clinvar_vcf:
         type: File?
         secondaryFiles: [.tbi]
+    tumor_sample_name:
+        type: string?
 outputs:
     mutect_unfiltered_vcf:
         type: File
@@ -175,6 +177,7 @@ steps:
             normal_bam: normal_bam
             interval_list: interval_list
             scatter_count: mutect_scatter_count
+            tumor_sample_name: tumor_sample_name
         out:
             [unfiltered_vcf, filtered_vcf]
     strelka:

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -340,9 +340,6 @@ steps:
             filter_mapq0_threshold: filter_mapq0_threshold
             filter_somatic_llr_threshold: filter_somatic_llr_threshold
             filter_minimum_depth: filter_minimum_depth
-            sample_names:
-                source: [normal_sample_name, tumor_sample_name]
-                linkMerge: merge_flattened
             tumor_bam: tumor_bam
             do_cle_vcf_filter: cle_vcf_filter
             reference: reference

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -5,7 +5,6 @@ class: Workflow
 label: "Detect Variants workflow"
 requirements:
     - class: SubworkflowFeatureRequirement
-    - class: MultipleInputFeatureRequirement
 inputs:
     reference:
         type: string

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -5,6 +5,7 @@ class: Workflow
 label: "Detect Variants workflow"
 requirements:
     - class: SubworkflowFeatureRequirement
+    - class: MultipleInputFeatureRequirement
 inputs:
     reference:
         type: string
@@ -285,8 +286,7 @@ steps:
         run: ../tools/bam_readcount.cwl
         in:
             vcf: annotate_variants/annotated_vcf
-            sample:
-                default: 'TUMOR'
+            sample: tumor_sample_name
             reference_fasta: reference
             bam: tumor_bam
             min_base_quality: readcount_minimum_base_quality
@@ -297,8 +297,7 @@ steps:
         run: ../tools/bam_readcount.cwl
         in:
             vcf: annotate_variants/annotated_vcf
-            sample:
-                default: 'NORMAL'
+            sample: normal_sample_name
             reference_fasta: reference
             bam: normal_bam
             min_base_quality: readcount_minimum_base_quality
@@ -313,8 +312,7 @@ steps:
             indel_bam_readcount_tsv: tumor_bam_readcount/indel_bam_readcount_tsv
             data_type:
                 default: 'DNA'
-            sample_name:
-                default: 'TUMOR'
+            sample_name: tumor_sample_name
         out:
             [annotated_bam_readcount_vcf]
     add_normal_bam_readcount_to_vcf:
@@ -325,8 +323,7 @@ steps:
             indel_bam_readcount_tsv: normal_bam_readcount/indel_bam_readcount_tsv
             data_type:
                 default: 'DNA'
-            sample_name:
-                default: 'NORMAL'
+            sample_name: normal_sample_name
         out:
             [annotated_bam_readcount_vcf]
     index:
@@ -344,10 +341,13 @@ steps:
             filter_somatic_llr_threshold: filter_somatic_llr_threshold
             filter_minimum_depth: filter_minimum_depth
             sample_names:
-                default: 'NORMAL,TUMOR'
+                source: [normal_sample_name, tumor_sample_name]
+                linkMerge: merge_flattened
             tumor_bam: tumor_bam
             do_cle_vcf_filter: cle_vcf_filter
             reference: reference
+            normal_sample_name: normal_sample_name
+            tumor_sample_name: tumor_sample_name
         out: 
             [filtered_vcf]
     annotated_filter_bgzip:

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -342,10 +342,8 @@ steps:
             tumor_bam: tumor_bam
             do_cle_vcf_filter: cle_vcf_filter
             reference: reference
-<<<<<<< HEAD
             normal_sample_name: normal_sample_name
             tumor_sample_name: tumor_sample_name
-=======
             gnomad_field_name:
               source: vep_custom_annotations
               valueFrom: |
@@ -359,7 +357,6 @@ steps:
                     }
                     return('gnomAD_AF');
                 }
->>>>>>> master
         out: 
             [filtered_vcf]
     annotated_filter_bgzip:

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -219,6 +219,8 @@ steps:
             normal_bam: normal_bam
             interval_list: interval_list
             insert_size: pindel_insert_size
+            tumor_sample_name: tumor_sample_name
+            normal_sample_name: normal_sample_name
         out:
             [unfiltered_vcf, filtered_vcf]
     docm:

--- a/definitions/pipelines/detect_variants_mouse.cwl
+++ b/definitions/pipelines/detect_variants_mouse.cwl
@@ -88,6 +88,10 @@ inputs:
     vep_to_table_fields:
         type: string[]?
         default: []
+    tumor_sample_name:
+        type: string
+    normal_sample_name:
+        type: string
 outputs:
     mutect_unfiltered_vcf:
         type: File
@@ -156,6 +160,7 @@ steps:
             normal_bam: normal_bam
             interval_list: interval_list
             scatter_count: mutect_scatter_count
+            tumor_sample_name: tumor_sample_name
         out:
             [unfiltered_vcf, filtered_vcf]
     strelka:
@@ -167,6 +172,8 @@ steps:
             interval_list: interval_list
             exome_mode: strelka_exome_mode
             cpu_reserved: strelka_cpu_reserved
+            tumor_sample_name: tumor_sample_name
+            normal_sample_name: normal_sample_name
         out:
             [unfiltered_vcf, filtered_vcf]
     varscan:
@@ -181,6 +188,8 @@ steps:
             min_var_freq: varscan_min_var_freq
             p_value: varscan_p_value
             max_normal_freq: varscan_max_normal_freq
+            tumor_sample_name: tumor_sample_name
+            normal_sample_name: normal_sample_name
         out:
             [unfiltered_vcf, filtered_vcf]
     pindel:
@@ -191,6 +200,8 @@ steps:
             normal_bam: normal_bam
             interval_list: interval_list
             insert_size: pindel_insert_size
+            tumor_sample_name: tumor_sample_name
+            normal_sample_name: normal_sample_name
         out:
             [unfiltered_vcf, filtered_vcf]
     combine:
@@ -292,10 +303,13 @@ steps:
             filter_somatic_llr_threshold: filter_somatic_llr_threshold
             filter_minimum_depth: filter_minimum_depth
             sample_names:
-                default: 'NORMAL,TUMOR'
+                source: [normal_sample_name, tumor_sample_name]
+                linkMerge: merge_flattened
             tumor_bam: tumor_bam
             do_cle_vcf_filter: cle_vcf_filter
             reference: reference
+            tumor_sample_name: tumor_sample_name
+            normal_sample_name: normal_sample_name
         out: 
             [filtered_vcf]
     annotated_filter_bgzip:

--- a/definitions/pipelines/detect_variants_mouse.cwl
+++ b/definitions/pipelines/detect_variants_mouse.cwl
@@ -302,9 +302,6 @@ steps:
             filter_mapq0_threshold: filter_mapq0_threshold
             filter_somatic_llr_threshold: filter_somatic_llr_threshold
             filter_minimum_depth: filter_minimum_depth
-            sample_names:
-                source: [normal_sample_name, tumor_sample_name]
-                linkMerge: merge_flattened
             tumor_bam: tumor_bam
             do_cle_vcf_filter: cle_vcf_filter
             reference: reference

--- a/definitions/pipelines/detect_variants_wgs.cwl
+++ b/definitions/pipelines/detect_variants_wgs.cwl
@@ -322,9 +322,6 @@ steps:
             filter_mapq0_threshold: filter_mapq0_threshold
             filter_somatic_llr_threshold: filter_somatic_llr_threshold
             filter_minimum_depth: filter_minimum_depth
-            sample_names:
-                source: [normal_sample_name, tumor_sample_name]
-                linkMerge: merge_flattened
             tumor_bam: tumor_bam
             do_cle_vcf_filter: cle_vcf_filter
             reference: reference

--- a/definitions/pipelines/detect_variants_wgs.cwl
+++ b/definitions/pipelines/detect_variants_wgs.cwl
@@ -324,10 +324,8 @@ steps:
             tumor_bam: tumor_bam
             do_cle_vcf_filter: cle_vcf_filter
             reference: reference
-<<<<<<< HEAD
             normal_sample_name: normal_sample_name
             tumor_sample_name: tumor_sample_name
-=======
             gnomad_field_name:
               source: vep_custom_annotations
               valueFrom: |
@@ -341,7 +339,6 @@ steps:
                     }
                     return('gnomAD_AF');
                 }
->>>>>>> master
         out: 
             [filtered_vcf]
     annotated_filter_bgzip:

--- a/definitions/pipelines/detect_variants_wgs.cwl
+++ b/definitions/pipelines/detect_variants_wgs.cwl
@@ -103,6 +103,10 @@ inputs:
     custom_clinvar_vcf:
         type: File?
         secondaryFiles: [.tbi]
+    tumor_sample_name:
+        type: string
+    normal_sample_name:
+        type: string
 outputs:
     mutect_unfiltered_vcf:
         type: File
@@ -167,6 +171,7 @@ steps:
             normal_bam: normal_bam
             interval_list: interval_list
             scatter_count: mutect_scatter_count
+            tumor_sample_name: tumor_sample_name
         out:
             [unfiltered_vcf, filtered_vcf]
     strelka:
@@ -178,6 +183,8 @@ steps:
             interval_list: interval_list
             exome_mode: strelka_exome_mode
             cpu_reserved: strelka_cpu_reserved
+            tumor_sample_name: tumor_sample_name
+            normal_sample_name: normal_sample_name
         out:
             [unfiltered_vcf, filtered_vcf]
     varscan:
@@ -192,6 +199,8 @@ steps:
             min_var_freq: varscan_min_var_freq
             p_value: varscan_p_value
             max_normal_freq: varscan_max_normal_freq
+            tumor_sample_name: tumor_sample_name
+            normal_sample_name: normal_sample_name
         out:
             [unfiltered_vcf, filtered_vcf]
     docm:
@@ -314,10 +323,13 @@ steps:
             filter_somatic_llr_threshold: filter_somatic_llr_threshold
             filter_minimum_depth: filter_minimum_depth
             sample_names:
-                default: 'NORMAL,TUMOR'
+                source: [normal_sample_name, tumor_sample_name]
+                linkMerge: merge_flattened
             tumor_bam: tumor_bam
             do_cle_vcf_filter: cle_vcf_filter
             reference: reference
+            normal_sample_name: normal_sample_name
+            tumor_sample_name: tumor_sample_name
         out: 
             [filtered_vcf]
     annotated_filter_bgzip:

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -273,9 +273,9 @@ inputs:
     pvacseq_threads:
         type: int?
 
-    immuno_tumor_sample_name:
+    tumor_sample_name:
         type: string
-    immuno_normal_sample_name:
+    normal_sample_name:
         type: string
 
 outputs:
@@ -735,8 +735,8 @@ steps:
             reference: reference
             reference_dict: reference_dict
             bam: somatic/tumor_cram
-            normal_sample_name: immuno_normal_sample_name
-            tumor_sample_name: immuno_tumor_sample_name
+            normal_sample_name: normal_sample_name
+            tumor_sample_name: tumor_sample_name
         out:
             [phased_vcf]
     extract_alleles:
@@ -748,9 +748,9 @@ steps:
     pvacseq:
         run: ../subworkflows/pvacseq.cwl
         in:
-            detect_variants_vcf: index_renamed_somatic/indexed_vcf
-            sample_name: immuno_tumor_sample_name
-            normal_sample_name: immuno_normal_sample_name
+            detect_variants_vcf: somatic/final_vcf
+            sample_name: tumor_sample_name
+            normal_sample_name: normal_sample_name
             rnaseq_bam: rnaseq/final_bam
             reference_fasta: reference
             readcount_minimum_base_quality: readcount_minimum_base_quality

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -727,32 +727,10 @@ steps:
         out:
             [cram,mark_duplicates_metrics,insert_size_metrics,insert_size_histogram,alignment_summary_metrics,hs_metrics,per_target_coverage_metrics,per_target_hs_metrics,per_base_coverage_metrics,per_base_hs_metrics,summary_hs_metrics,flagstats,verify_bam_id_metrics,verify_bam_id_depth,gvcf,final_vcf,coding_vcf,limited_vcf,vep_summary,optitype_tsv,optitype_plot]
 
-    rename_somatic_vcf_tumor_sample:
-        run: ../tools/replace_vcf_sample_name.cwl
-        in:
-            input_vcf: somatic/final_vcf
-            sample_to_replace:
-                default: 'TUMOR'
-            new_sample_name: immuno_tumor_sample_name
-        out: [renamed_vcf]
-    rename_somatic_vcf_normal_sample:
-        run: ../tools/replace_vcf_sample_name.cwl
-        in:
-            input_vcf: rename_somatic_vcf_tumor_sample/renamed_vcf
-            sample_to_replace:
-                default: 'NORMAL'
-            new_sample_name: immuno_normal_sample_name
-        out: [renamed_vcf]
-    index_renamed_somatic:
-        run: ../tools/index_vcf.cwl
-        in:
-            vcf: rename_somatic_vcf_normal_sample/renamed_vcf
-        out:
-            [indexed_vcf]
     phase_vcf:
         run: ../subworkflows/phase_vcf.cwl
         in:
-            somatic_vcf: index_renamed_somatic/indexed_vcf
+            somatic_vcf: somatic/final_vcf
             germline_vcf: germline/final_vcf
             reference: reference
             reference_dict: reference_dict

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -692,6 +692,8 @@ steps:
             manta_non_wgs: manta_non_wgs
             manta_output_contigs: manta_output_contigs
             somalier_vcf: somalier_vcf
+            tumor_sample_name: tumor_sample_name
+            normal_sample_name: normal_sample_name
         out:
             [tumor_cram,tumor_mark_duplicates_metrics,tumor_insert_size_metrics,tumor_alignment_summary_metrics,tumor_hs_metrics,tumor_per_target_coverage_metrics,tumor_per_target_hs_metrics,tumor_per_base_coverage_metrics,tumor_per_base_hs_metrics,tumor_summary_hs_metrics,tumor_flagstats,tumor_verify_bam_id_metrics,tumor_verify_bam_id_depth,normal_cram,normal_mark_duplicates_metrics,normal_insert_size_metrics,normal_alignment_summary_metrics,normal_hs_metrics,normal_per_target_coverage_metrics,normal_per_target_hs_metrics,normal_per_base_coverage_metrics,normal_per_base_hs_metrics,normal_summary_hs_metrics,normal_flagstats,normal_verify_bam_id_metrics,normal_verify_bam_id_depth,mutect_unfiltered_vcf,mutect_filtered_vcf,strelka_unfiltered_vcf,strelka_filtered_vcf,varscan_unfiltered_vcf,varscan_filtered_vcf,pindel_unfiltered_vcf,pindel_filtered_vcf,docm_filtered_vcf,final_vcf,final_filtered_vcf,final_tsv,vep_summary,tumor_snv_bam_readcount_tsv,tumor_indel_bam_readcount_tsv,normal_snv_bam_readcount_tsv,normal_indel_bam_readcount_tsv,intervals_antitarget,intervals_target,normal_antitarget_coverage,normal_target_coverage,reference_coverage,cn_diagram,cn_scatter_plot,tumor_antitarget_coverage,tumor_target_coverage,tumor_bin_level_ratios,tumor_segmented_ratios,diploid_variants,somatic_variants,all_candidates,small_candidates,tumor_only_variants,somalier_concordance_metrics,somalier_concordance_statistics]
     germline:

--- a/definitions/pipelines/panel_of_normals.cwl
+++ b/definitions/pipelines/panel_of_normals.cwl
@@ -25,8 +25,6 @@ inputs:
         secondaryFiles: [.tbi]
     normal_sample_name:
         type: string
-    tumor_sample_name:
-        type: string
 outputs:
     pon_vcf:
         type: File
@@ -49,7 +47,7 @@ steps:
                 default: true
             panel_of_normals_vcf:
                 default: null
-            tumor_sample_name: tumor_sample_name
+            tumor_sample_name: normal_sample_name
         out:
             [unfiltered_vcf]
     combine:

--- a/definitions/pipelines/panel_of_normals.cwl
+++ b/definitions/pipelines/panel_of_normals.cwl
@@ -23,6 +23,10 @@ inputs:
     cosmic_vcf:
         type: File?
         secondaryFiles: [.tbi]
+    normal_sample_name:
+        type: string
+    tumor_sample_name:
+        type: string
 outputs:
     pon_vcf:
         type: File
@@ -45,6 +49,7 @@ steps:
                 default: true
             panel_of_normals_vcf:
                 default: null
+            tumor_sample_name: tumor_sample_name
         out:
             [unfiltered_vcf]
     combine:

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -433,7 +433,6 @@ steps:
             variants_to_table_fields: variants_to_table_fields
             variants_to_table_genotype_fields: variants_to_table_genotype_fields
             vep_to_table_fields: vep_to_table_fields
-            custom_clinvar_vcf: custom_clinvar_vcf
             tumor_sample_name: tumor_sample_name
             normal_sample_name: normal_sample_name
             vep_custom_annotations: vep_custom_annotations

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -146,7 +146,9 @@ inputs:
     somalier_vcf:
         type: File
     tumor_sample_name:
-        type: string?
+        type: string
+    normal_sample_name:
+        type: string
 outputs:
     tumor_cram:
         type: File
@@ -436,6 +438,7 @@ steps:
             custom_gnomad_vcf: custom_gnomad_vcf
             custom_clinvar_vcf: custom_clinvar_vcf
             tumor_sample_name: tumor_sample_name
+            normal_sample_name: normal_sample_name
         out:
             [mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv]
     cnvkit:

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -145,6 +145,8 @@ inputs:
         type: boolean?
     somalier_vcf:
         type: File
+    tumor_sample_name:
+        type: string?
 outputs:
     tumor_cram:
         type: File
@@ -433,6 +435,7 @@ steps:
             vep_to_table_fields: vep_to_table_fields
             custom_gnomad_vcf: custom_gnomad_vcf
             custom_clinvar_vcf: custom_clinvar_vcf
+            tumor_sample_name: tumor_sample_name
         out:
             [mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv]
     cnvkit:

--- a/definitions/pipelines/somatic_exome_cle.cwl
+++ b/definitions/pipelines/somatic_exome_cle.cwl
@@ -368,7 +368,6 @@ steps:
             variants_to_table_fields: variants_to_table_fields
             variants_to_table_genotype_fields: variants_to_table_genotype_fields
             vep_to_table_fields: vep_to_table_fields
-            custom_clinvar_vcf: custom_clinvar_vcf
             tumor_sample_name: tumor_sample_name
             normal_sample_name: normal_sample_name
             vep_custom_annotations: vep_custom_annotations

--- a/definitions/pipelines/somatic_exome_cle.cwl
+++ b/definitions/pipelines/somatic_exome_cle.cwl
@@ -132,6 +132,10 @@ inputs:
         default: "#This laboratory developed test (LDT) was developed and its performance characteristics determined by the CLIA Licensed Environment laboratory at the McDonnell Genome Institute at Washington University (MGI-CLE, CLIA #26D2092546, CAP #9047655), Dr. David H. Spencer MD, PhD, FCAP, Medical Director. 4444 Forest Park Avenue, Rm 4127 St. Louis, Missouri 63108 (314) 286-1460 Fax: (314) 286-1810. The MGI-CLE laboratory is regulated under CLIA as certified to perform high-complexity testing. This test has not been cleared or approved by the FDA."
     disclaimer_version:
         type: string
+    tumor_sample_name:
+        type: string
+    normal_sample_name:
+        type: string
 outputs:
     tumor_cram:
         type: File
@@ -368,6 +372,8 @@ steps:
             vep_to_table_fields: vep_to_table_fields
             custom_gnomad_vcf: custom_gnomad_vcf
             custom_clinvar_vcf: custom_clinvar_vcf
+            tumor_sample_name: tumor_sample_name
+            normal_sample_name: normal_sample_name
         out:
             [mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv]
     add_disclaimer_to_final_tsv:

--- a/definitions/pipelines/somatic_exome_cle_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_cle_gathered.cwl
@@ -130,6 +130,10 @@ inputs:
         type: File
     disclaimer_version:
         type: string
+    tumor_sample_name:
+        type: string
+    normal_sample_name:
+        type: string
 outputs:
     final_outputs:
         type: string[]
@@ -183,6 +187,8 @@ steps:
             custom_gnomad_vcf: custom_gnomad_vcf
             somalier_vcf: somalier_vcf
             disclaimer_version: disclaimer_version
+            tumor_sample_name: tumor_sample_name
+            normal_sample_name: normal_sample_name
         out:
             [tumor_cram, tumor_mark_duplicates_metrics, tumor_insert_size_metrics, tumor_alignment_summary_metrics, tumor_hs_metrics, tumor_per_target_coverage_metrics, tumor_per_base_coverage_metrics, tumor_per_base_hs_metrics, tumor_summary_hs_metrics, tumor_flagstats, tumor_verify_bam_id_metrics, tumor_verify_bam_id_depth, normal_cram, normal_mark_duplicates_metrics, normal_insert_size_metrics, normal_alignment_summary_metrics, normal_hs_metrics, normal_per_target_coverage_metrics, normal_per_target_hs_metrics, normal_per_base_coverage_metrics, normal_per_base_hs_metrics, normal_summary_hs_metrics, normal_flagstats, normal_verify_bam_id_metrics, normal_verify_bam_id_depth, mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv, somalier_concordance_metrics, somalier_concordance_statistics]
     gatherer:

--- a/definitions/pipelines/somatic_exome_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_gathered.cwl
@@ -137,6 +137,10 @@ inputs:
         type: string
     somalier_vcf:
         type: File
+    tumor_sample_name:
+        type: string
+    normal_sample_name:
+        type: string
 outputs:
     final_outputs:
         type: string[]
@@ -192,6 +196,8 @@ steps:
             vep_to_table_fields: vep_to_table_fields
             custom_gnomad_vcf: custom_gnomad_vcf
             somalier_vcf: somalier_vcf
+            tumor_sample_name: tumor_sample_name
+            normal_sample_name: normal_sample_name
         out:
             [tumor_cram, tumor_mark_duplicates_metrics, tumor_insert_size_metrics, tumor_alignment_summary_metrics, tumor_hs_metrics, tumor_per_target_coverage_metrics, tumor_per_base_coverage_metrics, tumor_per_base_hs_metrics, tumor_summary_hs_metrics, tumor_flagstats, tumor_verify_bam_id_metrics, tumor_verify_bam_id_depth, normal_cram, normal_mark_duplicates_metrics, normal_insert_size_metrics, normal_alignment_summary_metrics, normal_hs_metrics, normal_per_target_coverage_metrics, normal_per_target_hs_metrics, normal_per_base_coverage_metrics, normal_per_base_hs_metrics, normal_summary_hs_metrics, normal_flagstats, normal_verify_bam_id_metrics, normal_verify_bam_id_depth, mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv, somalier_concordance_metrics, somalier_concordance_statistics]
     gatherer:

--- a/definitions/pipelines/somatic_exome_mouse.cwl
+++ b/definitions/pipelines/somatic_exome_mouse.cwl
@@ -99,6 +99,10 @@ inputs:
     vep_to_table_fields:
         type: string[]
         default: ['Consequence','SYMBOL','Feature']
+    tumor_sample_name:
+        type: string
+    normal_sample_name:
+        type: string
 outputs:
     tumor_cram:
         type: File
@@ -291,6 +295,8 @@ steps:
             vep_ensembl_version: vep_ensembl_version
             vep_ensembl_species: vep_ensembl_species
             vep_to_table_fields: vep_to_table_fields
+            tumor_sample_name: tumor_sample_name
+            normal_sample_name: normal_sample_name
         out:
             [mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv]
     tumor_bam_to_cram:

--- a/definitions/pipelines/somatic_wgs.cwl
+++ b/definitions/pipelines/somatic_wgs.cwl
@@ -145,6 +145,10 @@ inputs:
         type: boolean?
     somalier_vcf:
         type: File
+    tumor_sample_name:
+        type: string
+    normal_sample_name:
+        type: string
 outputs:
 ##tumor alignment and QC
     tumor_cram:
@@ -420,6 +424,8 @@ steps:
             vep_to_table_fields: vep_to_table_fields
             custom_gnomad_vcf: custom_gnomad_vcf
             custom_clinvar_vcf: custom_clinvar_vcf
+            tumor_sample_name: tumor_sample_name
+            normal_sample_name: normal_sample_name
         out:
             [mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv]
     manta: 

--- a/definitions/subworkflows/filter_vcf.cwl
+++ b/definitions/subworkflows/filter_vcf.cwl
@@ -25,6 +25,10 @@ inputs:
     filter_minimum_depth:
         type: int
     sample_names:
+        type: string[]
+    tumor_sample_name:
+        type: string
+    normal_sample_name:
         type: string
 outputs: 
     filtered_vcf:
@@ -67,6 +71,8 @@ steps:
         in:
             vcf: filter_vcf_depth/depth_filtered_vcf
             threshold: filter_somatic_llr_threshold
+            tumor_sample_name: tumor_sample_name
+            normal_sample_name: normal_sample_name
         out:
             [somatic_llr_filtered_vcf]
     set_final_vcf_name:

--- a/definitions/subworkflows/filter_vcf.cwl
+++ b/definitions/subworkflows/filter_vcf.cwl
@@ -6,6 +6,7 @@ label: "Apply filters to VCF file"
 requirements:
     - class: SubworkflowFeatureRequirement
     - class: StepInputExpressionRequirement
+    - class: MultipleInputFeatureRequirement
 inputs:
     vcf:
         type: File
@@ -24,8 +25,6 @@ inputs:
         type: string
     filter_minimum_depth:
         type: int
-    sample_names:
-        type: string[]
     tumor_sample_name:
         type: string
     normal_sample_name:
@@ -63,7 +62,9 @@ steps:
         in:
             vcf: filter_vcf_cle/cle_filtered_vcf
             minimum_depth: filter_minimum_depth
-            sample_names: sample_names
+            sample_names:
+                source: [normal_sample_name, tumor_sample_name]
+                linkMerge: merge_flattened
         out:
             [depth_filtered_vcf]
     filter_vcf_somatic_llr:

--- a/definitions/subworkflows/filter_vcf_mouse.cwl
+++ b/definitions/subworkflows/filter_vcf_mouse.cwl
@@ -6,6 +6,7 @@ label: "Apply filters to VCF file"
 requirements:
     - class: SubworkflowFeatureRequirement
     - class: StepInputExpressionRequirement
+    - class: MultipleInputFeatureRequirement
 inputs:
     vcf:
         type: File
@@ -22,8 +23,6 @@ inputs:
         type: string
     filter_minimum_depth:
         type: int
-    sample_names:
-        type: string
     tumor_sample_name:
         type: string
     normal_sample_name:
@@ -54,7 +53,9 @@ steps:
         in:
             vcf: filter_vcf_cle/cle_filtered_vcf
             minimum_depth: filter_minimum_depth
-            sample_names: sample_names
+            sample_names:
+                source: [normal_sample_name, tumor_sample_name]
+                linkMerge: merge_flattened
         out:
             [depth_filtered_vcf]
     filter_vcf_somatic_llr:

--- a/definitions/subworkflows/filter_vcf_mouse.cwl
+++ b/definitions/subworkflows/filter_vcf_mouse.cwl
@@ -24,6 +24,10 @@ inputs:
         type: int
     sample_names:
         type: string
+    tumor_sample_name:
+        type: string
+    normal_sample_name:
+        type: string
 outputs: 
     filtered_vcf:
         type: File
@@ -58,6 +62,8 @@ steps:
         in:
             vcf: filter_vcf_depth/depth_filtered_vcf
             threshold: filter_somatic_llr_threshold
+            tumor_sample_name: tumor_sample_name
+            normal_sample_name: normal_sample_name
         out:
             [somatic_llr_filtered_vcf]
     set_final_vcf_name:

--- a/definitions/subworkflows/mutect.cwl
+++ b/definitions/subworkflows/mutect.cwl
@@ -22,7 +22,7 @@ inputs:
     scatter_count:
         type: int
     tumor_sample_name:
-        type: string?
+        type: string
 outputs:
     unfiltered_vcf:
         type: File

--- a/definitions/subworkflows/mutect.cwl
+++ b/definitions/subworkflows/mutect.cwl
@@ -21,6 +21,8 @@ inputs:
         type: File
     scatter_count:
         type: int
+    tumor_sample_name:
+        type: string?
 outputs:
     unfiltered_vcf:
         type: File
@@ -67,6 +69,7 @@ steps:
             vcf: index/indexed_vcf
             variant_caller: 
                 valueFrom: "mutect"
+            sample_name: tumor_sample_name
         out:
             [unfiltered_vcf, filtered_vcf]
 

--- a/definitions/subworkflows/pindel.cwl
+++ b/definitions/subworkflows/pindel.cwl
@@ -25,6 +25,10 @@ inputs:
     scatter_count:
         type: int
         default: 50
+    tumor_sample_name:
+        type: string
+    normal_sample_name:
+        type: string
 outputs:
     unfiltered_vcf:
         type: File
@@ -51,6 +55,8 @@ steps:
             normal_bam: normal_bam
             region_file: split_interval_list_to_bed/split_beds
             insert_size: insert_size
+            tumor_sample_name: tumor_sample_name
+            normal_sample_name: normal_sample_name
         out:
             [per_region_pindel_out]
     cat_all:

--- a/definitions/subworkflows/pindel_cat.cwl
+++ b/definitions/subworkflows/pindel_cat.cwl
@@ -20,6 +20,10 @@ inputs:
     insert_size:
         type: int
         default: 400
+    tumor_sample_name:
+        type: string
+    normal_sample_name:
+        type: string
 outputs:
     per_region_pindel_out:
         type: File
@@ -33,6 +37,8 @@ steps:
             normal_bam: normal_bam
             insert_size: insert_size
             region_file: region_file
+            tumor_sample_name: tumor_sample_name
+            normal_sample_name: normal_sample_name
         out:
             [deletions, insertions, tandems, long_insertions, inversions]
     cat:

--- a/definitions/subworkflows/pindel_region.cwl
+++ b/definitions/subworkflows/pindel_region.cwl
@@ -28,6 +28,10 @@ inputs:
     output_name:
         type: string?
         default: "pindel.vcf"
+    tumor_sample_name:
+        type: string
+    normal_sample_name:
+        type: string
 outputs:
     pindel_region_vcf:
         type: File
@@ -42,6 +46,8 @@ steps:
             normal_bam: normal_bam
             insert_size: insert_size
             region_file: region_file
+            tumor_sample_name: tumor_sample_name
+            normal_sample_name: normal_sample_name
         out:
             [deletions, insertions, tandems, long_insertions, inversions]
     cat:

--- a/definitions/subworkflows/varscan_pre_and_post_processing.cwl
+++ b/definitions/subworkflows/varscan_pre_and_post_processing.cwl
@@ -32,6 +32,10 @@ inputs:
         default: 0.99
     max_normal_freq:
         type: float?
+    normal_sample_name:
+        type: string
+    tumor_sample_name:
+        type: string
 outputs:
     unfiltered_vcf:
         type: File
@@ -120,10 +124,28 @@ steps:
             vcfs: [index_snvs/indexed_vcf, index_indels/indexed_vcf]
         out:
             [merged_vcf]
+    rename_tumor_sample:
+        run: ../tools/replace_vcf_sample_name.cwl
+        in: 
+            input_vcf: merge/merged_vcf
+            sample_to_replace:
+                default: 'TUMOR'
+            new_sample_name: tumor_sample_name
+        out:
+            [renamed_vcf]
+    rename_normal_sample:
+        run: ../tools/replace_vcf_sample_name.cwl
+        in: 
+            input_vcf: rename_tumor_sample/renamed_vcf
+            sample_to_replace:
+                default: 'NORMAL'
+            new_sample_name: normal_sample_name
+        out:
+            [renamed_vcf]
     index:
         run: ../tools/index_vcf.cwl
         in:
-            vcf: merge/merged_vcf
+            vcf: rename_normal_sample/renamed_vcf
         out:
             [indexed_vcf]
     filter:
@@ -135,5 +157,6 @@ steps:
             min_var_freq: min_var_freq
             variant_caller: 
                 valueFrom: "varscan"
+            sample_name: tumor_sample_name
         out:
             [unfiltered_vcf, filtered_vcf]

--- a/definitions/tools/add_strelka_gt.cwl
+++ b/definitions/tools/add_strelka_gt.cwl
@@ -5,11 +5,99 @@ class: CommandLineTool
 label: "add GT tags"
 requirements:
     - class: DockerRequirement
-      dockerPull: "mgibio/cle:v1.3.1"
+      dockerPull: "ubuntu:xenial"
     - class: ResourceRequirement
       ramMin: 4000
+    - class: InitialWorkDirRequirement
+      listing:
+      - entryname: 'add_strelka_gt.pl'
+        entry: |
+            #!/usr/bin/perl
+
+            use strict;
+            use warnings;
+
+            use feature qw(say);
+
+            die("wrong number of arguments") unless scalar(@ARGV) == 2;
+            my ($strelka_vcf, $outdir) = @ARGV;
+
+            open(my $strelka_vcf_fh, '-|', '/bin/gunzip', '-c', $strelka_vcf) 
+                or die("couldn't open $strelka_vcf to read");
+            open(my $add_gt_fh, ">", "$outdir/add_gt.vcf") 
+                or die("couldn't open add_gt.vcf for write");
+
+            while (<$strelka_vcf_fh>) {
+                chomp;
+                if (/^##/) {
+                    say $add_gt_fh $_;
+                }
+                elsif (/^#/) { #COLUMN HEADER
+                    say $add_gt_fh '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">';
+                    say $add_gt_fh $_;
+                }
+                else {
+                    my @columns = split /\t/, $_;
+                    my ($ref, $alt, $info) = map{$columns[$_]}(3, 4, 7);
+                    my @alts = split /,/, $alt;
+
+                    my ($n_gt, $t_gt);
+
+                    if (length($ref) == 1 and length($alts[0]) == 1) {
+                        my ($n_gt_info, $n_gt_str, $t_gt_str) = $info =~ /NT=(\S+?);QSS.*SGT=(\S+?)\->(\S+?);/;
+                        unshift @alts, $ref;
+
+                        my %ids;
+                        my $id = 0;
+
+                        for my $base (@alts) {
+                            $ids{$base} = $id;
+                            $id++;
+                        }
+
+                        $n_gt = $n_gt_info eq 'ref' ? '0/0' : parse_gt($n_gt_str, \%ids);
+                        $t_gt = parse_gt($t_gt_str, \%ids);
+                    }
+                    else {#INDEL
+                        my ($n_gt_info, $t_gt_info) = $info =~ /;NT=(\S+?);.*SGT.*\->(\S+?);/;
+
+                        my %gt_info = (
+                            ref => '0/0',
+                            het => '0/1',
+                            hom => '1/1',
+                            conflict => './.',
+                        );
+
+                        $n_gt = $gt_info{$n_gt_info};
+                        $t_gt = $gt_info{$t_gt_info};
+                    }
+
+                    $columns[8]  = 'GT:'.$columns[8];
+                    $columns[9]  = $n_gt . ':' . $columns[9];
+                    $columns[10] = $t_gt . ':' . $columns[10];
+
+                    my $new_str = join "\t", @columns;
+                    say $add_gt_fh $new_str;
+                }
+            }
+
+            close($strelka_vcf_fh);
+            close($add_gt_fh);
+
+
+            sub parse_gt {
+                my ($gt_str, $ids) = @_;
+                my @gt_ids = map{$ids->{$_}}(split //, $gt_str);
+                return join '/', sort @gt_ids;
+            }
+
+            #SNV example
+            #1       10231   .       C       A       .       QSS_ref NT=ref;QSS=1;QSS_NT=1;SGT=AC->AC;SOMATIC;TQSS=2;TQSS_NT=2       DP:FDP:SDP:SUBDP:AU:CU:GU:TU    32:4:8:0:0,3:28,60:0,0:0,1      84:6:69:0:7,21:71,192:0,0:0,1
+            #INDEL example
+            ##1     965051  .       ATGTGTG A       .       QSI_ref IC=5;IHP=2;NT=ref;QSI=1;QSI_NT=1;RC=8;RU=TG;SGT=het->het;SOMATIC;TQSI=1;TQSI_NT=1       DP:DP2:TAR:TIR:TOR:DP50:FDP50:SUBDP50   8:8:6,6:0,0:2,4:10.3:0.00:0.00  18:18:8,8:5,6:5,8:21:0.25:0.00
+
 arguments: [
-    "/usr/bin/perl", "/usr/bin/add_strelka_gt.pl",
+    "/usr/bin/perl", "add_strelka_gt.pl",
     $(inputs.vcf.path), $(runtime.outdir)
 ]
 inputs:

--- a/definitions/tools/add_strelka_gt.cwl
+++ b/definitions/tools/add_strelka_gt.cwl
@@ -5,7 +5,7 @@ class: CommandLineTool
 label: "add GT tags"
 requirements:
     - class: DockerRequirement
-      dockerPull: "ubuntu:xenial"
+      dockerPull: "ubuntu:bionic"
     - class: ResourceRequirement
       ramMin: 4000
     - class: InitialWorkDirRequirement

--- a/definitions/tools/bam_readcount.cwl
+++ b/definitions/tools/bam_readcount.cwl
@@ -4,7 +4,7 @@ cwlVersion: v1.0
 class: CommandLineTool
 label: "run bam-readcount"
 
-baseCommand: ["/usr/bin/python", "/usr/bin/bam_readcount_helper.py"]
+baseCommand: ["/usr/bin/python", "bam_readcount_helper.py"]
 requirements:
     - class: ShellCommandRequirement
     - class: DockerRequirement
@@ -12,6 +12,117 @@ requirements:
     - class: ResourceRequirement
       ramMin: 16000
     - class: InlineJavascriptRequirement
+    - class: InitialWorkDirRequirement
+      listing:
+      - entryname: 'bam_readcount_helper.py'
+        entry: |
+            #!/usr/bin/env python
+
+            import sys
+            import os
+            from cyvcf2 import VCF
+            import tempfile
+            import csv
+            from subprocess import Popen, PIPE
+
+            def generate_region_list(hash):
+                fh = tempfile.NamedTemporaryFile('w', delete=False)
+                writer = csv.writer(fh, delimiter='\t')
+                for chr, positions in hash.items():
+                    for pos in sorted(positions.keys()):
+                        writer.writerow([chr, pos, pos])
+                fh.close()
+                return fh.name
+
+            def filter_sites_in_hash(region_list, bam_file, ref_fasta, prefixed_sample, output_dir, insertion_centric, map_qual, base_qual):
+                bam_readcount_cmd = ['/usr/bin/bam-readcount', '-f', ref_fasta, '-l', region_list, '-w', '0', '-b', str(base_qual), '-q', str(map_qual)]
+                if insertion_centric:
+                    bam_readcount_cmd.append('-i')
+                    output_file = os.path.join(output_dir, prefixed_sample + '_bam_readcount_indel.tsv')
+                else:
+                    output_file = os.path.join(output_dir, prefixed_sample + '_bam_readcount_snv.tsv')
+                bam_readcount_cmd.append(bam_file)
+                execution = Popen(bam_readcount_cmd, stdout=PIPE, stderr=PIPE)
+                stdout, stderr = execution.communicate()
+                if execution.returncode == 0:
+                    with open(output_file, 'wb') as output_fh:
+                        output_fh.write(stdout)
+                else:
+                    sys.exit(stderr)
+
+            #initializing these with default values
+            min_base_qual = 20
+            min_mapping_qual = 0
+
+            if len(sys.argv) == 7:
+                (script_name, vcf_filename, sample, ref_fasta, bam_file, prefix, output_dir)= sys.argv
+            elif len(sys.argv) == 8:
+                (script_name, vcf_filename, sample, ref_fasta, bam_file, prefix, output_dir, min_base_qual)= sys.argv
+            elif len(sys.argv) == 9: #elif instead of else for explicit safety
+                (script_name, vcf_filename, sample, ref_fasta, bam_file, prefix, output_dir, min_base_qual, min_mapping_qual)= sys.argv
+
+            if prefix == 'NOPREFIX':
+                prefixed_sample = sample
+            else:
+                prefixed_sample = '_'.join([prefix, sample])
+
+            vcf_file = VCF(vcf_filename)
+            sample_index = vcf_file.samples.index(sample)
+
+            rc_for_indel = {}
+            rc_for_snp   = {}
+            for variant in vcf_file:
+                ref = variant.REF
+                chr = variant.CHROM
+                start = variant.start
+                end = variant.end
+                pos = variant.POS
+                for var in  variant.ALT:
+                    if len(ref) > 1 or len(var) > 1:
+                        #it's an indel or mnp
+                        if len(ref) == len(var) or (len(ref) > 1 and len(var) > 1):
+                            sys.stderr.write("Complex variant or MNP will be skipped: %s\t%s\t%s\t%s\n" % (chr, pos, ref , var))
+                            continue
+                        elif len(ref) > len(var):
+                            #it's a deletion
+                            pos += 1
+                            unmodified_ref = ref
+                            ref = unmodified_ref[1]
+                            var = "-%s" % unmodified_ref[1:]
+                        else:
+                            #it's an insertion
+                            var = "+%s" % var[1:]
+                        if chr not in rc_for_indel:
+                            rc_for_indel[chr] = {}
+                        if pos not in rc_for_indel[chr]:
+                            rc_for_indel[chr][pos] = {}
+                        if ref not in rc_for_indel[chr][pos]:
+                            rc_for_indel[chr][pos][ref] = {}
+                        rc_for_indel[chr][pos][ref] = variant
+                    else:
+                        #it's a SNP
+                        if chr not in rc_for_snp:
+                            rc_for_snp[chr] = {}
+                        if pos not in rc_for_snp[chr]:
+                            rc_for_snp[chr][pos] = {}
+                        if ref not in rc_for_snp[chr][pos]:
+                            rc_for_snp[chr][pos][ref] = {}
+                        rc_for_snp[chr][pos][ref] = variant
+
+            if len(rc_for_snp.keys()) > 0:
+                region_file = generate_region_list(rc_for_snp)
+                filter_sites_in_hash(region_file, bam_file, ref_fasta, prefixed_sample, output_dir, False, min_mapping_qual, min_base_qual)
+            else:
+                output_file = os.path.join(output_dir, prefixed_sample + '_bam_readcount_snv.tsv')
+                open(output_file, 'w').close()
+
+            if len(rc_for_indel.keys()) > 0:
+                region_file = generate_region_list(rc_for_indel)
+                filter_sites_in_hash(region_file, bam_file, ref_fasta, prefixed_sample, output_dir, True, min_mapping_qual, min_base_qual)
+            else:
+                output_file = os.path.join(output_dir, prefixed_sample + '_bam_readcount_indel.tsv')
+                open(output_file, 'w').close()
+
 arguments: [
     { valueFrom: $(runtime.outdir), position: -3 }
 ]

--- a/definitions/tools/filter_vcf_depth.cwl
+++ b/definitions/tools/filter_vcf_depth.cwl
@@ -22,8 +22,9 @@ inputs:
             prefix: "--minimum_depth"
             position: -3
     sample_names:
-        type: string
+        type: string[]
         inputBinding:
+            itemSeparator: ","
             position: -1
 outputs:
      depth_filtered_vcf:

--- a/definitions/tools/filter_vcf_docm.cwl
+++ b/definitions/tools/filter_vcf_docm.cwl
@@ -3,12 +3,101 @@
 cwlVersion: v1.0
 class: CommandLineTool
 label: "Filter variants from the DoCM detector"
-baseCommand: ["/usr/bin/perl", "/usr/bin/docm_filter.pl"]
+baseCommand: ["/usr/bin/perl", "docm_filter.pl"]
 requirements:
     - class: DockerRequirement
       dockerPull: "mgibio/cle:v1.4.2"
     - class: ResourceRequirement
       ramMin: 4000
+    - class: InitialWorkDirRequirement
+      listing:
+      - entryname: 'docm_filter.pl'
+        entry: |
+            #!/usr/bin/perl
+
+            use strict;
+            use warnings;
+
+            use feature qw(say);
+
+            die("Wrong number of arguments. Provide docm_vcf, normal_cram, tumor_cram, output_vcf_file, set_filter_flag") unless scalar(@ARGV) == 5;
+            my ($docm_vcf, $normal_cram, $tumor_cram, $output_vcf_file, $set_filter_flag) = @ARGV;
+
+            my $samtools = '/opt/samtools/bin/samtools';
+            my $normal_header_str = `$samtools view -H $normal_cram`;
+            my $tumor_header_str  = `$samtools view -H $tumor_cram`;
+
+            my ($normal_name) = $normal_header_str =~ /\s+SM:(\S+)/;
+            my ($tumor_name)  = $tumor_header_str =~ /\s+SM:(\S+)/;
+
+            unless ($normal_name and $tumor_name) {
+                die "Failed to get normal_name: $normal_name from $normal_cram AND tumor_name: $tumor_name from $tumor_cram";
+            }
+
+            my $docm_vcf_fh;
+            if($docm_vcf =~ /.gz$/){
+                open($docm_vcf_fh, "gunzip -c $docm_vcf |") or die("couldn't open $docm_vcf to read");
+            } else {
+                open($docm_vcf_fh, $docm_vcf) or die("couldn't open $docm_vcf to read");
+            }
+            open(my $docm_out_fh, ">", "$output_vcf_file") or die("couldn't open $output_vcf_file for write");
+
+            my ($normal_index, $tumor_index);
+
+            while (<$docm_vcf_fh>) {
+                chomp;
+                if (/^##/) {
+                    say $docm_out_fh $_;
+                }
+                elsif (/^#CHROM/) {
+                    if ($set_filter_flag) {
+                        say $docm_out_fh '##FILTER=<ID=DOCM_ONLY,Description="ignore Docm variants">';
+                    }
+                    my @columns = split /\t/, $_;
+                    my %index = (
+                        $columns[9]  => 9,
+                        $columns[10] => 10,
+                    );
+                    ($normal_index, $tumor_index) = map{$index{$_}}($normal_name, $tumor_name);
+                    unless ($normal_index and $tumor_index) {
+                        die "Failed to get normal_index: $normal_index for $normal_name AND tumor_index: $tumor_index for $tumor_name";
+                    }
+                    $columns[9]  = 'NORMAL';
+                    $columns[10] = 'TUMOR';
+                    my $header = join "\t", @columns;
+                    say $docm_out_fh $header;
+                }
+                else {
+                    my @columns = split /\t/, $_;
+                    my @tumor_info = split /:/, $columns[$tumor_index];
+                    my ($AD, $DP) = ($tumor_info[1], $tumor_info[2]);
+                    next unless $AD;
+                    my @AD = split /,/, $AD;
+                    shift @AD; #the first one is ref count
+                    
+                    for my $ad (@AD) {
+                        if ($ad > 5 and $ad/$DP > 0.01) {
+                            my ($normal_col, $tumor_col) = map{$columns[$_]}($normal_index, $tumor_index);
+                            $columns[9]  = $normal_col;
+                            $columns[10] = $tumor_col;
+                            if ($set_filter_flag) {
+                                $columns[6] = 'DOCM_ONLY';
+                            }
+                            else {
+                                $columns[6] = '.';
+                            }
+                            my $new_line = join "\t", @columns;
+                            say $docm_out_fh $new_line;
+                            last;
+                        }
+                    }
+                }
+            }
+
+            close($docm_vcf_fh);
+            close($docm_out_fh);
+
+
 arguments: [
     $(runtime.outdir)/docm_filtered_variants.vcf
 ]

--- a/definitions/tools/filter_vcf_docm.cwl
+++ b/definitions/tools/filter_vcf_docm.cwl
@@ -27,8 +27,8 @@ requirements:
             my $normal_header_str = `$samtools view -H $normal_cram`;
             my $tumor_header_str  = `$samtools view -H $tumor_cram`;
 
-            my ($normal_name) = $normal_header_str =~ /\s+SM:(\S+)/;
-            my ($tumor_name)  = $tumor_header_str =~ /\s+SM:(\S+)/;
+            my ($normal_name) = $normal_header_str =~ /SM:([ -~]+)/;
+            my ($tumor_name)  = $tumor_header_str =~ /SM:([ -~]+)/;
 
             unless ($normal_name and $tumor_name) {
                 die "Failed to get normal_name: $normal_name from $normal_cram AND tumor_name: $tumor_name from $tumor_cram";

--- a/definitions/tools/filter_vcf_docm.cwl
+++ b/definitions/tools/filter_vcf_docm.cwl
@@ -62,8 +62,8 @@ requirements:
                     unless ($normal_index and $tumor_index) {
                         die "Failed to get normal_index: $normal_index for $normal_name AND tumor_index: $tumor_index for $tumor_name";
                     }
-                    $columns[9]  = 'NORMAL';
-                    $columns[10] = 'TUMOR';
+                    $columns[9]  = $normal_name;
+                    $columns[10] = $tumor_name;
                     my $header = join "\t", @columns;
                     say $docm_out_fh $header;
                 }

--- a/definitions/tools/filter_vcf_somatic_llr.cwl
+++ b/definitions/tools/filter_vcf_somatic_llr.cwl
@@ -22,6 +22,15 @@ inputs:
          inputBinding:
              prefix: "--llr-threshold"
              position: -2
+    tumor_sample_name:
+        type: string
+        inputBinding:
+            prefix: "--tumor-sample-name"
+            position: -3
+    normal_sample_name:
+        type: string
+        inputBinding:
+            prefix: "--normal-sample-name"
 outputs:
      somatic_llr_filtered_vcf:
          type: File

--- a/definitions/tools/intervals_to_bed.cwl
+++ b/definitions/tools/intervals_to_bed.cwl
@@ -4,7 +4,7 @@ class: CommandLineTool
 baseCommand: ['/usr/bin/perl', 'intervals_to_bed.pl']
 requirements:
     - class: DockerRequirement
-      dockerPull: "ubuntu:xenial"
+      dockerPull: "ubuntu:bionic"
     - class: ResourceRequirement
       ramMin: 4000
     - class: InitialWorkDirRequirement

--- a/definitions/tools/intervals_to_bed.cwl
+++ b/definitions/tools/intervals_to_bed.cwl
@@ -1,12 +1,27 @@
 #!/usr/bin/env cwl-runner
 cwlVersion: v1.0
 class: CommandLineTool
-baseCommand: ['/usr/bin/perl', '/usr/bin/intervals_to_bed.pl']
+baseCommand: ['/usr/bin/perl', 'intervals_to_bed.pl']
 requirements:
     - class: DockerRequirement
-      dockerPull: "mgibio/perl_helper-cwl:1.0.0"
+      dockerPull: "ubuntu:xenial"
     - class: ResourceRequirement
       ramMin: 4000
+    - class: InitialWorkDirRequirement
+      listing:
+      - entryname: 'intervals_to_bed.pl'
+        entry: |
+            use feature qw(say);
+
+            for my $line (<>) {
+                chomp $line;
+
+                next if substr($line,0,1) eq '@'; #skip header lines
+
+                my ($chrom, $start, $stop) = split(/\t/, $line);
+                say(join("\t", $chrom, $start-1, $stop));
+            }
+
 stdout: "interval_list.bed"
 inputs:
     interval_list:

--- a/definitions/tools/mutect.cwl
+++ b/definitions/tools/mutect.cwl
@@ -21,7 +21,7 @@ requirements:
             
             TUMOR=`(samtools view -H $3 | grep "^@RG" | sed "s/.*SM:\([^\t]*\).*/\1/g" | head -n 1)` #Extracting the sample name from the TUMOR bam.
             NORMAL=`(samtools view -H $4 | grep "^@RG" | sed "s/.*SM:\([^\t]*\).*/\1/g" | head -n 1)` #Extracting the sample name from the NORMAL bam.
-            /gatk/gatk Mutect2 --java-options "-Xmx20g" -O $1 -R $2 -I $3 -tumor $TUMOR -I $4 -normal $NORMAL -L $5 #Running Mutect2.
+            /gatk/gatk Mutect2 --java-options "-Xmx20g" -O $1 -R $2 -I $3 -tumor "$TUMOR" -I $4 -normal "$NORMAL" -L $5 #Running Mutect2.
             /gatk/gatk FilterMutectCalls -R $2 -V mutect.vcf.gz -O mutect.filtered.vcf.gz #Running FilterMutectCalls on the output vcf.
 
 arguments:

--- a/definitions/tools/mutect.cwl
+++ b/definitions/tools/mutect.cwl
@@ -18,9 +18,12 @@ requirements:
         entry: |
             set -o pipefail
             set -o errexit
-            
-            TUMOR=`(samtools view -H $3 | grep "^@RG" | sed "s/.*SM:\([^\t]*\).*/\1/g" | head -n 1)` #Extracting the sample name from the TUMOR bam.
-            NORMAL=`(samtools view -H $4 | grep "^@RG" | sed "s/.*SM:\([^\t]*\).*/\1/g" | head -n 1)` #Extracting the sample name from the NORMAL bam.
+
+            export tumor_bam="$3"
+            export normal_bam="$4"
+
+            TUMOR=`perl -e 'my $header_str = qx(samtools view -H $ENV{tumor_bam}); my ($sample_name) = $header_str =~ /SM:([ -~]+)/; print $sample_name'` #Extracting the sample name from the TUMOR bam.
+            NORMAL=`perl -e 'my $header_str = qx(samtools view -H $ENV{normal_bam}); my ($sample_name) = $header_str =~ /SM:([ -~]+)/; print $sample_name'` #Extracting the sample name from the NORMAL bam.
             /gatk/gatk Mutect2 --java-options "-Xmx20g" -O $1 -R $2 -I $3 -tumor "$TUMOR" -I $4 -normal "$NORMAL" -L $5 #Running Mutect2.
             /gatk/gatk FilterMutectCalls -R $2 -V mutect.vcf.gz -O mutect.filtered.vcf.gz #Running FilterMutectCalls on the output vcf.
 

--- a/definitions/tools/mutect.cwl
+++ b/definitions/tools/mutect.cwl
@@ -22,14 +22,7 @@ requirements:
             TUMOR=`(samtools view -H $3 | grep "^@RG" | sed "s/.*SM:\([^\t]*\).*/\1/g" | head -n 1)` #Extracting the sample name from the TUMOR bam.
             NORMAL=`(samtools view -H $4 | grep "^@RG" | sed "s/.*SM:\([^\t]*\).*/\1/g" | head -n 1)` #Extracting the sample name from the NORMAL bam.
             /gatk/gatk Mutect2 --java-options "-Xmx20g" -O $1 -R $2 -I $3 -tumor $TUMOR -I $4 -normal $NORMAL -L $5 #Running Mutect2.
-            gunzip mutect.vcf.gz #Unzipping the Mutect2 output vcf file to alter the header names.
-            grep "^##" mutect.vcf >mutect.final.vcf #Extracting all the lines above #CHROM in the vcf to a new output vcf.
-            grep "^#CHROM" mutect.vcf | sed "s/\<$TUMOR\>/TUMOR/g; s/\<$NORMAL\>/NORMAL/g" >> mutect.final.vcf #Concatenating the #CHROM line with substituted sample headers to the output vcf.
-            perl -nae 'print $_ unless $_ =~ /^#/' mutect.vcf >> mutect.final.vcf #Concatenating the sites to the output vcf. Changed grep to perl because grep throws a rc of 1 if the output is null.
-            bgzip mutect.final.vcf #Bzipping the final output vcf.
-            tabix mutect.final.vcf.gz #Indexing the bzipped output vcf.
-            mv mutect.vcf.gz.stats mutect.final.vcf.gz.stats #Renaming the .stats file to match the name conversion of the final output vcf.
-            /gatk/gatk FilterMutectCalls -R $2 -V mutect.final.vcf.gz -O mutect.final.filtered.vcf.gz #Running FilterMutectCalls on the output vcf.
+            /gatk/gatk FilterMutectCalls -R $2 -V mutect.vcf.gz -O mutect.filtered.vcf.gz #Running FilterMutectCalls on the output vcf.
 
 arguments:
     - position: 1
@@ -59,5 +52,5 @@ outputs:
     vcf:
         type: File
         outputBinding:
-            glob: "mutect.final.filtered.vcf.gz"
+            glob: "mutect.filtered.vcf.gz"
         secondaryFiles: [.tbi]

--- a/definitions/tools/pindel.cwl
+++ b/definitions/tools/pindel.cwl
@@ -3,10 +3,7 @@
 cwlVersion: v1.0
 class: CommandLineTool
 label: "pindel v0.2.5b8"
-arguments: [
-    "/usr/bin/perl", "pindel_helper.pl",
-    $(inputs.normal_bam.path), $(inputs.tumor_bam.path), $(inputs.insert_size)
-]
+arguments: ["/usr/bin/perl", "pindel_helper.pl"]
 requirements:
     - class: ResourceRequirement
       ramMin: 16000
@@ -25,16 +22,16 @@ requirements:
 
             use IO::File;
 
-            unless (@ARGV > 3) {
-                die "Usage: $0 normal.bam tumor.bam insert_size <args>";
+            unless (@ARGV > 5) {
+                die "Usage: $0 normal.bam tumor.bam insert_size normal_sample_name tumor_sample_name <args>";
             }
 
-            my ($normal_bam, $tumor_bam, $insert_size, @args) = @ARGV;
+            my ($normal_bam, $tumor_bam, $insert_size, $normal_name, $tumor_name, @args) = @ARGV;
 
             my $fh = IO::File->new("> pindel.config");
 
-            $fh->say(join("\t", $normal_bam, $insert_size, 'NORMAL'));
-            $fh->say(join("\t", $tumor_bam, $insert_size, 'TUMOR'));
+            $fh->say(join("\t", $normal_bam, $insert_size, $normal_name));
+            $fh->say(join("\t", $tumor_bam, $insert_size, $tumor_name));
             $fh->close;
 
             exit system(qw(/usr/bin/pindel -i pindel.config -w 30 -T 4 -o all), @args);
@@ -43,24 +40,41 @@ inputs:
     tumor_bam:
         type: File
         secondaryFiles: ["^.bai"]
+        inputBinding:
+            position: 1
     normal_bam:
         type: File
         secondaryFiles: ["^.bai"]
+        inputBinding:
+            position: 2
+    insert_size:
+        type: int
+        default: 400
+        inputBinding:
+            position: 3
+    tumor_sample_name:
+        type: string
+        inputBinding:
+            position: 4
+    normal_sample_name:
+        type: string
+        inputBinding:
+            position: 5
     reference:
         type: string
         inputBinding:
             prefix: "-f"
+            position: 6
     chromosome:
         type: string?
         inputBinding:
             prefix: "-c"
+            position: 7
     region_file:
         type: File?
         inputBinding:
             prefix: "-j"
-    insert_size:
-        type: int
-        default: 400
+            position: 8
 outputs:
     deletions:
         type: File

--- a/definitions/tools/pindel.cwl
+++ b/definitions/tools/pindel.cwl
@@ -4,7 +4,7 @@ cwlVersion: v1.0
 class: CommandLineTool
 label: "pindel v0.2.5b8"
 arguments: [
-    "/usr/bin/perl", "/usr/bin/pindel_helper.pl",
+    "/usr/bin/perl", "pindel_helper.pl",
     $(inputs.normal_bam.path), $(inputs.tumor_bam.path), $(inputs.insert_size)
 ]
 requirements:
@@ -14,6 +14,31 @@ requirements:
       coresMin: 4
     - class: DockerRequirement
       dockerPull: "mgibio/cle:v1.4.2"
+    - class: InitialWorkDirRequirement
+      listing:
+      - entryname: 'pindel_helper.pl'
+        entry: |
+            #!/usr/bin/perl
+
+            use strict;
+            use warnings;
+
+            use IO::File;
+
+            unless (@ARGV > 3) {
+                die "Usage: $0 normal.bam tumor.bam insert_size <args>";
+            }
+
+            my ($normal_bam, $tumor_bam, $insert_size, @args) = @ARGV;
+
+            my $fh = IO::File->new("> pindel.config");
+
+            $fh->say(join("\t", $normal_bam, $insert_size, 'NORMAL'));
+            $fh->say(join("\t", $tumor_bam, $insert_size, 'TUMOR'));
+            $fh->close;
+
+            exit system(qw(/usr/bin/pindel -i pindel.config -w 30 -T 4 -o all), @args);
+
 inputs:
     tumor_bam:
         type: File

--- a/definitions/tools/replace_vcf_sample_name.cwl
+++ b/definitions/tools/replace_vcf_sample_name.cwl
@@ -18,7 +18,13 @@ requirements:
           set -eou pipefail
           basen=`basename "$3"`
           basen="renamed.$basen"
-          echo "$1 $2" > sample_update.txt
+
+          #escape spaces, otherwise bcftools will try to use them as a delimiter
+          #triple backslash to escape within backticks and then again within sed
+          old_name=`echo "$1" | sed 's/ /\\\ /g'`
+          new_name=`echo "$2" | sed 's/ /\\\ /g'`
+
+          echo "$old_name $new_name" > sample_update.txt
           /opt/bcftools/bin/bcftools reheader -s sample_update.txt -o "$basen" "$3"
 
 inputs:

--- a/definitions/tools/split_interval_list.cwl
+++ b/definitions/tools/split_interval_list.cwl
@@ -2,12 +2,28 @@
 
 cwlVersion: v1.0
 class: CommandLineTool
-baseCommand: ['/usr/bin/perl', '/usr/bin/split_interval_list_helper.pl']
+baseCommand: ['/usr/bin/perl', 'split_interval_list_helper.pl']
 requirements:
     - class: ResourceRequirement
       ramMin: 6000
     - class: DockerRequirement
-      dockerPull: mgibio/cle:v1.3.1
+      dockerPull: perl:5.26
+    - class: InitialWorkDirRequirement
+      listing:
+      - entryname: 'split_interval_list_helper.pl'
+        entry: |
+            use File::Copy;
+
+            my $retval = system('/usr/bin/java', '-jar', '/usr/picard/picard.jar', 'IntervalListTools', @ARGV);
+            exit $retval if $retval != 0;
+
+            my $i = 1;
+            for(glob('*/scattered.interval_list')) {
+                #create unique names and relocate all the scattered intervals to a single directory
+                File::Copy::move($_, qq{$i.interval_list});
+                $i++
+            }
+
 arguments:
     [{ valueFrom: OUTPUT=$(runtime.outdir) }]
 inputs:

--- a/definitions/tools/split_interval_list.cwl
+++ b/definitions/tools/split_interval_list.cwl
@@ -7,7 +7,7 @@ requirements:
     - class: ResourceRequirement
       ramMin: 6000
     - class: DockerRequirement
-      dockerPull: perl:5.26
+      dockerPull: mgibio/cle:v1.3.1
     - class: InitialWorkDirRequirement
       listing:
       - entryname: 'split_interval_list_helper.pl'

--- a/definitions/tools/varscan_somatic.cwl
+++ b/definitions/tools/varscan_somatic.cwl
@@ -3,12 +3,61 @@
 cwlVersion: v1.0
 class: CommandLineTool
 label: "varscan v2.4.2 somatic"
-baseCommand: "/usr/bin/varscan_helper.sh"
+baseCommand: "varscan_helper.sh"
 requirements:
     - class: ResourceRequirement
       ramMin: 12000
     - class: DockerRequirement
       dockerPull: "mgibio/cle:v1.3.1"
+    - class: InitialWorkDirRequirement
+      listing:
+      - entryname: 'varscan_helper.sh'
+        entry: |
+            #!/bin/bash
+
+            set -o errexit
+            set -o nounset
+
+            if [ $# -lt 7 ]
+            then
+                echo "Usage: $0 [TUMOR_BAM] [NORMAL_BAM] [REFERENCE] [STRAND_FILTER] [MIN_COVERAGE] [MIN_VAR_FREQ] [P_VALUE] [roi_bed?]"
+                exit 1
+            fi
+
+            TUMOR_BAM="$1"
+            NORMAL_BAM="$2"
+            REFERENCE="$3"
+            STRAND_FILTER="$4"
+            MIN_COVERAGE="$5"
+            MIN_VAR_FREQ="$6"
+            P_VALUE="$7"
+            OUTPUT="${HOME}/output"
+
+            if [ -z ${8+x} ]
+            then
+                #run without ROI
+                java -jar /opt/varscan/VarScan.jar somatic \
+                    <(/opt/samtools/bin/samtools mpileup --no-baq -f "$REFERENCE" "$NORMAL_BAM" "$TUMOR_BAM") \
+                    $OUTPUT \
+                    --strand-filter $STRAND_FILTER \
+                    --min-coverage $MIN_COVERAGE \
+                    --min-var-freq $MIN_VAR_FREQ \
+                    --p-value $P_VALUE \
+                    --mpileup 1 \
+                    --output-vcf
+            else
+                ROI_BED="$8"
+                java -jar /opt/varscan/VarScan.jar somatic \
+                    <(/opt/samtools/bin/samtools mpileup --no-baq -l "$ROI_BED" -f "$REFERENCE" "$NORMAL_BAM" "$TUMOR_BAM") \
+                    $OUTPUT \
+                    --strand-filter $STRAND_FILTER \
+                    --min-coverage $MIN_COVERAGE \
+                    --min-var-freq $MIN_VAR_FREQ \
+                    --p-value $P_VALUE \
+                    --mpileup 1 \
+                    --output-vcf
+            fi
+
 inputs:
     tumor_bam:
         type: File


### PR DESCRIPTION
This PR modifies the detect_variants* pipelines to preserve the actual sample names in all vcf headers, instead of always renaming them to NORMAL/TUMOR. Most of the changes to each file are the addition of 2 new arguments, `tumor_sample_name` and `normal_sample_name`, and the needed connections. Along the way, I moved the scripts of several tools from docker images into the CWL file itself. For those tools that needed changes to support the new naming scheme, transcription into CWL and the actual change to preserve the names are two separate commits. 