### PR TITLE
Add workflows to process CLE vcf evaluation analysis

### DIFF
--- a/definitions/subworkflows/cram_to_bam_and_index.cwl
+++ b/definitions/subworkflows/cram_to_bam_and_index.cwl
@@ -8,7 +8,10 @@ inputs:
         type: File
         secondaryFiles: [^.crai]
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
 outputs:
     bam:
         type: File

--- a/definitions/subworkflows/vcf_eval_cle_gold.cwl
+++ b/definitions/subworkflows/vcf_eval_cle_gold.cwl
@@ -28,13 +28,12 @@ inputs:
         secondaryFiles: [.tbi]
     true_negative_bed:
         type: File
+    output_dir:
+        type: string
 outputs:
-    eval_out:
-        type: File
-        outputSource: evaluation/eval_out
-    vaf_report_out:
-        type: File
-        outputSource: evaluation/vaf_report
+    output_directory:
+        type: Directory
+        outputSource: gather_to_sub_directory/gathered_directory
 steps:
     normal_cram_to_bam_and_index:
         run: cram_to_bam_and_index.cwl
@@ -132,13 +131,13 @@ steps:
         out:
             [intersect_result] 
     sompy:
-         run: ../tools/sompy.cwl
-         in:
+        run: ../tools/sompy.cwl
+        in:
             reference: reference
             roi_bed:  roi_bed
             truth_vcf: gold_vcf
             query_vcf: query_vcf_pass/filtered_vcf
-         out:
+        out:
             [sompy_out]
     evaluation:
         run: ../tools/eval_cle_gold.cwl
@@ -154,4 +153,10 @@ steps:
             tumor_indel_bam_readcount_tsv: tumor_bam_readcount/indel_bam_readcount_tsv
         out:
             [eval_out, vaf_report]
-
+    gather_to_sub_directory:
+        run: ../tools/gather_to_sub_directory.cwl
+        in:
+            outdir: output_dir
+            files: [evaluation/eval_out,evaluation/vaf_report]
+        out:
+            [gathered_directory]

--- a/definitions/subworkflows/vcf_eval_cle_gold.cwl
+++ b/definitions/subworkflows/vcf_eval_cle_gold.cwl
@@ -23,6 +23,12 @@ inputs:
     tumor_cram:
         type: File
         secondaryFiles: [^.crai]
+    normal_sample_name:
+        type: string?
+        default: 'NORMAL'
+    tumor_sample_name:
+        type: string?
+        default: 'TUMOR'
     gold_vcf:
         type: File
         secondaryFiles: [.tbi]
@@ -70,8 +76,7 @@ steps:
         run: ../tools/bam_readcount.cwl
         in:
             vcf: combine_vcf/combined_vcf
-            sample:
-                default: 'NORMAL'
+            sample: normal_sample_name
             reference_fasta: reference
             bam: normal_cram_to_bam_and_index/bam
         out:
@@ -80,8 +85,7 @@ steps:
         run: ../tools/bam_readcount.cwl
         in:
             vcf: combine_vcf/combined_vcf
-            sample:
-                default: 'TUMOR'
+            sample: tumor_sample_name
             reference_fasta: reference
             bam: tumor_cram_to_bam_and_index/bam
         out:

--- a/definitions/subworkflows/vcf_eval_cle_gold.cwl
+++ b/definitions/subworkflows/vcf_eval_cle_gold.cwl
@@ -1,0 +1,157 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+label: "CLE gold vcf evaluation workflow"
+requirements:
+    - class: SubworkflowFeatureRequirement
+    - class: StepInputExpressionRequirement
+inputs:
+    reference:
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
+    roi_bed:
+        type: File
+    query_vcf:
+        type: File
+        secondaryFiles: [.tbi]
+    normal_cram:
+        type: File
+        secondaryFiles: [^.crai]
+    tumor_cram:
+        type: File
+        secondaryFiles: [^.crai]
+    gold_vcf:
+        type: File
+        secondaryFiles: [.tbi]
+    true_negative_bed:
+        type: File
+outputs:
+    eval_out:
+        type: File
+        outputSource: evaluation/eval_out
+    vaf_report_out:
+        type: File
+        outputSource: evaluation/vaf_report
+steps:
+    normal_cram_to_bam_and_index:
+        run: cram_to_bam_and_index.cwl
+        in:
+            cram: normal_cram
+            reference: reference
+        out:
+            [bam]
+    tumor_cram_to_bam_and_index:
+        run: cram_to_bam_and_index.cwl
+        in:
+            cram: tumor_cram
+            reference: reference
+        out:
+            [bam]
+    query_vcf_pass:
+        run: ../tools/select_variants.cwl
+        in:
+            reference: reference
+            vcf: query_vcf
+            exclude_filtered: 
+                default: true
+        out:
+            [filtered_vcf]
+    combine_vcf:
+        run: ../tools/combine_variants_concordance.cwl
+        in:
+            reference: reference
+            base_vcf: gold_vcf
+            query_vcf: query_vcf_pass/filtered_vcf
+        out:
+           [combined_vcf]
+    normal_bam_readcount:
+        run: ../tools/bam_readcount.cwl
+        in:
+            vcf: combine_vcf/combined_vcf
+            sample:
+                default: 'NORMAL'
+            reference_fasta: reference
+            bam: normal_cram_to_bam_and_index/bam
+        out:
+            [snv_bam_readcount_tsv, indel_bam_readcount_tsv]
+    tumor_bam_readcount:
+        run: ../tools/bam_readcount.cwl
+        in:
+            vcf: combine_vcf/combined_vcf
+            sample:
+                default: 'TUMOR'
+            reference_fasta: reference
+            bam: tumor_cram_to_bam_and_index/bam
+        out:
+            [snv_bam_readcount_tsv, indel_bam_readcount_tsv]
+    query_vcf_pass_snv:
+        run: ../tools/select_variants.cwl
+        in:
+            reference: reference
+            vcf: query_vcf_pass/filtered_vcf
+            select_type: 
+                default: 'SNP'
+        out:
+            [filtered_vcf]
+    query_vcf_pass_indel:
+        run: ../tools/select_variants.cwl
+        in:
+            reference: reference
+            vcf: query_vcf_pass/filtered_vcf
+            select_type: 
+                default: 'INDEL'
+        out:
+            [filtered_vcf]
+    true_negative_intersect_query_snv:
+        run: ../tools/bedtools_intersect.cwl
+        in:
+            file_a: true_negative_bed
+            file_b: query_vcf_pass_snv/filtered_vcf
+            output_file_a: 
+                default: false
+            unique_result: 
+                default: false
+            output_name:
+                default: 'tn_x_query_snv.bed'   
+        out:
+            [intersect_result] 
+    true_negative_intersect_query_indel:
+        run: ../tools/bedtools_intersect.cwl
+        in:
+            file_a: true_negative_bed
+            file_b: query_vcf_pass_indel/filtered_vcf
+            output_file_a: 
+                default: false
+            unique_result: 
+                default: false
+            output_name: 
+                default: 'tn_x_query_indel.bed'   
+        out:
+            [intersect_result] 
+    sompy:
+         run: ../tools/sompy.cwl
+         in:
+            reference: reference
+            roi_bed:  roi_bed
+            truth_vcf: gold_vcf
+            query_vcf: query_vcf_pass/filtered_vcf
+         out:
+            [sompy_out]
+    evaluation:
+        run: ../tools/eval_cle_gold.cwl
+        in:
+            sompy_out: sompy/sompy_out
+            true_negative_bed: true_negative_bed
+            tn_x_query_snv: true_negative_intersect_query_snv/intersect_result
+            tn_x_query_indel: true_negative_intersect_query_indel/intersect_result
+            combined_vcf: combine_vcf/combined_vcf
+            normal_snv_bam_readcount_tsv: normal_bam_readcount/snv_bam_readcount_tsv
+            normal_indel_bam_readcount_tsv: normal_bam_readcount/indel_bam_readcount_tsv
+            tumor_snv_bam_readcount_tsv: tumor_bam_readcount/snv_bam_readcount_tsv
+            tumor_indel_bam_readcount_tsv: tumor_bam_readcount/indel_bam_readcount_tsv
+        out:
+            [eval_out, vaf_report]
+

--- a/definitions/subworkflows/vcf_eval_concordance.cwl
+++ b/definitions/subworkflows/vcf_eval_concordance.cwl
@@ -1,0 +1,160 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+label: "Vcf concordance evaluation workflow"
+requirements:
+    - class: SubworkflowFeatureRequirement
+    - class: StepInputExpressionRequirement
+inputs:
+    reference:
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
+    roi_bed:
+        type: File
+    base_normal_cram:
+        type: File
+        secondaryFiles: [^.crai]
+    base_tumor_cram:
+        type: File
+        secondaryFiles: [^.crai]
+    base_vcf:
+        type: File
+        secondaryFiles: [.tbi]
+    query_normal_cram:
+        type: File
+        secondaryFiles: [^.crai]
+    query_tumor_cram:
+        type: File
+        secondaryFiles: [^.crai]
+    query_vcf:
+        type: File
+        secondaryFiles: [.tbi]
+outputs:
+    concordance_out:
+        type: File
+        outputSource: sompy/sompy_out
+    vaf_report_out:
+        type: File
+        outputSource: vaf_report/out_file
+steps:
+    base_normal_cram_to_bam_and_index:
+        run: cram_to_bam_and_index.cwl
+        in:
+            cram: base_normal_cram
+            reference: reference
+        out:
+            [bam]
+    base_tumor_cram_to_bam_and_index:
+        run: cram_to_bam_and_index.cwl
+        in:
+            cram: base_tumor_cram
+            reference: reference
+        out:
+            [bam]
+    query_normal_cram_to_bam_and_index:
+        run: cram_to_bam_and_index.cwl
+        in:
+            cram: query_normal_cram
+            reference: reference
+        out:
+            [bam]
+    query_tumor_cram_to_bam_and_index:
+        run: cram_to_bam_and_index.cwl
+        in:
+            cram: query_tumor_cram
+            reference: reference
+        out:
+            [bam]
+    base_vcf_pass:
+        run: ../tools/select_variants.cwl
+        in:
+            reference: reference
+            vcf: base_vcf
+            exclude_filtered: 
+                default: true
+        out:
+            [filtered_vcf]
+    query_vcf_pass:
+        run: ../tools/select_variants.cwl
+        in:
+            reference: reference
+            vcf: query_vcf
+            exclude_filtered: 
+                default: true
+        out:
+            [filtered_vcf]
+    combine_vcf:
+        run: ../tools/combine_variants_concordance.cwl
+        in:
+            reference: reference
+            base_vcf: base_vcf_pass/filtered_vcf
+            query_vcf:  query_vcf_pass/filtered_vcf
+        out:
+            [combined_vcf]
+    base_normal_bam_readcount:
+        run: ../tools/bam_readcount.cwl
+        in:
+            vcf: combine_vcf/combined_vcf
+            sample:
+                default: 'NORMAL'
+            reference_fasta: reference
+            bam: base_normal_cram_to_bam_and_index/bam
+        out:
+            [snv_bam_readcount_tsv, indel_bam_readcount_tsv]
+    base_tumor_bam_readcount:
+        run: ../tools/bam_readcount.cwl
+        in:
+            vcf: combine_vcf/combined_vcf
+            sample:
+                default: 'TUMOR'
+            reference_fasta: reference
+            bam: base_tumor_cram_to_bam_and_index/bam
+        out:
+            [snv_bam_readcount_tsv, indel_bam_readcount_tsv]
+    query_normal_bam_readcount:
+        run: ../tools/bam_readcount.cwl
+        in:
+            vcf: combine_vcf/combined_vcf
+            sample:
+                default: 'NORMAL'
+            reference_fasta: reference
+            bam: query_normal_cram_to_bam_and_index/bam
+        out:
+            [snv_bam_readcount_tsv, indel_bam_readcount_tsv]
+    query_tumor_bam_readcount:
+        run: ../tools/bam_readcount.cwl
+        in:
+            vcf: combine_vcf/combined_vcf
+            sample:
+                default: 'TUMOR'
+            reference_fasta: reference
+            bam: query_tumor_cram_to_bam_and_index/bam
+        out:
+            [snv_bam_readcount_tsv, indel_bam_readcount_tsv]
+    sompy:
+         run: ../tools/sompy.cwl
+         in:
+            reference: reference
+            roi_bed:  roi_bed
+            truth_vcf: base_vcf_pass/filtered_vcf
+            query_vcf: query_vcf_pass/filtered_vcf
+         out:
+            [sompy_out]
+    vaf_report:
+        run: ../tools/eval_vaf_report.cwl
+        in:
+            combined_vcf: combine_vcf/combined_vcf
+            base_normal_snv_bam_readcount_tsv: base_normal_bam_readcount/snv_bam_readcount_tsv
+            base_normal_indel_bam_readcount_tsv: base_normal_bam_readcount/indel_bam_readcount_tsv
+            base_tumor_snv_bam_readcount_tsv: base_tumor_bam_readcount/snv_bam_readcount_tsv
+            base_tumor_indel_bam_readcount_tsv: base_tumor_bam_readcount/indel_bam_readcount_tsv
+            query_normal_snv_bam_readcount_tsv: query_normal_bam_readcount/snv_bam_readcount_tsv
+            query_normal_indel_bam_readcount_tsv: query_normal_bam_readcount/indel_bam_readcount_tsv
+            query_tumor_snv_bam_readcount_tsv: query_tumor_bam_readcount/snv_bam_readcount_tsv
+            query_tumor_indel_bam_readcount_tsv: query_tumor_bam_readcount/indel_bam_readcount_tsv
+        out:
+            [out_file]
+

--- a/definitions/subworkflows/vcf_eval_concordance.cwl
+++ b/definitions/subworkflows/vcf_eval_concordance.cwl
@@ -32,6 +32,12 @@ inputs:
     query_vcf:
         type: File
         secondaryFiles: [.tbi]
+    normal_sample_name:
+        type: string?
+        default: 'NORMAL'
+    tumor_sample_name:
+        type: string?
+        default: 'TUMOR'
     output_dir:
         type: string
 outputs:
@@ -97,8 +103,7 @@ steps:
         run: ../tools/bam_readcount.cwl
         in:
             vcf: combine_vcf/combined_vcf
-            sample:
-                default: 'NORMAL'
+            sample: normal_sample_name
             reference_fasta: reference
             bam: base_normal_cram_to_bam_and_index/bam
         out:
@@ -107,8 +112,7 @@ steps:
         run: ../tools/bam_readcount.cwl
         in:
             vcf: combine_vcf/combined_vcf
-            sample:
-                default: 'TUMOR'
+            sample: tumor_sample_name
             reference_fasta: reference
             bam: base_tumor_cram_to_bam_and_index/bam
         out:
@@ -117,8 +121,7 @@ steps:
         run: ../tools/bam_readcount.cwl
         in:
             vcf: combine_vcf/combined_vcf
-            sample:
-                default: 'NORMAL'
+            sample: normal_sample_name
             reference_fasta: reference
             bam: query_normal_cram_to_bam_and_index/bam
         out:
@@ -127,8 +130,7 @@ steps:
         run: ../tools/bam_readcount.cwl
         in:
             vcf: combine_vcf/combined_vcf
-            sample:
-                default: 'TUMOR'
+            sample: tumor_sample_name
             reference_fasta: reference
             bam: query_tumor_cram_to_bam_and_index/bam
         out:

--- a/definitions/subworkflows/vcf_eval_concordance.cwl
+++ b/definitions/subworkflows/vcf_eval_concordance.cwl
@@ -32,13 +32,12 @@ inputs:
     query_vcf:
         type: File
         secondaryFiles: [.tbi]
+    output_dir:
+        type: string
 outputs:
-    concordance_out:
-        type: File
-        outputSource: sompy/sompy_out
-    vaf_report_out:
-        type: File
-        outputSource: vaf_report/out_file
+    output_directory:
+        type: Directory
+        outputSource: gather_to_sub_directory/gathered_directory
 steps:
     base_normal_cram_to_bam_and_index:
         run: cram_to_bam_and_index.cwl
@@ -157,4 +156,10 @@ steps:
             query_tumor_indel_bam_readcount_tsv: query_tumor_bam_readcount/indel_bam_readcount_tsv
         out:
             [out_file]
-
+    gather_to_sub_directory:
+        run: ../tools/gather_to_sub_directory.cwl
+        in:
+            outdir: output_dir
+            files: [sompy/sompy_out,vaf_report/out_file]
+        out:
+            [gathered_directory]

--- a/definitions/tools/combine_variants_concordance.cwl
+++ b/definitions/tools/combine_variants_concordance.cwl
@@ -1,0 +1,44 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: "CombineVariants (GATK 3.6)"
+baseCommand: ["/usr/bin/java", "-Xmx8g", "-jar", "/opt/GenomeAnalysisTK.jar", "-T", "CombineVariants"]
+requirements:
+    - class: ResourceRequirement
+      ramMin: 9000
+      tmpdirMin: 25000
+    - class: DockerRequirement
+      dockerPull: "mgibio/gatk-cwl:3.6.0"
+arguments:
+    ["-genotypeMergeOptions", "PRIORITIZE",
+     "--rod_priority_list", "query,base",
+     "-setKey", "source",
+     "-o", { valueFrom: $(runtime.outdir)/combined_concordance.vcf.gz }]
+inputs:
+    reference:
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
+        inputBinding:
+            prefix: "-R"
+            position: 1
+    base_vcf:
+        type: File
+        inputBinding:
+            prefix: "--variant:base"
+            position: 3
+        secondaryFiles: [.tbi]
+    query_vcf:
+        type: File
+        inputBinding:
+            prefix: "--variant:query"
+            position: 6
+        secondaryFiles: [.tbi]
+outputs:
+    combined_vcf:
+        type: File
+        outputBinding:
+            glob: "combined_concordance.vcf.gz"
+

--- a/definitions/tools/cram_to_bam.cwl
+++ b/definitions/tools/cram_to_bam.cwl
@@ -13,7 +13,10 @@ arguments:
         ["-o", { valueFrom: $(runtime.outdir)/$(inputs.cram.nameroot).bam }]
 inputs:
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             prefix: "-T"
             position: 1

--- a/definitions/tools/eval_cle_gold.cwl
+++ b/definitions/tools/eval_cle_gold.cwl
@@ -26,21 +26,22 @@ requirements:
             my $tn_query_snv_size = bed_size($tn_query_snv_bed);
             my $tn_query_indel_size = bed_size($tn_query_indel_bed);
 
-            my $snv_specificity   = sprintf("%.6f", ($tn_size-$tn_query_snv_size)/$tn_size);
-            my $indel_specificity = sprintf("%.6f", ($tn_size-$tn_query_indel_size)/$tn_size);            
+            my $snv_specificity   = sprintf("%.9f", ($tn_size-$tn_query_snv_size)/$tn_size);
+            my $indel_specificity = sprintf("%.9f", ($tn_size-$tn_query_indel_size)/$tn_size);
             open(my $sompy_fh, $sompy_out) or die("couldn't open $sompy_out to read");
             open(my $eval_out_fh, ">$out_dir/gold_eval.out") or die("couldn't open gold_eval.out for write");
           
             while (<$sompy_fh>) {
                next if /^\s+$|\s+records\s+/;
+               chomp;
                if (/^\s+type\s+/) {
-                   say $eval_out_fh $_."\tspecificity";
+                   say $eval_out_fh $_."  specificity";
                }
                elsif (/\s+indels\s+/) {
-                   say $eval_out_fh $_."\t".$indel_specificity;
+                   say $eval_out_fh $_."  ".$indel_specificity;
                }
                elsif (/\s+SNVs\s+/) {
-                   say $eval_out_fh $_."\t".$snv_specificity;
+                   say $eval_out_fh $_."  ".$snv_specificity;
                }
             }
             close $sompy_fh;
@@ -93,7 +94,7 @@ requirements:
                 open(my $fh, $bed) or die "could not open $bed for read";
                 while (<$fh>) {
                     my (undef, $start, $end) = split /\t/, $_;
-                    $size += $end - $start + 1;
+                    $size += $end - $start;
                 }
                 close $fh;
                 return $size;

--- a/definitions/tools/eval_cle_gold.cwl
+++ b/definitions/tools/eval_cle_gold.cwl
@@ -1,0 +1,208 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: "Make CLE gold evaluation output and vaf report"
+requirements:
+    - class: DockerRequirement
+      dockerPull: "ubuntu:bionic"
+    - class: ResourceRequirement
+      ramMin: 4000
+    - class: InitialWorkDirRequirement
+      listing:
+      - entryname: 'eval_cle_gold.pl'
+        entry: |
+            #!/usr/bin/perl
+
+            use strict;
+            use warnings;
+
+            use feature qw(say);
+
+            die("wrong number of arguments, 10 are needed") unless scalar(@ARGV) == 10;
+            my ($out_dir, $sompy_out, $tn_bed, $tn_query_snv_bed, $tn_query_indel_bed, $vcf, $n_snv_br, $n_indel_br, $t_snv_br, $t_indel_br) = @ARGV;
+
+            my $tn_size = bed_size($tn_bed);
+            my $tn_query_snv_size = bed_size($tn_query_snv_bed);
+            my $tn_query_indel_size = bed_size($tn_query_indel_bed);
+
+            my $snv_specificity   = sprintf("%.6f", ($tn_size-$tn_query_snv_size)/$tn_size);
+            my $indel_specificity = sprintf("%.6f", ($tn_size-$tn_query_indel_size)/$tn_size);            
+            open(my $sompy_fh, $sompy_out) or die("couldn't open $sompy_out to read");
+            open(my $eval_out_fh, ">$out_dir/gold_eval.out") or die("couldn't open gold_eval.out for write");
+          
+            while (<$sompy_fh>) {
+               next if /^\s+$|\s+records\s+/;
+               if (/^\s+type\s+/) {
+                   say $eval_out_fh $_."\tspecificity";
+               }
+               elsif (/\s+indels\s+/) {
+                   say $eval_out_fh $_."\t".$indel_specificity;
+               }
+               elsif (/\s+SNVs\s+/) {
+                   say $eval_out_fh $_."\t".$snv_specificity;
+               }
+            }
+            close $sompy_fh;
+            close $eval_out_fh;
+
+            my $t_snv_bamrc_info   = get_bamrc_info($t_snv_br);
+            my $t_indel_bamrc_info = get_bamrc_info($t_indel_br);
+            my $n_snv_bamrc_info   = get_bamrc_info($n_snv_br);
+            my $n_indel_bamrc_info = get_bamrc_info($n_indel_br);
+
+            my $vaf_out = $out_dir. '/vaf_report.out';
+            open(my $out_fh, ">$vaf_out") or die "fail to write to $vaf_out";
+
+            say $out_fh join "\t", 'Chr', 'Pos', 'Ref', 'Alt', 'Gold', 'Query', 'Normal_Dp', 'Normal_Vaf', 'Tumor_Dp', 'Tumor_Vaf';
+
+            open(my $fh, "/bin/gunzip -c $vcf |") or die("couldn't open $vcf to read");
+
+            while (<$fh>) {
+                next if $_ =~ /^#/;
+                my @columns = split /\t/, $_;
+                my ($chr, $pos, $ref, $alt, $info) = map{$columns[$_]}qw(0 1 3 4 7);
+    
+                my ($base, $query);
+                if ($info =~ /source=Intersection/) {
+                    ($base, $query) = (1, 1);
+                }
+                elsif ($info =~ /source=base/) {
+                    ($base, $query) = (1, 0);
+                }
+                elsif ($info =~ /source=query/) {
+                    ($base, $query) = (0, 1);
+                }
+                elsif ($info =~ /source=(FilteredInAll|filterInquery-base|query-filterInbase)/) {
+                    ($base, $query) = ('-', '-');
+                }
+                else {
+                    die "Line $_ does not have source info";
+                }
+    
+                my @alts = split /,/, $alt;
+                my ($n_AF, $n_dp) = get_AF_dp($chr, $pos, $ref, $alts[0], $n_snv_bamrc_info, $n_indel_bamrc_info);
+                my ($t_AF, $t_dp) = get_AF_dp($chr, $pos, $ref, $alts[0], $t_snv_bamrc_info, $t_indel_bamrc_info);
+                say $out_fh join "\t", $chr, $pos, $ref, $alt, $base, $query, $n_dp, $n_AF, $t_dp, $t_AF;
+            }
+            $fh->close;
+
+            sub bed_size {
+                my $bed = shift;
+                my $size = 0;
+                open(my $fh, $bed) or die "could not open $bed for read";
+                while (<$fh>) {
+                    my (undef, $start, $end) = split /\t/, $_;
+                    $size += $end - $start + 1;
+                }
+                close $fh;
+                return $size;
+            }
+
+            sub get_bamrc_info {
+                my $bamrc = shift;
+                my $bamrc_info;
+    
+                open(my $bamrc_fh, $bamrc) or die "failed to open $bamrc for read";
+                while (<$bamrc_fh>) {
+                    chomp;
+                    my ($chr, $pos, $ref, $depth, $rest) = $_ =~ /^(.+)\t(\d+)\t([AaCcGgTtRrYyKkMmSsWwBbDdHhVvNn])\t(\d+)\t(.+)$/x; 
+                    my @allele_info = split /\t/, $rest;
+                    my $allele_ct;
+                    for my $allele_str (@allele_info) {
+                        my @info = split /:/, $allele_str;
+                        $allele_ct->{$info[0]} = $info[1];
+                    }
+                    $bamrc_info->{$chr.'__'.$pos} = {
+                        ref => $ref,
+                        depth => $depth,
+                        allele_ct => $allele_ct,
+                    };
+                }
+                close $bamrc_fh;
+                return $bamrc_info;
+            }
+
+            sub get_AF_dp {
+                my ($chr, $pos, $ref, $alt, $snv_br_info, $indel_br_info) = @_;
+                my ($AF, $dp) = ('NA', 'NA');
+                
+                if (length($ref) == 1 and length($alt) == 1) { #SNV
+                    my $id = $chr .'__'.$pos;
+                    my $br_info = $snv_br_info->{$id};
+                    if ($br_info) {
+                        $AF = sprintf("%.5f", $br_info->{allele_ct}->{$alt}/$br_info->{depth});
+                        $dp = $br_info->{depth};
+                    }
+                }
+                else {
+                    my ($indel_pos, $bamrc_str);
+                    if (length($ref) > length($alt)) { #DEL
+                        $indel_pos = $pos + 1;
+                        $bamrc_str = '-'.substr($ref, length($alt));
+                    }
+                    else { #INS
+                        $indel_pos = $pos;
+                        $bamrc_str = '+'.substr($alt, length($ref));
+                    }
+                    my $id = $chr.'__'.$indel_pos;
+                    my $br_info = $indel_br_info->{$id};
+                    if ($br_info) {
+                        my $alt_ct = exists $br_info->{allele_ct}->{$bamrc_str} ? $br_info->{allele_ct}->{$bamrc_str} : 0;
+                        $AF = sprintf("%.5f", $alt_ct/$br_info->{depth});
+                        $dp = $br_info->{depth};
+                    }
+                }
+                return ($AF, $dp);
+            }
+
+arguments: [
+    "/usr/bin/perl", "eval_cle_gold.pl", $(runtime.outdir)
+]
+inputs:
+    sompy_out:
+        type: File
+        inputBinding:
+            position: 1
+    true_negative_bed:
+        type: File
+        inputBinding:
+            position: 2
+    tn_x_query_snv:
+        type: File
+        inputBinding:
+            position: 3
+    tn_x_query_indel:
+        type: File
+        inputBinding:
+            position: 4
+    combined_vcf:
+        type: File
+        inputBinding:
+            position: 5
+    normal_snv_bam_readcount_tsv:
+        type: File
+        inputBinding:
+            position: 6
+    normal_indel_bam_readcount_tsv:
+        type: File
+        inputBinding:
+            position: 7
+    tumor_snv_bam_readcount_tsv:
+        type: File
+        inputBinding:
+            position: 8
+    tumor_indel_bam_readcount_tsv:
+        type: File
+        inputBinding:
+            position: 9
+outputs:
+    eval_out:
+        type: File
+        outputBinding:
+            glob: "gold_eval.out"
+    vaf_report:
+        type: File
+        outputBinding:
+            glob: "vaf_report.out"
+

--- a/definitions/tools/eval_vaf_report.cwl
+++ b/definitions/tools/eval_vaf_report.cwl
@@ -1,0 +1,176 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: "Generate vaf report for concordance analysis"
+requirements:
+    - class: DockerRequirement
+      dockerPull: "ubuntu:bionic"
+    - class: ResourceRequirement
+      ramMin: 4000
+    - class: InitialWorkDirRequirement
+      listing:
+      - entryname: 'eval_vaf_report.pl'
+        entry: |
+            #!/usr/bin/perl
+
+            use strict;
+            use warnings;
+
+            use feature qw(say);
+
+            die("wrong number of arguments, 10 are needed") unless scalar(@ARGV) == 10;
+            my ($out_dir, $vcf, $b_n_snv_br, $b_n_indel_br, $b_t_snv_br, $b_t_indel_br, $q_n_snv_br, $q_n_indel_br, $q_t_snv_br, $q_t_indel_br) = @ARGV;
+
+            my $b_n_snv_bamrc_info   = get_bamrc_info($b_n_snv_br);
+            my $b_n_indel_bamrc_info = get_bamrc_info($b_n_indel_br);
+            my $b_t_snv_bamrc_info   = get_bamrc_info($b_t_snv_br);
+            my $b_t_indel_bamrc_info = get_bamrc_info($b_t_indel_br);
+
+            my $q_n_snv_bamrc_info   = get_bamrc_info($q_n_snv_br);
+            my $q_n_indel_bamrc_info = get_bamrc_info($q_n_indel_br);
+            my $q_t_snv_bamrc_info   = get_bamrc_info($q_t_snv_br);
+            my $q_t_indel_bamrc_info = get_bamrc_info($q_t_indel_br);
+            
+            my $vaf_out = $out_dir.'/vaf_report.out';
+            open(my $out_fh, ">$vaf_out") or die "fail to write to $vaf_out";
+
+            say $out_fh join "\t", 'Chr', 'Pos', 'Ref', 'Alt', 'Base', 'Query', 'Base_Normal_Dp', 'Base_Normal_Vaf', 'Base_Tumor_Dp', 'Base_Tumor_Vaf',  'Query_Normal_Dp', 'Query_Normal_Vaf', 'Query_Tumor_Dp', 'Query_Tumor_Vaf';
+
+            open(my $fh, "/bin/gunzip -c $vcf |") or die("couldn't open $vcf to read");
+
+            while (<$fh>) {
+                next if $_ =~ /^#/;
+                my @columns = split /\t/, $_;
+                my ($chr, $pos, $ref, $alt, $info) = map{$columns[$_]}qw(0 1 3 4 7);
+    
+                my ($base, $query);
+                if ($info =~ /source=Intersection/) {
+                    ($base, $query) = (1, 1);
+                }
+                elsif ($info =~ /source=base/) {
+                    ($base, $query) = (1, 0);
+                }
+                elsif ($info =~ /source=query/) {
+                    ($base, $query) = (0, 1);
+                }
+                elsif ($info =~ /source=(FilteredInAll|filterInquery-base|query-filterInbase)/) {
+                    ($base, $query) = ('-', '-');
+                }
+                else {
+                    die "Line $_ does not have source info";
+                }
+    
+                my @alts = split /,/, $alt;
+                my ($b_n_AF, $b_n_dp) = get_AF_dp($chr, $pos, $ref, $alts[0], $b_n_snv_bamrc_info, $b_n_indel_bamrc_info);
+                my ($b_t_AF, $b_t_dp) = get_AF_dp($chr, $pos, $ref, $alts[0], $b_t_snv_bamrc_info, $b_t_indel_bamrc_info);
+                my ($q_n_AF, $q_n_dp) = get_AF_dp($chr, $pos, $ref, $alts[0], $q_n_snv_bamrc_info, $q_n_indel_bamrc_info);
+                my ($q_t_AF, $q_t_dp) = get_AF_dp($chr, $pos, $ref, $alts[0], $q_t_snv_bamrc_info, $q_t_indel_bamrc_info);
+                
+                say $out_fh join "\t", $chr, $pos, $ref, $alt, $base, $query, $b_n_dp, $b_n_AF, $b_t_dp, $b_t_AF, $q_n_dp, $q_n_AF, $q_t_dp, $q_t_AF;
+            }
+            $fh->close;
+
+            sub get_bamrc_info {
+                my $bamrc = shift;
+                my $bamrc_info;
+    
+                open(my $bamrc_fh, $bamrc) or die "failed to open $bamrc for read";
+                while (<$bamrc_fh>) {
+                    chomp;
+                    my ($chr, $pos, $ref, $depth, $rest) = $_ =~ /^(.+)\t(\d+)\t([AaCcGgTtRrYyKkMmSsWwBbDdHhVvNn])\t(\d+)\t(.+)$/x; 
+                    my @allele_info = split /\t/, $rest;
+                    my $allele_ct;
+                    for my $allele_str (@allele_info) {
+                        my @info = split /:/, $allele_str;
+                        $allele_ct->{$info[0]} = $info[1];
+                    }
+                    $bamrc_info->{$chr.'__'.$pos} = {
+                        ref => $ref,
+                        depth => $depth,
+                        allele_ct => $allele_ct,
+                    };
+                }
+                close $bamrc_fh;
+                return $bamrc_info;
+            }
+
+            sub get_AF_dp {
+                my ($chr, $pos, $ref, $alt, $snv_br_info, $indel_br_info) = @_;
+                my ($AF, $dp) = ('NA', 'NA');
+                
+                if (length($ref) == 1 and length($alt) == 1) { #SNV
+                    my $id = $chr .'__'.$pos;
+                    my $br_info = $snv_br_info->{$id};
+                    if ($br_info) {
+                        $AF = sprintf("%.5f", $br_info->{allele_ct}->{$alt}/$br_info->{depth});
+                        $dp = $br_info->{depth};
+                    }
+                }
+                else {
+                    my ($indel_pos, $bamrc_str);
+                    if (length($ref) > length($alt)) { #DEL
+                        $indel_pos = $pos + 1;
+                        $bamrc_str = '-'.substr($ref, length($alt));
+                    }
+                    else { #INS
+                        $indel_pos = $pos;
+                        $bamrc_str = '+'.substr($alt, length($ref));
+                    }
+                    my $id = $chr.'__'.$indel_pos;
+                    my $br_info = $indel_br_info->{$id};
+                    if ($br_info) {
+                        my $alt_ct = exists $br_info->{allele_ct}->{$bamrc_str} ? $br_info->{allele_ct}->{$bamrc_str} : 0;
+                        $AF = sprintf("%.5f", $alt_ct/$br_info->{depth});
+                        $dp = $br_info->{depth};
+                    }
+                }
+                return ($AF, $dp);
+            }
+
+arguments: [
+    "/usr/bin/perl", "eval_vaf_report.pl", $(runtime.outdir)
+]
+inputs:
+    combined_vcf:
+        type: File
+        inputBinding:
+            position: 1
+    base_normal_snv_bam_readcount_tsv:
+        type: File
+        inputBinding:
+            position: 2
+    base_normal_indel_bam_readcount_tsv:
+        type: File
+        inputBinding:
+            position: 3
+    base_tumor_snv_bam_readcount_tsv:
+        type: File
+        inputBinding:
+            position: 4
+    base_tumor_indel_bam_readcount_tsv:
+        type: File
+        inputBinding:
+            position: 5
+    query_normal_snv_bam_readcount_tsv:
+        type: File
+        inputBinding:
+            position: 6
+    query_normal_indel_bam_readcount_tsv:
+        type: File
+        inputBinding:
+            position: 7
+    query_tumor_snv_bam_readcount_tsv:
+        type: File
+        inputBinding:
+            position: 8
+    query_tumor_indel_bam_readcount_tsv:
+        type: File
+        inputBinding:
+            position: 9
+outputs:
+    out_file:
+        type: File
+        outputBinding:
+            glob: "vaf_report.out"
+

--- a/definitions/tools/select_variants.cwl
+++ b/definitions/tools/select_variants.cwl
@@ -46,6 +46,15 @@ inputs:
             prefix: "--sample_name"
             position: 5
         doc: 'include genotypes from this sample'
+    select_type:
+        type:
+            - "null"
+            - type: enum
+              symbols: ["INDEL", "SNP", "MIXED", "MNP", "SYMBOLIC", "NO_VARIATION"]
+        inputBinding:
+            prefix: "-selectType"
+            position: 6
+        doc: 'select only a certain type of variants' 
 outputs:
     filtered_vcf:
         type: File

--- a/definitions/tools/sompy.cwl
+++ b/definitions/tools/sompy.cwl
@@ -1,0 +1,43 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: "som.py compares variants in vcf by location and alleles (using bcftools isec)."
+baseCommand: ["/opt/hap.py/bin/som.py"]
+requirements:
+    - class: ResourceRequirement
+      coresMin: 1
+      ramMin: 16000
+    - class: DockerRequirement
+      dockerPull: "pkrusche/hap.py"
+arguments: [
+    "-N",
+    "-o", "sompy",
+]
+stdout: "sompy.out"
+inputs:
+    truth_vcf:
+        type: File
+        inputBinding:
+            position: -2
+    query_vcf:
+        type: File
+        inputBinding:
+            position: -1
+    reference:
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
+        inputBinding:
+            prefix: "-r"
+            position: 1
+    roi_bed:
+        type: File
+        doc: 'region of interest bed file to restrict'
+        inputBinding:
+            prefix: "-R"
+            position: 2
+outputs:
+    sompy_out:
+        type: stdout

--- a/definitions/tools/sompy.cwl
+++ b/definitions/tools/sompy.cwl
@@ -9,7 +9,7 @@ requirements:
       coresMin: 1
       ramMin: 16000
     - class: DockerRequirement
-      dockerPull: "pkrusche/hap.py"
+      dockerPull: "pkrusche/hap.py:v0.3.9"
 arguments: [
     "-N",
     "-o", "sompy",


### PR DESCRIPTION
For CLE, there are bunch of old evaluation scripts to process evaluation analysis of vcf concordance and gold standard outputs for sensitivity, specificity and positive predict value (PPV). This PR is to replace those outdated scripts with cwl workflows that use som.py (bcftools inside) as comparison tool and vaf_report process to evaluate the result. Two subworkflows are tested and the result matches expectation.

Refer to https://jira.ris.wustl.edu/browse/CI-421