### PR TITLE
Added missing requirements to improve cwl portability

### DIFF
--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -9,6 +9,7 @@ requirements:
       types:
           - $import: ../types/vep_custom_annotation.yml
     - class: StepInputExpressionRequirement
+    - class: InlineJavascriptRequirement
 inputs:
     reference:
         type:

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -8,6 +8,7 @@ requirements:
     - class: SchemaDefRequirement
       types:
           - $import: ../types/vep_custom_annotation.yml
+    - class: StepInputExpressionRequirement
 inputs:
     reference:
         type:

--- a/definitions/pipelines/detect_variants_wgs.cwl
+++ b/definitions/pipelines/detect_variants_wgs.cwl
@@ -8,6 +8,7 @@ requirements:
     - class: SchemaDefRequirement
       types:
           - $import: ../types/vep_custom_annotation.yml
+    - class: StepInputExpressionRequirement
 inputs:
     reference:
         type: string

--- a/definitions/pipelines/detect_variants_wgs.cwl
+++ b/definitions/pipelines/detect_variants_wgs.cwl
@@ -9,6 +9,7 @@ requirements:
       types:
           - $import: ../types/vep_custom_annotation.yml
     - class: StepInputExpressionRequirement
+    - class: InlineJavascriptRequirement
 inputs:
     reference:
         type: string

--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -10,6 +10,7 @@ requirements:
           - $import: ../types/sequence_data.yml
           - $import: ../types/vep_custom_annotation.yml
     - class: SubworkflowFeatureRequirement
+    - class: StepInputExpressionRequirement
 inputs:
     reference:
         type:

--- a/definitions/subworkflows/bam_to_trimmed_fastq_and_hisat_alignments.cwl
+++ b/definitions/subworkflows/bam_to_trimmed_fastq_and_hisat_alignments.cwl
@@ -7,6 +7,7 @@ requirements:
     - class: MultipleInputFeatureRequirement
     - class: SubworkflowFeatureRequirement
     - class: InlineJavascriptRequirement
+    - class: StepInputExpressionRequirement
 inputs:
     bam:
         type: File

--- a/definitions/subworkflows/fp_filter.cwl
+++ b/definitions/subworkflows/fp_filter.cwl
@@ -5,6 +5,7 @@ class: Workflow
 label: "fp_filter workflow"
 requirements:
     - class: SubworkflowFeatureRequirement
+    - class: StepInputExpressionRequirement
 inputs:
     bam:
         type: File

--- a/definitions/subworkflows/gatk_haplotypecaller_iterator.cwl
+++ b/definitions/subworkflows/gatk_haplotypecaller_iterator.cwl
@@ -6,6 +6,7 @@ label: "scatter GATK HaplotypeCaller over intervals"
 requirements:
     - class: InlineJavascriptRequirement
     - class: ScatterFeatureRequirement
+    - class: StepInputExpressionRequirement
 inputs:
     reference:
         type:

--- a/definitions/subworkflows/germline_detect_variants.cwl
+++ b/definitions/subworkflows/germline_detect_variants.cwl
@@ -8,6 +8,8 @@ requirements:
     - class: SchemaDefRequirement
       types:
           - $import: ../types/vep_custom_annotation.yml
+    - class: StepInputExpressionRequirement
+    - class: InlineJavascriptRequirement
 inputs:
     reference:
         type:

--- a/definitions/subworkflows/qc_exome_no_verify_bam.cwl
+++ b/definitions/subworkflows/qc_exome_no_verify_bam.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
     - class: SubworkflowFeatureRequirement
+    - class: StepInputExpressionRequirement
 inputs:
     bam:
         type: File

--- a/definitions/tools/add_string_at_line.cwl
+++ b/definitions/tools/add_string_at_line.cwl
@@ -9,6 +9,7 @@ requirements:
       dockerPull: 'ubuntu:xenial'
     - class: ResourceRequirement
       ramMin: 4000
+    - class: StepInputExpressionRequirement
 arguments:
     [ "-v", { valueFrom: n=$(inputs.line_number) }, "-v", { valueFrom: s=$(inputs.some_text) }, 'NR == n {print s} {print}']
 inputs:

--- a/definitions/tools/add_string_at_line_bgzipped.cwl
+++ b/definitions/tools/add_string_at_line_bgzipped.cwl
@@ -10,6 +10,7 @@ requirements:
       dockerPull: "mgibio/samtools-cwl:1.0.0"
     - class: ResourceRequirement
       ramMin: 4000
+    - class: StepInputExpressionRequirement
 arguments:
     [ { valueFrom: $(inputs.input_file.path) } , { shellQuote: false, valueFrom: "|" },
       "awk", "-v", { valueFrom: n=$(inputs.line_number) }, "-v", { valueFrom: s=$(inputs.some_text) }, 'NR == n {print s} {print}', { shellQuote: false, valueFrom: "|" },

--- a/definitions/tools/collect_hs_metrics.cwl
+++ b/definitions/tools/collect_hs_metrics.cwl
@@ -12,6 +12,7 @@ requirements:
     - class: InlineJavascriptRequirement
     - class: DockerRequirement
       dockerPull: "mgibio/picard-cwl:2.18.1"
+    - class: StepInputExpressionRequirement
 inputs:
     bam:
         type: File

--- a/definitions/tools/filter_known_variants.cwl
+++ b/definitions/tools/filter_known_variants.cwl
@@ -11,6 +11,7 @@ requirements:
       dockerPull: "mgibio/bcftools-cwl:1.9"
     - class: ResourceRequirement
       ramMin: 8000
+    - class: StepInputExpressionRequirement
 
 baseCommand: ["/opt/bcftools/bin/bcftools", "annotate"]
 arguments:

--- a/definitions/tools/filter_vcf_custom_allele_freq.cwl
+++ b/definitions/tools/filter_vcf_custom_allele_freq.cwl
@@ -10,6 +10,8 @@ requirements:
       dockerPull: "mgibio/vep_helper-cwl:1.0.0"
     - class: ResourceRequirement
       ramMin: 4000
+    - class: StepInputExpressionRequirement
+
 arguments:
     [{ valueFrom: $(inputs.vcf.path) },
     { valueFrom: $(runtime.outdir)/annotated.af_filtered.vcf },

--- a/definitions/tools/filter_vcf_docm.cwl
+++ b/definitions/tools/filter_vcf_docm.cwl
@@ -9,6 +9,7 @@ requirements:
       dockerPull: "mgibio/cle:v1.4.2"
     - class: ResourceRequirement
       ramMin: 4000
+    - class: StepInputExpressionRequirement
     - class: InitialWorkDirRequirement
       listing:
       - entryname: 'docm_filter.pl'

--- a/definitions/tools/filter_vcf_exac.cwl
+++ b/definitions/tools/filter_vcf_exac.cwl
@@ -10,6 +10,7 @@ requirements:
       dockerPull: mgibio/cle:v1.3.1
     - class: ResourceRequirement
       ramMin: 4000
+    - class: StepInputExpressionRequirement
 arguments:
     [{ valueFrom: $(inputs.vcf.path) },
     { valueFrom: $(runtime.outdir)/annotated.exac_filtered.vcf },

--- a/definitions/tools/generate_qc_metrics.cwl
+++ b/definitions/tools/generate_qc_metrics.cwl
@@ -10,6 +10,7 @@ requirements:
       coresMin: 1
     - class: DockerRequirement
       dockerPull: mgibio/rnaseq
+    - class: StepInputExpressionRequirement
 arguments: [ {valueFrom: "O=$(runtime.outdir)/rna_metrics.txt"},
              {valueFrom: "CHART=$(runtime.outdir)/rna_metrics.pdf"} ]
 inputs:

--- a/definitions/tools/hisat2_align.cwl
+++ b/definitions/tools/hisat2_align.cwl
@@ -11,6 +11,7 @@ requirements:
       coresMin: 16
     - class: DockerRequirement
       dockerPull: "mgibio/rnaseq"
+    - class: StepInputExpressionRequirement
 arguments: [
     "-p", $(runtime.cores),
     "--dta",

--- a/definitions/tools/index_vcf.cwl
+++ b/definitions/tools/index_vcf.cwl
@@ -14,6 +14,7 @@ requirements:
       dockerPull: "mgibio/samtools-cwl:1.0.0"
     - class: ResourceRequirement
       ramMin: 4000
+    - class: StepInputExpressionRequirement
 inputs:
     vcf:
         type: File

--- a/definitions/tools/kallisto.cwl
+++ b/definitions/tools/kallisto.cwl
@@ -10,6 +10,7 @@ requirements:
       coresMin: 8
     - class: DockerRequirement
       dockerPull: "mgibio/rnaseq"
+    - class: StepInputExpressionRequirement
 arguments: [
     "quant",
     "-t", $(runtime.cores),

--- a/definitions/tools/stringtie.cwl
+++ b/definitions/tools/stringtie.cwl
@@ -10,6 +10,7 @@ requirements:
       coresMin: 12
     - class: DockerRequirement
       dockerPull: "mgibio/rnaseq"
+    - class: StepInputExpressionRequirement
 arguments: [
     "-o", "$(runtime.outdir)/stringtie_transcripts.gtf",
     "-A", "$(runtime.outdir)/stringtie_gene_expression.tsv",

--- a/definitions/tools/survivor.cwl
+++ b/definitions/tools/survivor.cwl
@@ -13,6 +13,7 @@ requirements:
     - class: ResourceRequirement
       ramMin: 2000
       coresMin: 1
+    - class: StepInputExpressionRequirement
 
 inputs:
     vcfs:

--- a/definitions/tools/varscan_process_somatic.cwl
+++ b/definitions/tools/varscan_process_somatic.cwl
@@ -14,6 +14,7 @@ requirements:
       dockerPull: "mgibio/cle:v1.3.1"
     - class: ResourceRequirement
       ramMin: 4000
+    - class: StepInputExpressionRequirement
 inputs:
     variants:
         type: File


### PR DESCRIPTION
According to the [CWL specification](https://www.commonwl.org/v1.0/Workflow.html#StepInputExpressionRequirement), `StepInputExpressionRequirement` must be defined in order to use the `valueFrom` field in inputs. Cromwell isn't very strict about some CWL requirements, including this one, but other runners are, as noted in #831. I've updated all instances of the missing requirement I could find.