### PR TITLE
Address some compatibility issues with cnvnator.cwl

### DIFF
--- a/definitions/tools/cnvnator.cwl
+++ b/definitions/tools/cnvnator.cwl
@@ -35,7 +35,7 @@ requirements:
           # while with later versions of CNVnator these steps will accept a fasta.gz file the cnvnator2VCF.pl will not
           mkdir FASTA_CHRS
           awk 'BEGIN { CHROM="" } { if ($1~"^>") CHROM=substr($1,2); print $0 > "FASTA_CHRS/"CHROM".fa" }' "$REFERENCE"
-                    
+
           # extract read mapping from input bam(single sample)
           cnvnator -root "${SAMPLE}.root" -tree "$BAM" -chrom $CHROMOSOMES
           # generate read depth histogram

--- a/definitions/tools/cnvnator.cwl
+++ b/definitions/tools/cnvnator.cwl
@@ -37,18 +37,18 @@ requirements:
           awk 'BEGIN { CHROM="" } { if ($1~"^>") CHROM=substr($1,2); print $0 > "FASTA_CHRS/"CHROM".fa" }' "$REFERENCE"
 
           # extract read mapping from input bam(single sample)
-          cnvnator -root "${SAMPLE}.root" -tree "$BAM" -chrom $CHROMOSOMES
+          cnvnator -root "$SAMPLE.root" -tree "$BAM" -chrom $CHROMOSOMES
           # generate read depth histogram
-          cnvnator -root "${SAMPLE}.root" -his "${BIN_SIZE}" -d FASTA_CHRS/ -chrom $CHROMOSOMES
+          cnvnator -root "$SAMPLE.root" -his "$BIN_SIZE" -d FASTA_CHRS/ -chrom $CHROMOSOMES
           # calculate statistics
-          cnvnator -root "${SAMPLE}.root" -stat "${BIN_SIZE}" -chrom $CHROMOSOMES
+          cnvnator -root "$SAMPLE.root" -stat "$BIN_SIZE" -chrom $CHROMOSOMES
           # read depth signal partitioning
-          cnvnator -root "${SAMPLE}.root" -partition "${BIN_SIZE}" -chrom $CHROMOSOMES
+          cnvnator -root "$SAMPLE.root" -partition "$BIN_SIZE" -chrom $CHROMOSOMES
           # cnv calling
-          cnvnator -root "${SAMPLE}.root" -call "${BIN_SIZE}" -chrom $CHROMOSOMES > "${SAMPLE}.CNVnator.cn"
+          cnvnator -root "$SAMPLE.root" -call "$BIN_SIZE" -chrom $CHROMOSOMES > "$SAMPLE.CNVnator.cn"
 
           # convert to vcf
-          cnvnator2VCF.pl -reference "$REFERENCE" "${SAMPLE}.CNVnator.cn" FASTA_CHRS/ >  "${SAMPLE}.CNVnator.vcf"
+          cnvnator2VCF.pl -reference "$REFERENCE" "$SAMPLE.CNVnator.cn" FASTA_CHRS/ >  "$SAMPLE.CNVnator.vcf"
           exit 0
 inputs:
     bam:

--- a/definitions/tools/cnvnator.cwl
+++ b/definitions/tools/cnvnator.cwl
@@ -4,7 +4,7 @@ cwlVersion: v1.0
 class: CommandLineTool
 label: "Run CNVnator to calculate copy number variations in WGS samples"
 
-arguments: ["source", "/opt/root/bin/thisroot.sh", { shellQuote: false, valueFrom: "&&" },  "/bin/bash", "run_cnvnator.sh"]
+baseCommand: ["/bin/bash", "run_cnvnator.sh"]
 
 requirements:
     - class: DockerRequirement
@@ -13,12 +13,15 @@ requirements:
       ramMin: 20000
       coresMin: 1
       tmpdirMin: 10000
-    - class: ShellCommandRequirement
     - class: InitialWorkDirRequirement
       listing:
       - entryname: "run_cnvnator.sh"
         entry: |
           #!/bin/bash
+
+          #set up the environment
+          source /opt/root/bin/thisroot.sh
+
           set -eou pipefail
 
           # set vars


### PR DESCRIPTION
This makes some changes to address issues #838 and #839. Specifically:

* avoids the `${}` syntax
* pulls `thisroot.sh` into the inline bash script so we're assured to be running under `/bin/bash`

I ran this with a tiny test.  it completed, but I'd feel better using a test case that produces meaningful results.