### PR TITLE
Added cle variant filter

### DIFF
--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -104,7 +104,7 @@ inputs:
     vep_custom_annotations:
         type: ../types/vep_custom_annotation.yml#vep_custom_annotation[]
         doc: "custom type, check types directory for input format"
-    cle_variants:
+    known_variants:
         type: File?
         secondaryFiles: [.tbi]
 outputs:
@@ -353,7 +353,7 @@ steps:
                     }
                     return('gnomAD_AF');
                 }
-            cle_variants: cle_variants
+            known_variants: known_variants
         out: 
             [filtered_vcf]
     annotated_filter_bgzip:

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -107,6 +107,7 @@ inputs:
     known_variants:
         type: File?
         secondaryFiles: [.tbi]
+        doc: "Previously discovered variants to be flagged in this pipelines's output vcf"
 outputs:
     mutect_unfiltered_vcf:
         type: File

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -104,6 +104,9 @@ inputs:
     vep_custom_annotations:
         type: ../types/vep_custom_annotation.yml#vep_custom_annotation[]
         doc: "custom type, check types directory for input format"
+    cle_variants:
+        type: File?
+        secondaryFiles: [.tbi]
 outputs:
     mutect_unfiltered_vcf:
         type: File
@@ -350,6 +353,7 @@ steps:
                     }
                     return('gnomAD_AF');
                 }
+            cle_variants: cle_variants
         out: 
             [filtered_vcf]
     annotated_filter_bgzip:

--- a/definitions/pipelines/detect_variants_wgs.cwl
+++ b/definitions/pipelines/detect_variants_wgs.cwl
@@ -103,6 +103,9 @@ inputs:
     vep_custom_annotations:
         type: ../types/vep_custom_annotation.yml#vep_custom_annotation[]
         doc: "custom type, check types directory for input format"
+    cle_variants:
+        type: File?
+        secondaryFiles: [.tbi]
 outputs:
     mutect_unfiltered_vcf:
         type: File
@@ -330,6 +333,7 @@ steps:
                     }
                     return('gnomAD_AF');
                 }
+            cle_variants: cle_variants
         out: 
             [filtered_vcf]
     annotated_filter_bgzip:

--- a/definitions/pipelines/detect_variants_wgs.cwl
+++ b/definitions/pipelines/detect_variants_wgs.cwl
@@ -106,6 +106,7 @@ inputs:
     known_variants:
         type: File?
         secondaryFiles: [.tbi]
+        doc: "Previously discovered variants to be flagged in this pipelines's output vcf"
 outputs:
     mutect_unfiltered_vcf:
         type: File

--- a/definitions/pipelines/detect_variants_wgs.cwl
+++ b/definitions/pipelines/detect_variants_wgs.cwl
@@ -103,7 +103,7 @@ inputs:
     vep_custom_annotations:
         type: ../types/vep_custom_annotation.yml#vep_custom_annotation[]
         doc: "custom type, check types directory for input format"
-    cle_variants:
+    known_variants:
         type: File?
         secondaryFiles: [.tbi]
 outputs:
@@ -333,7 +333,7 @@ steps:
                     }
                     return('gnomAD_AF');
                 }
-            cle_variants: cle_variants
+            known_variants: known_variants
         out: 
             [filtered_vcf]
     annotated_filter_bgzip:

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -185,7 +185,7 @@ inputs:
         type: boolean?
     somalier_vcf:
         type: File
-    cle_variants:
+    known_variants:
         type: File?
         secondaryFiles: [.tbi]
 
@@ -688,7 +688,7 @@ steps:
             manta_non_wgs: manta_non_wgs
             manta_output_contigs: manta_output_contigs
             somalier_vcf: somalier_vcf
-            cle_variants: cle_variants
+            known_variants: known_variants
         out:
             [tumor_cram,tumor_mark_duplicates_metrics,tumor_insert_size_metrics,tumor_alignment_summary_metrics,tumor_hs_metrics,tumor_per_target_coverage_metrics,tumor_per_target_hs_metrics,tumor_per_base_coverage_metrics,tumor_per_base_hs_metrics,tumor_summary_hs_metrics,tumor_flagstats,tumor_verify_bam_id_metrics,tumor_verify_bam_id_depth,normal_cram,normal_mark_duplicates_metrics,normal_insert_size_metrics,normal_alignment_summary_metrics,normal_hs_metrics,normal_per_target_coverage_metrics,normal_per_target_hs_metrics,normal_per_base_coverage_metrics,normal_per_base_hs_metrics,normal_summary_hs_metrics,normal_flagstats,normal_verify_bam_id_metrics,normal_verify_bam_id_depth,mutect_unfiltered_vcf,mutect_filtered_vcf,strelka_unfiltered_vcf,strelka_filtered_vcf,varscan_unfiltered_vcf,varscan_filtered_vcf,pindel_unfiltered_vcf,pindel_filtered_vcf,docm_filtered_vcf,final_vcf,final_filtered_vcf,final_tsv,vep_summary,tumor_snv_bam_readcount_tsv,tumor_indel_bam_readcount_tsv,normal_snv_bam_readcount_tsv,normal_indel_bam_readcount_tsv,intervals_antitarget,intervals_target,normal_antitarget_coverage,normal_target_coverage,reference_coverage,cn_diagram,cn_scatter_plot,tumor_antitarget_coverage,tumor_target_coverage,tumor_bin_level_ratios,tumor_segmented_ratios,diploid_variants,somatic_variants,all_candidates,small_candidates,tumor_only_variants,somalier_concordance_metrics,somalier_concordance_statistics]
     germline:

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -188,6 +188,7 @@ inputs:
     known_variants:
         type: File?
         secondaryFiles: [.tbi]
+        doc: "Previously discovered variants to be flagged in this pipelines's output vcf"
 
     #germline inputs
     emit_reference_confidence:

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -185,6 +185,9 @@ inputs:
         type: boolean?
     somalier_vcf:
         type: File
+    cle_variants:
+        type: File?
+        secondaryFiles: [.tbi]
 
     #germline inputs
     emit_reference_confidence:
@@ -685,6 +688,7 @@ steps:
             manta_non_wgs: manta_non_wgs
             manta_output_contigs: manta_output_contigs
             somalier_vcf: somalier_vcf
+            cle_variants: cle_variants
         out:
             [tumor_cram,tumor_mark_duplicates_metrics,tumor_insert_size_metrics,tumor_alignment_summary_metrics,tumor_hs_metrics,tumor_per_target_coverage_metrics,tumor_per_target_hs_metrics,tumor_per_base_coverage_metrics,tumor_per_base_hs_metrics,tumor_summary_hs_metrics,tumor_flagstats,tumor_verify_bam_id_metrics,tumor_verify_bam_id_depth,normal_cram,normal_mark_duplicates_metrics,normal_insert_size_metrics,normal_alignment_summary_metrics,normal_hs_metrics,normal_per_target_coverage_metrics,normal_per_target_hs_metrics,normal_per_base_coverage_metrics,normal_per_base_hs_metrics,normal_summary_hs_metrics,normal_flagstats,normal_verify_bam_id_metrics,normal_verify_bam_id_depth,mutect_unfiltered_vcf,mutect_filtered_vcf,strelka_unfiltered_vcf,strelka_filtered_vcf,varscan_unfiltered_vcf,varscan_filtered_vcf,pindel_unfiltered_vcf,pindel_filtered_vcf,docm_filtered_vcf,final_vcf,final_filtered_vcf,final_tsv,vep_summary,tumor_snv_bam_readcount_tsv,tumor_indel_bam_readcount_tsv,normal_snv_bam_readcount_tsv,normal_indel_bam_readcount_tsv,intervals_antitarget,intervals_target,normal_antitarget_coverage,normal_target_coverage,reference_coverage,cn_diagram,cn_scatter_plot,tumor_antitarget_coverage,tumor_target_coverage,tumor_bin_level_ratios,tumor_segmented_ratios,diploid_variants,somatic_variants,all_candidates,small_candidates,tumor_only_variants,somalier_concordance_metrics,somalier_concordance_statistics]
     germline:

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -146,6 +146,7 @@ inputs:
     known_variants:
         type: File?
         secondaryFiles: [.tbi]
+        doc: "Previously discovered variants to be flagged in this pipelines's output vcf"
 outputs:
     tumor_cram:
         type: File

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -143,6 +143,9 @@ inputs:
         type: boolean?
     somalier_vcf:
         type: File
+    cle_variants:
+        type: File?
+        secondaryFiles: [.tbi]
 outputs:
     tumor_cram:
         type: File
@@ -430,6 +433,7 @@ steps:
             variants_to_table_genotype_fields: variants_to_table_genotype_fields
             vep_to_table_fields: vep_to_table_fields
             vep_custom_annotations: vep_custom_annotations
+            cle_variants: cle_variants
         out:
             [mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv]
     cnvkit:

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -143,7 +143,7 @@ inputs:
         type: boolean?
     somalier_vcf:
         type: File
-    cle_variants:
+    known_variants:
         type: File?
         secondaryFiles: [.tbi]
 outputs:
@@ -433,7 +433,7 @@ steps:
             variants_to_table_genotype_fields: variants_to_table_genotype_fields
             vep_to_table_fields: vep_to_table_fields
             vep_custom_annotations: vep_custom_annotations
-            cle_variants: cle_variants
+            known_variants: known_variants
         out:
             [mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv]
     cnvkit:

--- a/definitions/pipelines/somatic_exome_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_gathered.cwl
@@ -138,7 +138,7 @@ inputs:
         type: string
     somalier_vcf:
         type: File
-    cle_variants:
+    known_variants:
         type: File?
         secondaryFiles: [.tbi]
 outputs:
@@ -196,7 +196,7 @@ steps:
             vep_to_table_fields: vep_to_table_fields
             vep_custom_annotations: vep_custom_annotations
             somalier_vcf: somalier_vcf
-            cle_variants: cle_variants
+            known_variants: known_variants
         out:
             [tumor_cram, tumor_mark_duplicates_metrics, tumor_insert_size_metrics, tumor_alignment_summary_metrics, tumor_hs_metrics, tumor_per_target_coverage_metrics, tumor_per_base_coverage_metrics, tumor_per_base_hs_metrics, tumor_summary_hs_metrics, tumor_flagstats, tumor_verify_bam_id_metrics, tumor_verify_bam_id_depth, normal_cram, normal_mark_duplicates_metrics, normal_insert_size_metrics, normal_alignment_summary_metrics, normal_hs_metrics, normal_per_target_coverage_metrics, normal_per_target_hs_metrics, normal_per_base_coverage_metrics, normal_per_base_hs_metrics, normal_summary_hs_metrics, normal_flagstats, normal_verify_bam_id_metrics, normal_verify_bam_id_depth, mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv, somalier_concordance_metrics, somalier_concordance_statistics]
     gatherer:

--- a/definitions/pipelines/somatic_exome_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_gathered.cwl
@@ -138,6 +138,9 @@ inputs:
         type: string
     somalier_vcf:
         type: File
+    cle_variants:
+        type: File?
+        secondaryFiles: [.tbi]
 outputs:
     final_outputs:
         type: string[]
@@ -193,6 +196,7 @@ steps:
             vep_to_table_fields: vep_to_table_fields
             vep_custom_annotations: vep_custom_annotations
             somalier_vcf: somalier_vcf
+            cle_variants: cle_variants
         out:
             [tumor_cram, tumor_mark_duplicates_metrics, tumor_insert_size_metrics, tumor_alignment_summary_metrics, tumor_hs_metrics, tumor_per_target_coverage_metrics, tumor_per_base_coverage_metrics, tumor_per_base_hs_metrics, tumor_summary_hs_metrics, tumor_flagstats, tumor_verify_bam_id_metrics, tumor_verify_bam_id_depth, normal_cram, normal_mark_duplicates_metrics, normal_insert_size_metrics, normal_alignment_summary_metrics, normal_hs_metrics, normal_per_target_coverage_metrics, normal_per_target_hs_metrics, normal_per_base_coverage_metrics, normal_per_base_hs_metrics, normal_summary_hs_metrics, normal_flagstats, normal_verify_bam_id_metrics, normal_verify_bam_id_depth, mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv, somalier_concordance_metrics, somalier_concordance_statistics]
     gatherer:

--- a/definitions/pipelines/somatic_exome_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_gathered.cwl
@@ -141,6 +141,7 @@ inputs:
     known_variants:
         type: File?
         secondaryFiles: [.tbi]
+        doc: "Previously discovered variants to be flagged in this pipelines's output vcf"
 outputs:
     final_outputs:
         type: string[]

--- a/definitions/pipelines/somatic_wgs.cwl
+++ b/definitions/pipelines/somatic_wgs.cwl
@@ -143,6 +143,9 @@ inputs:
         type: boolean?
     somalier_vcf:
         type: File
+    cle_variants:
+        type: File?
+        secondaryFiles: [.tbi]
 outputs:
 ##tumor alignment and QC
     tumor_cram:
@@ -417,6 +420,7 @@ steps:
             variants_to_table_genotype_fields: variants_to_table_genotype_fields
             vep_to_table_fields: vep_to_table_fields
             vep_custom_annotations: vep_custom_annotations
+            cle_variants: cle_variants
         out:
             [mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv]
     manta: 

--- a/definitions/pipelines/somatic_wgs.cwl
+++ b/definitions/pipelines/somatic_wgs.cwl
@@ -143,7 +143,7 @@ inputs:
         type: boolean?
     somalier_vcf:
         type: File
-    cle_variants:
+    known_variants:
         type: File?
         secondaryFiles: [.tbi]
 outputs:
@@ -420,7 +420,7 @@ steps:
             variants_to_table_genotype_fields: variants_to_table_genotype_fields
             vep_to_table_fields: vep_to_table_fields
             vep_custom_annotations: vep_custom_annotations
-            cle_variants: cle_variants
+            known_variants: known_variants
         out:
             [mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv]
     manta: 

--- a/definitions/pipelines/somatic_wgs.cwl
+++ b/definitions/pipelines/somatic_wgs.cwl
@@ -146,6 +146,7 @@ inputs:
     known_variants:
         type: File?
         secondaryFiles: [.tbi]
+        doc: "Previously discovered variants to be flagged in this pipelines's output vcf"
 outputs:
 ##tumor alignment and QC
     tumor_cram:

--- a/definitions/subworkflows/filter_vcf.cwl
+++ b/definitions/subworkflows/filter_vcf.cwl
@@ -9,6 +9,7 @@ requirements:
 inputs:
     vcf:
         type: File
+        secondaryFiles: [.tbi]
     filter_mapq0_threshold: 
         type: float
     filter_gnomADe_maximum_population_allele_frequency:
@@ -28,15 +29,25 @@ inputs:
         type: int
     sample_names:
         type: string
+    cle_variants:
+        type: File?
+        secondaryFiles: [.tbi]
 outputs: 
     filtered_vcf:
         type: File
         outputSource: set_final_vcf_name/replacement
 steps:
+    filter_cle_variants:
+        run: ../tools/filter_cle_variants.cwl
+        in:
+            cle_variants: cle_variants
+            vcf: vcf
+        out:
+            [cle_flagged]
     filter_vcf_gnomADe_allele_freq:
         run: ../tools/filter_vcf_custom_allele_freq.cwl
         in:
-            vcf: vcf
+            vcf: filter_cle_variants/cle_flagged
             maximum_population_allele_frequency: filter_gnomADe_maximum_population_allele_frequency
             field_name: gnomad_field_name
         out:

--- a/definitions/subworkflows/filter_vcf.cwl
+++ b/definitions/subworkflows/filter_vcf.cwl
@@ -29,7 +29,7 @@ inputs:
         type: int
     sample_names:
         type: string
-    cle_variants:
+    known_variants:
         type: File?
         secondaryFiles: [.tbi]
 outputs: 
@@ -37,17 +37,17 @@ outputs:
         type: File
         outputSource: set_final_vcf_name/replacement
 steps:
-    filter_cle_variants:
-        run: ../tools/filter_cle_variants.cwl
+    filter_known_variants:
+        run: ../tools/filter_known_variants.cwl
         in:
-            cle_variants: cle_variants
+            known_variants: known_variants
             vcf: vcf
         out:
-            [cle_flagged]
+            [known_filtered]
     filter_vcf_gnomADe_allele_freq:
         run: ../tools/filter_vcf_custom_allele_freq.cwl
         in:
-            vcf: filter_cle_variants/cle_flagged
+            vcf: filter_known_variants/known_filtered
             maximum_population_allele_frequency: filter_gnomADe_maximum_population_allele_frequency
             field_name: gnomad_field_name
         out:

--- a/definitions/subworkflows/filter_vcf.cwl
+++ b/definitions/subworkflows/filter_vcf.cwl
@@ -32,6 +32,7 @@ inputs:
     known_variants:
         type: File?
         secondaryFiles: [.tbi]
+        doc: "Previously discovered variants to be flagged in this workflow's output vcf"
 outputs: 
     filtered_vcf:
         type: File

--- a/definitions/tools/filter_cle_variants.cwl
+++ b/definitions/tools/filter_cle_variants.cwl
@@ -1,0 +1,38 @@
+#!/usr/bin/env cwl-runner
+ 
+cwlVersion: v1.0
+class: CommandLineTool
+label: "Adds an INFO tag (CLE) to variants in the target file present in a CLE-validated vcf file"
+
+requirements:
+    - class: ShellCommandRequirement
+    - class: InlineJavascriptRequirement
+    - class: DockerRequirement
+      dockerPull: "mgibio/bcftools-cwl:1.9"
+    - class: ResourceRequirement
+      ramMin: 8000
+
+baseCommand: ["/opt/bcftools/bin/bcftools", "annotate"]
+arguments:
+    [ "-Oz", "-o", "cle_variants_flagged.vcf.gz" ]  
+
+inputs:
+    cle_variants:
+        type: File?
+        secondaryFiles: [.tbi]
+        inputBinding:
+            position: 1
+            valueFrom: |
+                ${
+                    return [ '-a', inputs.cle_variants.path, '-m', 'CLE' ];
+                }
+    vcf:
+        type: File
+        secondaryFiles: [.tbi]
+        inputBinding:
+            position: 2
+outputs:
+    cle_flagged:
+        type: File
+        outputBinding:
+            glob: "cle_variants_flagged.vcf.gz"

--- a/definitions/tools/filter_known_variants.cwl
+++ b/definitions/tools/filter_known_variants.cwl
@@ -2,7 +2,7 @@
  
 cwlVersion: v1.0
 class: CommandLineTool
-label: "Adds an INFO tag (CLE) to variants in the target file present in a CLE-validated vcf file"
+label: "Adds an INFO tag (PREVIOUSLY_DISCOVERED) flagging variants in the target vcf present in a known-variants file"
 
 requirements:
     - class: ShellCommandRequirement
@@ -14,17 +14,17 @@ requirements:
 
 baseCommand: ["/opt/bcftools/bin/bcftools", "annotate"]
 arguments:
-    [ "-Oz", "-o", "cle_variants_flagged.vcf.gz" ]  
+    [ "-Oz", "-o", "known_variants_filtered.vcf.gz" ]  
 
 inputs:
-    cle_variants:
+    known_variants:
         type: File?
         secondaryFiles: [.tbi]
         inputBinding:
             position: 1
             valueFrom: |
                 ${
-                    return [ '-a', inputs.cle_variants.path, '-m', 'CLE' ];
+                    return [ '-a', self.path, '-m', 'PREVIOUSLY_DISCOVERED' ];
                 }
     vcf:
         type: File
@@ -32,7 +32,7 @@ inputs:
         inputBinding:
             position: 2
 outputs:
-    cle_flagged:
+    known_filtered:
         type: File
         outputBinding:
-            glob: "cle_variants_flagged.vcf.gz"
+            glob: "known_variants_filtered.vcf.gz"

--- a/definitions/tools/filter_known_variants.cwl
+++ b/definitions/tools/filter_known_variants.cwl
@@ -26,11 +26,13 @@ inputs:
                 ${
                     return [ '-a', self.path, '-m', 'PREVIOUSLY_DISCOVERED' ];
                 }
+        doc: "A vcf of previously discovered variants to be marked in the second input vcf; if not provided, this tool does nothing but rename the second input vcf"
     vcf:
         type: File
         secondaryFiles: [.tbi]
         inputBinding:
             position: 2
+        doc: "Each variant in this file that is also in the above file (if supplied) will be marked with a PREVIOUSLY_DISCOVERED flag in its INFO field"
 outputs:
     known_filtered:
         type: File


### PR DESCRIPTION
This PR adds a new tool, `filter_cle_variants`. It takes in an input target vcf and a second vcf containing CLE validated variants, and adds a "CLE" tag to the INFO field of variants in the target file that are present in the CLE file. 
This is intended for the immuno workflow, but was added to the `filter_vcf` subworkflow, which is shared by many pipelines. The input vcf is already present in all other calling pipelines, and the CLE vcf is optional. When the CLE vcf is not provided, this step does nothing beyond renaming the input file and adding the line `##FILTER=<ID=PASS,Description="All filters passed">`, so it shouldn't effect the other pipelines. 
Note that the input vcf to this step must have an index file; due to this, I added in a `secondaryFiles` requirement to the `filter_vcf` subworkflow, but since all other pipelines that call this already pass an indexed vcf, this shouldn't change anything.