### PR TITLE
use a docker image tag for rnaseq tools

### DIFF
--- a/definitions/tools/bam_to_fastq.cwl
+++ b/definitions/tools/bam_to_fastq.cwl
@@ -10,7 +10,7 @@ requirements:
       ramMin: 6000
       tmpdirMin: 25000
     - class: DockerRequirement
-      dockerPull: "mgibio/rnaseq"
+      dockerPull: "mgibio/rnaseq:1.0.0"
 arguments: [ {valueFrom: "F=$(runtime.outdir)/read1.fastq"},
              {valueFrom: "F2=$(runtime.outdir)/read2.fastq"} ]
 inputs:

--- a/definitions/tools/generate_qc_metrics.cwl
+++ b/definitions/tools/generate_qc_metrics.cwl
@@ -9,7 +9,7 @@ requirements:
       ramMin: 18000
       coresMin: 1
     - class: DockerRequirement
-      dockerPull: mgibio/rnaseq
+      dockerPull: mgibio/rnaseq:1.0.0
 arguments: [ {valueFrom: "O=$(runtime.outdir)/rna_metrics.txt"},
              {valueFrom: "CHART=$(runtime.outdir)/rna_metrics.pdf"} ]
 inputs:

--- a/definitions/tools/hisat2_align.cwl
+++ b/definitions/tools/hisat2_align.cwl
@@ -10,7 +10,7 @@ requirements:
       ramMin: 16000
       coresMin: 16
     - class: DockerRequirement
-      dockerPull: "mgibio/rnaseq"
+      dockerPull: "mgibio/rnaseq:1.0.0"
 arguments: [
     "-p", $(runtime.cores),
     "--dta",

--- a/definitions/tools/kallisto.cwl
+++ b/definitions/tools/kallisto.cwl
@@ -9,7 +9,7 @@ requirements:
       ramMin: 32000
       coresMin: 8
     - class: DockerRequirement
-      dockerPull: "mgibio/rnaseq"
+      dockerPull: "mgibio/rnaseq:1.0.0"
 arguments: [
     "quant",
     "-t", $(runtime.cores),

--- a/definitions/tools/stringtie.cwl
+++ b/definitions/tools/stringtie.cwl
@@ -9,7 +9,7 @@ requirements:
       ramMin: 16000
       coresMin: 12
     - class: DockerRequirement
-      dockerPull: "mgibio/rnaseq"
+      dockerPull: "mgibio/rnaseq:1.0.0"
 arguments: [
     "-o", "$(runtime.outdir)/stringtie_transcripts.gtf",
     "-A", "$(runtime.outdir)/stringtie_gene_expression.tsv",

--- a/definitions/tools/transcript_to_gene.cwl
+++ b/definitions/tools/transcript_to_gene.cwl
@@ -12,7 +12,7 @@ requirements:
       ramMin: 2000
       coresMin: 1
     - class: DockerRequirement
-      dockerPull: "mgibio/rnaseq"
+      dockerPull: "mgibio/rnaseq:1.0.0"
 inputs:
     gene_transcript_lookup_table:
         type: File


### PR DESCRIPTION
removes the latest image tags for the cwl tools. future images and PRs should be made to use smaller images instead of the large rnaseq one. 

WIP until the docker image creation succeeds on docker hub