### PR TITLE
Fixing warnings: subworkflow directory low-hanging fruit edition

### DIFF
--- a/definitions/subworkflows/align_sort_markdup.cwl
+++ b/definitions/subworkflows/align_sort_markdup.cwl
@@ -19,7 +19,7 @@ inputs:
             - File
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     final_name:
-        type: string?
+        type: string
         default: 'final.bam'
 outputs:
     final_bam:

--- a/definitions/subworkflows/bam_to_bqsr.cwl
+++ b/definitions/subworkflows/bam_to_bqsr.cwl
@@ -21,7 +21,7 @@ inputs:
         type: File
         secondaryFiles: [.tbi]
     final_name:
-        type: string?
+        type: string
         default: 'final.bam'
     mills:
         type: File

--- a/definitions/subworkflows/bisulfite_qc.cwl
+++ b/definitions/subworkflows/bisulfite_qc.cwl
@@ -16,7 +16,7 @@ inputs:
       QCannotation:
            type: File
       output_dir:
-           type: string?
+           type: string
            default: bisulfite_QC
 
 outputs:

--- a/definitions/subworkflows/cnvkit_single_sample.cwl
+++ b/definitions/subworkflows/cnvkit_single_sample.cwl
@@ -23,7 +23,7 @@ inputs:
     reference_cnn:
         type: File
     cnvkit_vcf_name:
-        type: string?
+        type: string
         default: "cnvkit.vcf"
     segment_filter:
         type:

--- a/definitions/subworkflows/cram_to_cnvkit.cwl
+++ b/definitions/subworkflows/cram_to_cnvkit.cwl
@@ -6,8 +6,10 @@ label: "Subworkflow to allow calling cnvkit with cram instead of bam files"
 inputs:
     normal_cram:
         type: File
+        secondaryFiles: [^.crai]
     tumor_cram:
         type: File
+        secondaryFiles: [^.crai]
     reference:
         type: string
     bait_intervals:

--- a/definitions/subworkflows/fastq_to_bqsr.cwl
+++ b/definitions/subworkflows/fastq_to_bqsr.cwl
@@ -23,7 +23,7 @@ inputs:
         type: File
         secondaryFiles: [.tbi]
     final_name:
-        type: string?
+        type: string
         default: 'final.bam'
     mills:
         type: File

--- a/definitions/subworkflows/germline_detect_variants.cwl
+++ b/definitions/subworkflows/germline_detect_variants.cwl
@@ -40,7 +40,7 @@ inputs:
         type: string
         doc: "ensembl species - Must be present in the cache directory. Examples: homo_sapiens or mus_musculus"
     vep_plugins:
-        type: string[]?
+        type: string[]
         default: [Downstream, Wildtype]
     synonyms_file:
         type: File?
@@ -62,7 +62,7 @@ inputs:
         type: string?
         default: 'variants'
     filter_gnomAD_maximum_population_allele_frequency:
-        type: float?
+        type: float
         default: 0.05
 outputs:
     gvcf:

--- a/definitions/subworkflows/germline_detect_variants.cwl
+++ b/definitions/subworkflows/germline_detect_variants.cwl
@@ -16,6 +16,7 @@ inputs:
         secondaryFiles: [.fai, ^.dict, .index]
     bam:
         type: File
+        secondaryFiles: [^.bai]
     emit_reference_confidence:
         type: string
     gvcf_gq_bands:

--- a/definitions/subworkflows/germline_filter_vcf.cwl
+++ b/definitions/subworkflows/germline_filter_vcf.cwl
@@ -23,9 +23,11 @@ inputs:
 outputs: 
     filtered_vcf:
         type: File
+        secondaryFiles: [.tbi]
         outputSource: index_filtered_vcf/indexed_vcf
     final_vcf:
         type: File
+        secondaryFiles: [.tbi]
         outputSource: limit_variants/filtered_vcf
 steps:
     coding_variant_filter:

--- a/definitions/subworkflows/mutect.cwl
+++ b/definitions/subworkflows/mutect.cwl
@@ -16,7 +16,7 @@ inputs:
         secondaryFiles: [.fai, ^.dict]
     tumor_bam:
         type: File
-        secondaryFiles: [^.bai]
+        secondaryFiles: [^.bai, .bai]
     normal_bam:
         type: File?
         secondaryFiles: [^.bai]

--- a/definitions/subworkflows/phase_vcf.cwl
+++ b/definitions/subworkflows/phase_vcf.cwl
@@ -10,6 +10,7 @@ requirements:
 inputs:
     somatic_vcf:
         type: File
+        secondaryFiles: [.tbi]
     germline_vcf:
         type: File
     reference:

--- a/definitions/subworkflows/pindel.cwl
+++ b/definitions/subworkflows/pindel.cwl
@@ -16,7 +16,7 @@ inputs:
         secondaryFiles: [.fai, ^.dict]
     tumor_bam:
         type: File
-        secondaryFiles: [^.bai]
+        secondaryFiles: [.bai, ^.bai]
     normal_bam:
         type: File
         secondaryFiles: [^.bai]

--- a/definitions/subworkflows/qc_exome.cwl
+++ b/definitions/subworkflows/qc_exome.cwl
@@ -26,7 +26,7 @@ inputs:
         type: File
         secondaryFiles: [.tbi]
     picard_metric_accumulation_level:
-        type: string?
+        type: string
         default: ALL_READS
     minimum_mapping_quality:
         type: int?

--- a/definitions/subworkflows/qc_exome_no_verify_bam.cwl
+++ b/definitions/subworkflows/qc_exome_no_verify_bam.cwl
@@ -22,7 +22,7 @@ inputs:
     target_intervals:
         type: File
     picard_metric_accumulation_level:
-        type: string?
+        type: string
         default: ALL_READS
     minimum_mapping_quality:
         type: int?

--- a/definitions/subworkflows/qc_wgs.cwl
+++ b/definitions/subworkflows/qc_wgs.cwl
@@ -26,7 +26,7 @@ inputs:
         type: File
         secondaryFiles: [.tbi]
     picard_metric_accumulation_level:
-        type: string?
+        type: string
         default: ALL_READS
     minimum_mapping_quality:
         type: int?

--- a/definitions/subworkflows/qc_wgs_mouse.cwl
+++ b/definitions/subworkflows/qc_wgs_mouse.cwl
@@ -18,7 +18,7 @@ inputs:
             - File
         secondaryFiles: [.fai, ^.dict]
     picard_metric_accumulation_level:
-        type: string?
+        type: string
         default: ALL_READS
     minimum_mapping_quality:
         type: int?

--- a/definitions/subworkflows/sequence_to_bqsr.cwl
+++ b/definitions/subworkflows/sequence_to_bqsr.cwl
@@ -25,7 +25,7 @@ inputs:
         type: File
         secondaryFiles: [.tbi]
     final_name:
-        type: string?
+        type: string
         default: 'final'
     mills:
         type: File

--- a/definitions/subworkflows/sequence_to_bqsr_mouse.cwl
+++ b/definitions/subworkflows/sequence_to_bqsr_mouse.cwl
@@ -20,7 +20,7 @@ inputs:
             - File
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     final_name:
-        type: string?
+        type: string
         default: 'final.bam'
 outputs:
     final_bam:

--- a/definitions/subworkflows/varscan_pre_and_post_processing.cwl
+++ b/definitions/subworkflows/varscan_pre_and_post_processing.cwl
@@ -15,7 +15,7 @@ inputs:
         secondaryFiles: [.fai, ^.dict]
     tumor_bam:
         type: File
-        secondaryFiles: [^.bai]
+        secondaryFiles: [^.bai, .bai]
     normal_bam:
         type: File
         secondaryFiles: [^.bai]

--- a/definitions/tools/clip_overlap.cwl
+++ b/definitions/tools/clip_overlap.cwl
@@ -28,5 +28,6 @@ inputs:
 outputs:
     clipped_bam:
         type: File
+        secondaryFiles: [^.bai]
         outputBinding:
             glob: "clipped.bam"


### PR DESCRIPTION
This fixes some validator warnings in our subworkflows that result from one of a few circumstances:
* an optional input with default is mapped to a required input:
  this is made required to eliminate the ability to pass `null` overriding the default
* some missing `secondaryFile` declarations have been added.