### PR TITLE
Expose more options in the downsample tool.

### DIFF
--- a/definitions/subworkflows/downsampled_alignment.cwl
+++ b/definitions/subworkflows/downsampled_alignment.cwl
@@ -36,19 +36,19 @@ outputs:
         outputSource: align_workflow/mark_duplicates_metrics_file
 steps:
     downsample:
-        scatter: [bam]
+        scatter: [sam]
         scatterMethod: dotproduct
         run: ../tools/downsample.cwl
         in:
-            bam: bams
+            sam: bams
             probability: downsample_probability
             reference: reference
         out:
-            [downsampled_bam]
+            [downsampled_sam]
     align_workflow:
         run: bam_to_bqsr.cwl
         in:
-            bams: downsample/downsampled_bam
+            bams: downsample/downsampled_sam
             readgroups: readgroups
             reference: reference
             dbsnp_vcf: dbsnp_vcf

--- a/definitions/tools/downsample.cwl
+++ b/definitions/tools/downsample.cwl
@@ -4,29 +4,49 @@ cwlVersion: v1.0
 class: CommandLineTool
 label: "downsample unaligned BAM"
 
-baseCommand: ["/usr/bin/java", "-Xmx16g", "-jar", "/opt/picard/picard.jar", "DownsampleSam"]
+baseCommand: ["/gatk/gatk", "--java-options", "-Xmx16g", "DownsampleSam"]
 arguments:
-    ["OUTPUT=", { valueFrom: $(runtime.outdir)/downsampled.bam }]
+    ["--OUTPUT=", { valueFrom: $(runtime.outdir)/$(inputs.sam.nameroot).bam }, "--CREATE_INDEX", "--CREATE_MD5_FILE"]
 requirements:
     - class: ResourceRequirement
       ramMin: 18000
     - class: DockerRequirement
-      dockerPull: "mgibio/cle:v1.3.1"
+      dockerPull: "broadinstitute/gatk:4.1.4.1"
 inputs:
-    bam:
+    sam:
         type: File
         inputBinding:
-            prefix: "INPUT="
+            prefix: "--INPUT="
+            separate: false
     probability:
         type: float
         inputBinding:
-            prefix: "PROBABILITY="
+            prefix: "--PROBABILITY="
+            separate: false
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
-            prefix: "REFERENCE_SEQUENCE="
+            prefix: "--REFERENCE_SEQUENCE="
+            separate: false
+    random_seed:
+        type: int?
+        inputBinding:
+            prefix: "--RANDOM_SEED="
+            separate: false
+    strategy:
+        type: 
+            - "null"
+            - type: enum
+              symbols: ["HighAccuracy", "ConstantMemory", "Chained"]
+        inputBinding:
+            prefix: "--STRATEGY="
+            separate: false
 outputs:
-    downsampled_bam:
+    downsampled_sam:
         type: File
+        secondaryFiles: ['.md5', '^.bai']
         outputBinding:
-            glob: "downsampled.bam"
+            glob: $(inputs.sam.nameroot).bam


### PR DESCRIPTION
Picard currently forces BAM output even given CRAM input, so this assumes BAM output for now.

We can revisit that if this line is changed in the future:
https://github.com/broadinstitute/picard/blob/d7e09b8e3f7f0583346117b95aafb7bd815aaa65/src/main/java/picard/sam/DownsampleSam.java#L215