### PR TITLE
Missed input connection, already fixed in gms test run

### DIFF
--- a/definitions/subworkflows/pindel.cwl
+++ b/definitions/subworkflows/pindel.cwl
@@ -107,5 +107,6 @@ steps:
             vcf: reindex/indexed_vcf
             variant_caller: 
                 valueFrom: "pindel"
+            sample_name: tumor_sample_name
         out:
             [unfiltered_vcf, filtered_vcf]


### PR DESCRIPTION
This input was accidentally left out, forcing the tool to use its default and creating a mismatch with the expected sample name in the rest of the pipeline. Patched in a processing profile used in the first gms test run, fixing the error that was preventing this build from succeeding.