### PR TITLE
Reduce pipeline warnings

### DIFF
--- a/definitions/pipelines/alignment_wgs_mouse.cwl
+++ b/definitions/pipelines/alignment_wgs_mouse.cwl
@@ -21,13 +21,13 @@ inputs:
     final_name:
         type: string?
     per_base_intervals:
-        type: ../types/labelled_file.yml#labelled_file[]?
+        type: ../types/labelled_file.yml#labelled_file[]
         default: []
     per_target_intervals:
-        type: ../types/labelled_file.yml#labelled_file[]?
+        type: ../types/labelled_file.yml#labelled_file[]
         default: []
     summary_intervals:
-        type: ../types/labelled_file.yml#labelled_file[]?
+        type: ../types/labelled_file.yml#labelled_file[]
         default: []
     picard_metric_accumulation_level:
         type: string

--- a/definitions/pipelines/chipseq.cwl
+++ b/definitions/pipelines/chipseq.cwl
@@ -35,13 +35,13 @@ inputs:
     intervals:
         type: File
     per_base_intervals:
-        type: ../types/labelled_file.yml#labelled_file[]?
+        type: ../types/labelled_file.yml#labelled_file[]
         default: []
     per_target_intervals:
-        type: ../types/labelled_file.yml#labelled_file[]?
+        type: ../types/labelled_file.yml#labelled_file[]
         default: []
     summary_intervals:
-        type: ../types/labelled_file.yml#labelled_file[]?
+        type: ../types/labelled_file.yml#labelled_file[]
         default: []
     picard_metric_accumulation_level:
         type: string

--- a/definitions/pipelines/chipseq_alignment_mouse.cwl
+++ b/definitions/pipelines/chipseq_alignment_mouse.cwl
@@ -21,13 +21,13 @@ inputs:
     chipseq_sequence:
         type: ../types/sequence_data.yml#sequence_data[]
     per_base_intervals:
-        type: ../types/labelled_file.yml#labelled_file[]?
+        type: ../types/labelled_file.yml#labelled_file[]
         default: []
     per_target_intervals:
-        type: ../types/labelled_file.yml#labelled_file[]?
+        type: ../types/labelled_file.yml#labelled_file[]
         default: []
     summary_intervals:
-        type: ../types/labelled_file.yml#labelled_file[]?
+        type: ../types/labelled_file.yml#labelled_file[]
         default: []
     picard_metric_accumulation_level:
         type: string

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -32,7 +32,7 @@ inputs:
     readcount_minimum_mapping_quality:
         type: int?
     mutect_scatter_count:
-        type: int?
+        type: int
         default: 50
     varscan_strand_filter:
         type: int?
@@ -55,7 +55,7 @@ inputs:
         type: File
         secondaryFiles: [.tbi]
     filter_docm_variants:
-        type: boolean?
+        type: boolean
         default: true
     vep_cache_dir:
         type: string
@@ -78,31 +78,31 @@ inputs:
             - type: enum
               symbols: ["pick", "flag_pick", "pick_allele", "per_gene", "pick_allele_gene", "flag_pick_allele", "flag_pick_allele_gene"]
     vep_plugins:
-        type: string[]?
+        type: string[]
         default: [Downstream, Wildtype]
     filter_gnomADe_maximum_population_allele_frequency:
-        type: float?
+        type: float
         default: 0.001
     filter_mapq0_threshold:
-        type: float?
+        type: float
         default: 0.15
     filter_minimum_depth:
-        type: int?
+        type: int
         default: 1
     cle_vcf_filter:
-        type: boolean?
+        type: boolean
         default: false
     filter_somatic_llr_threshold:
-        type: float?
+        type: float
         default: 5
     variants_to_table_fields:
-        type: string[]?
+        type: string[]
         default: [CHROM,POS,ID,REF,ALT,set,AC,AF]
     variants_to_table_genotype_fields:
-        type: string[]?
+        type: string[]
         default: [GT,AD]
     vep_to_table_fields:
-        type: string[]?
+        type: string[]
         default: [HGVSc,HGVSp]
     tumor_sample_name:
         type: string

--- a/definitions/pipelines/detect_variants_mouse.cwl
+++ b/definitions/pipelines/detect_variants_mouse.cwl
@@ -29,7 +29,7 @@ inputs:
     readcount_minimum_mapping_quality:
         type: int?
     mutect_scatter_count:
-        type: int?
+        type: int
     varscan_strand_filter:
         type: int?
         default: 0

--- a/definitions/pipelines/detect_variants_mouse.cwl
+++ b/definitions/pipelines/detect_variants_mouse.cwl
@@ -68,28 +68,28 @@ inputs:
             - type: enum
               symbols: ["pick", "flag_pick", "pick_allele", "per_gene", "pick_allele_gene", "flag_pick_allele", "flag_pick_allele_gene"]
     vep_plugins:
-        type: string[]?
+        type: string[]
         default: [Downstream, Wildtype]
     filter_mapq0_threshold:
-        type: float?
+        type: float
         default: 0.15
     filter_minimum_depth:
-        type: int?
+        type: int
         default: 1
     cle_vcf_filter:
-        type: boolean?
+        type: boolean
         default: false
     filter_somatic_llr_threshold:
-        type: float?
+        type: float
         default: 5
     variants_to_table_fields:
-        type: string[]?
+        type: string[]
         default: [CHROM,POS,ID,REF,ALT,set,AC,AF]
     variants_to_table_genotype_fields:
-        type: string[]?
+        type: string[]
         default: [GT,AD]
     vep_to_table_fields:
-        type: string[]?
+        type: string[]
         default: []
     tumor_sample_name:
         type: string

--- a/definitions/pipelines/tumor_only_detect_variants.cwl
+++ b/definitions/pipelines/tumor_only_detect_variants.cwl
@@ -53,7 +53,7 @@ inputs:
     synonyms_file:
         type: File?
     annotate_coding_only:
-        type: boolean?
+        type: boolean
         default: true
     vep_pick:
         type:
@@ -61,16 +61,16 @@ inputs:
             - type: enum
               symbols: ["pick", "flag_pick", "pick_allele", "per_gene", "pick_allele_gene", "flag_pick_allele", "flag_pick_allele_gene"]
     variants_to_table_fields:
-        type: string[]?
+        type: string[]
         default: [CHROM,POS,REF,ALT,set]
     variants_to_table_genotype_fields:
-        type: string[]?
+        type: string[]
         default: [GT,AD,AF,DP]
     vep_to_table_fields:
-        type: string[]?
+        type: string[]
         default: [Consequence,SYMBOL,Feature_type,Feature,HGVSc,HGVSp,cDNA_position,CDS_position,Protein_position,Amino_acids,Codons,HGNC_ID,Existing_variation,gnomADe_AF,CLIN_SIG,SOMATIC,PHENO]
     vep_plugins:
-        type: string[]?
+        type: string[]
         default: [Downstream, Wildtype]
     sample_name:
         type: string


### PR DESCRIPTION
This mostly makes optional inputs with defaults into required inputs with defaults.  This should have no practical effect except to make `cwltool --validate` stop warning as much.

For good measure, this PR also includes one change where an optional input really should've been required--see, attacking warnings is worthwhile :smile: