### PR TITLE
Explicitly pass reference for portable cram decompression

### DIFF
--- a/definitions/pipelines/germline_exome_hla_typing.cwl
+++ b/definitions/pipelines/germline_exome_hla_typing.cwl
@@ -179,5 +179,6 @@ steps:
         in:
             optitype_name: optitype_name
             cram: germline_exome/cram
+            reference: reference
         out:
             [optitype_tsv, optitype_plot]

--- a/definitions/tools/optitype_dna.cwl
+++ b/definitions/tools/optitype_dna.cwl
@@ -13,7 +13,7 @@ requirements:
       coresMin: 4
       tmpdirMin: 20000
     - class: DockerRequirement
-      dockerPull: "mgibio/immuno_tools-cwl:1.0.0"
+      dockerPull: "mgibio/immuno_tools-cwl:1.0.1"
 inputs:
     optitype_name:
         type: string?
@@ -26,6 +26,14 @@ inputs:
         doc: "File to be HLA-typed"
         inputBinding:
             position: 2
+    reference:
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai]
+        doc: "Reference fasta used to make the cram"
+        inputBinding:
+            position: 3
 outputs:
     optitype_tsv:
         type: File


### PR DESCRIPTION
Previously, cram to bam conversion was being performed by samtools without a reference fasta explicitly provided. Samtools is smart enough to check the cram header for a path to the reference and try using that. This works on compute0 since the entire filesystem is mounted by default, but not on compute1, which is closer to a standard docker implementation and only mounts explicitly defined volumes. This PR adds the reference as an input, allowing Cromwell to handle staging if the reference is specified as a file. If it is a string, the user must ensure that dir containing the reference (and the index) is properly mounted by the optitype docker container.