### PR TITLE
Minimal changes to ensure unique immuno output names

### DIFF
--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -285,6 +285,9 @@ inputs:
         type: boolean?
     pvacseq_threads:
         type: int?
+    vep_to_table_prefix:
+        type: string?
+        default: 'pvacseq'
 
     tumor_sample_name:
         type: string
@@ -808,5 +811,6 @@ steps:
             variants_to_table_fields: variants_to_table_fields
             variants_to_table_genotype_fields: variants_to_table_genotype_fields
             vep_to_table_fields: vep_to_table_fields
+            vep_to_table_prefix: vep_to_table_prefix
         out:
             [annotated_vcf, annotated_tsv, mhc_i_all_epitopes, mhc_i_filtered_epitopes, mhc_i_ranked_epitopes, mhc_ii_all_epitopes, mhc_ii_filtered_epitopes, mhc_ii_ranked_epitopes, combined_all_epitopes, combined_filtered_epitopes, combined_ranked_epitopes]

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -285,9 +285,6 @@ inputs:
         type: boolean?
     pvacseq_threads:
         type: int?
-    vep_to_table_prefix:
-        type: string?
-        default: 'pvacseq'
 
     tumor_sample_name:
         type: string
@@ -811,6 +808,5 @@ steps:
             variants_to_table_fields: variants_to_table_fields
             variants_to_table_genotype_fields: variants_to_table_genotype_fields
             vep_to_table_fields: vep_to_table_fields
-            vep_to_table_prefix: vep_to_table_prefix
         out:
             [annotated_vcf, annotated_tsv, mhc_i_all_epitopes, mhc_i_filtered_epitopes, mhc_i_ranked_epitopes, mhc_ii_all_epitopes, mhc_ii_filtered_epitopes, mhc_ii_ranked_epitopes, combined_all_epitopes, combined_filtered_epitopes, combined_ranked_epitopes]

--- a/definitions/subworkflows/pvacseq.cwl
+++ b/definitions/subworkflows/pvacseq.cwl
@@ -106,9 +106,6 @@ inputs:
     vep_to_table_fields:
         type: string[]?
         default: [HGVSc,HGVSp]
-    vep_to_table_prefix:
-        type: string?
-        default: 'pvacseq'
 outputs:
     annotated_vcf:
         type: File
@@ -250,5 +247,6 @@ steps:
             vcf: index/indexed_vcf
             vep_fields: vep_to_table_fields
             tsv: variants_to_table/variants_tsv
-            prefix: vep_to_table_prefix
+            prefix:
+                default: 'pvacseq'
         out: [annotated_variants_tsv]

--- a/definitions/subworkflows/pvacseq.cwl
+++ b/definitions/subworkflows/pvacseq.cwl
@@ -108,6 +108,7 @@ inputs:
         default: [HGVSc,HGVSp]
     vep_to_table_prefix:
         type: string?
+        default: 'pvacseq'
 outputs:
     annotated_vcf:
         type: File

--- a/definitions/subworkflows/pvacseq.cwl
+++ b/definitions/subworkflows/pvacseq.cwl
@@ -106,6 +106,8 @@ inputs:
     vep_to_table_fields:
         type: string[]?
         default: [HGVSc,HGVSp]
+    vep_to_table_prefix:
+        type: string?
 outputs:
     annotated_vcf:
         type: File
@@ -247,4 +249,5 @@ steps:
             vcf: index/indexed_vcf
             vep_fields: vep_to_table_fields
             tsv: variants_to_table/variants_tsv
+            prefix: vep_to_table_prefix
         out: [annotated_variants_tsv]

--- a/definitions/tools/vep.cwl
+++ b/definitions/tools/vep.cwl
@@ -24,7 +24,7 @@ arguments:
     "--offline",
     "--cache",
     "--symbol",
-    "-o", { valueFrom: $(runtime.outdir)/annotated.vcf }]
+    "-o", { valueFrom: $(runtime.outdir)/$(inputs.vcf.nameroot)_annotated.vcf }]
 inputs:
     vcf:
         type: File
@@ -123,8 +123,8 @@ outputs:
     annotated_vcf:
         type: File
         outputBinding:
-            glob: "annotated.vcf"
+            glob: "$(inputs.vcf.nameroot)_annotated.vcf"
     vep_summary:
         type: File
         outputBinding:
-            glob: "annotated.vcf_summary.html"
+            glob: "$(inputs.vcf.nameroot)_annotated.vcf_summary.html"


### PR DESCRIPTION
Previously, there were 2 pairs of output files with the same name.
`annotated.vcf_summary.html` was a hardcoded name in vep, run in both the `somatic_exome` and `germline_exome` pipeline. This now pulls part of its name from the input vcf.
`variants.annotated.tsv` had an optional unused prefix in add_vep_fields_to_table, run in both `somatic_exome` and `pvacseq`. I added a new input with a default that adds a prefix to the pvacseq branch. Neither change requires any new inputs.