### PR TITLE
Remove outdated secondaryFile

### DIFF
--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -13,7 +13,7 @@ inputs:
         type:
             - string
             - File
-        secondaryFiles: [.fai, ^.dict, .index]
+        secondaryFiles: [.fai, ^.dict]
     tumor_bam:
         type: File
         secondaryFiles: [.bai,^.bai]

--- a/definitions/pipelines/detect_variants_mouse.cwl
+++ b/definitions/pipelines/detect_variants_mouse.cwl
@@ -10,7 +10,7 @@ inputs:
         type:
             - string
             - File
-        secondaryFiles: [.fai, ^.dict, .index]
+        secondaryFiles: [.fai, ^.dict]
     tumor_bam:
         type: File
         secondaryFiles: [.bai,^.bai]

--- a/definitions/pipelines/germline_exome.cwl
+++ b/definitions/pipelines/germline_exome.cwl
@@ -15,7 +15,7 @@ inputs:
         type:
             - string
             - File
-        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa, .index]
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
     mills:

--- a/definitions/pipelines/germline_exome_hla_typing.cwl
+++ b/definitions/pipelines/germline_exome_hla_typing.cwl
@@ -15,7 +15,7 @@ inputs:
         type:
             - string
             - File
-        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa, .index]
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
     mills:

--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -15,7 +15,7 @@ inputs:
         type:
             - string
             - File
-        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa, .index]
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
     mills:

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -58,7 +58,7 @@ inputs:
         type:
             - string
             - File
-        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa, .index]
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
 
     tumor_sequence:
         type: ../types/sequence_data.yml#sequence_data[]

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -25,7 +25,7 @@ inputs:
         type:
             - string
             - File
-        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa, .index]
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
         label: "reference: Reference fasta file for a desired assembly"
         doc: |
           reference contains the nucleotide sequence for a given assembly (hg37, hg38, etc.)

--- a/definitions/pipelines/somatic_exome_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_gathered.cwl
@@ -16,7 +16,7 @@ inputs:
         type:
             - string
             - File
-        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa, .index]
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     tumor_sequence:
         type: ../types/sequence_data.yml#sequence_data[]
     tumor_cram_name:

--- a/definitions/pipelines/somatic_exome_mouse.cwl
+++ b/definitions/pipelines/somatic_exome_mouse.cwl
@@ -14,7 +14,7 @@ inputs:
         type:
             - string
             - File
-        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa, .index]
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     tumor_bams:
         type: File[]
     tumor_readgroups:

--- a/definitions/pipelines/tumor_only_detect_variants.cwl
+++ b/definitions/pipelines/tumor_only_detect_variants.cwl
@@ -15,7 +15,7 @@ inputs:
         type:
             - string
             - File
-        secondaryFiles: [.fai, ^.dict, .index]
+        secondaryFiles: [.fai, ^.dict]
     bam:
         type: File
         secondaryFiles: [^.bai,.bai]

--- a/definitions/pipelines/tumor_only_exome.cwl
+++ b/definitions/pipelines/tumor_only_exome.cwl
@@ -15,7 +15,7 @@ inputs:
         type:
             - string
             - File
-        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa, .index]
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
     mills:

--- a/definitions/pipelines/tumor_only_wgs.cwl
+++ b/definitions/pipelines/tumor_only_wgs.cwl
@@ -15,7 +15,7 @@ inputs:
         type:
             - string
             - File
-        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa, .index]
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
     mills:

--- a/definitions/subworkflows/germline_detect_variants.cwl
+++ b/definitions/subworkflows/germline_detect_variants.cwl
@@ -13,7 +13,7 @@ inputs:
         type:
             - string
             - File
-        secondaryFiles: [.fai, ^.dict, .index]
+        secondaryFiles: [.fai, ^.dict]
     bam:
         type: File
         secondaryFiles: [^.bai]

--- a/definitions/subworkflows/single_sample_sv_callers.cwl
+++ b/definitions/subworkflows/single_sample_sv_callers.cwl
@@ -17,7 +17,7 @@ inputs:
         type:
             - string
             - File
-        secondaryFiles: [.fai, ^.dict, .index]
+        secondaryFiles: [.fai, ^.dict]
 
     cnvkit_diagram:
         type: boolean?

--- a/definitions/tools/vep.cwl
+++ b/definitions/tools/vep.cwl
@@ -83,7 +83,7 @@ inputs:
             - "null"
             - string
             - File
-        secondaryFiles: [.fai, ^.dict, .index]
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "--fasta" 
             position: 7


### PR DESCRIPTION
Following discussion in #774 and some testing, it was determined that the vep configuration used in our pipeline does not use a `.index` file; it has the `faidx` module and so is able to generate/use a `.fai` file. Even if our pipeline is modified to use a different vep docker image or a local install that is configured to require this file, vep will generate it on the fly if not present. Additionally, our workflow runner (Cromwell) does not support optional `secondaryFiles`, so this requirement will be removed completely. This also closes #830, since there is no need to provide an example file.