### PR TITLE
link correct output file

### DIFF
--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -268,7 +268,7 @@ outputs:
         outputSource: add_disclaimer_survivor_sv_vcf/output_file
     survivor_merged_annotated_tsv:
         type: File
-        outputSource: add_disclaimer_survivor_sv_vcf/output_file
+        outputSource: add_disclaimer_survivor_sv_tsv/output_file
     bcftools_merged_vcf:
         type: File
         outputSource: add_disclaimer_bcftools_sv_vcf/output_file


### PR DESCRIPTION
In a previous PR I duplicated the output link for 2 files. 
This caused one of the outputs be incorrect and for there to be 2 outputs of the same file in the outputs.json. When the GMS attempted to move the results it fails as there are 2 files with the same name. 
This PR correctly links the survivor TSV output file. 