### PR TITLE
More input choices to make vep_cache more portable

### DIFF
--- a/definitions/pipelines/aml_trio_cle.cwl
+++ b/definitions/pipelines/aml_trio_cle.cwl
@@ -110,7 +110,9 @@ inputs:
         type: int?
         default: 20
     vep_cache_dir:
-        type: string
+        type:
+            - string
+            - Directory
     synonyms_file:
         type: File?
     annotate_coding_only:

--- a/definitions/pipelines/aml_trio_cle_gathered.cwl
+++ b/definitions/pipelines/aml_trio_cle_gathered.cwl
@@ -110,7 +110,9 @@ inputs:
         type: int?
         default: 20
     vep_cache_dir:
-        type: string
+        type:
+            - string
+            - Directory
     vep_ensembl_assembly:
         type: string
         doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -58,7 +58,9 @@ inputs:
         type: boolean
         default: true
     vep_cache_dir:
-        type: string
+        type:
+            - string
+            - Directory
     vep_ensembl_assembly:
         type: string
         doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"

--- a/definitions/pipelines/detect_variants_mouse.cwl
+++ b/definitions/pipelines/detect_variants_mouse.cwl
@@ -48,7 +48,9 @@ inputs:
         type: int
         default: 400
     vep_cache_dir:
-        type: string
+        type:
+            - string
+            - Directory
     vep_ensembl_assembly:
         type: string
         doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"

--- a/definitions/pipelines/detect_variants_wgs.cwl
+++ b/definitions/pipelines/detect_variants_wgs.cwl
@@ -54,7 +54,9 @@ inputs:
         type: boolean?
         default: true
     vep_cache_dir:
-        type: string
+        type:
+            - string
+            - Directory
     vep_ensembl_assembly:
         type: string
         doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"

--- a/definitions/pipelines/germline_exome.cwl
+++ b/definitions/pipelines/germline_exome.cwl
@@ -57,7 +57,9 @@ inputs:
                 type: array
                 items: string
     vep_cache_dir:
-        type: string
+        type:
+            - string
+            - Directory
     vep_ensembl_assembly:
         type: string
         doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"

--- a/definitions/pipelines/germline_exome_hla_typing.cwl
+++ b/definitions/pipelines/germline_exome_hla_typing.cwl
@@ -57,7 +57,9 @@ inputs:
                 type: array
                 items: string
     vep_cache_dir:
-        type: string
+        type:
+            - string
+            - Directory
     vep_ensembl_assembly:
         type: string
         doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"

--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -49,7 +49,9 @@ inputs:
     variant_reporting_intervals:
         type: File
     vep_cache_dir:
-        type: string
+        type:
+            - string
+            - Directory
     vep_ensembl_assembly:
         type: string
         doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -146,7 +146,9 @@ inputs:
         type: boolean?
         default: true
     vep_cache_dir:
-        type: string
+        type:
+            - string
+            - Directory
     vep_ensembl_assembly:
         type: string
         doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -183,7 +183,9 @@ inputs:
         type: boolean?
         default: true
     vep_cache_dir:
-        type: string
+        type:
+            - string
+            - Directory
     vep_ensembl_assembly:
         type: string
         doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"

--- a/definitions/pipelines/somatic_exome_cle.cwl
+++ b/definitions/pipelines/somatic_exome_cle.cwl
@@ -89,7 +89,9 @@ inputs:
         type: int?
         default: 20
     vep_cache_dir:
-        type: string
+        type:
+            - string
+            - Directory
     vep_ensembl_assembly:
         type: string
         doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"

--- a/definitions/pipelines/somatic_exome_cle_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_cle_gathered.cwl
@@ -89,7 +89,9 @@ inputs:
         type: int?
         default: 20
     vep_cache_dir:
-        type: string?
+        type:
+            - string
+            - Directory
     vep_ensembl_assembly:
         type: string
         doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"

--- a/definitions/pipelines/somatic_exome_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_gathered.cwl
@@ -102,7 +102,9 @@ inputs:
         type: boolean?
         default: true
     vep_cache_dir:
-        type: string?
+        type:
+            - string
+            - Directory
     vep_ensembl_assembly:
         type: string
         doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"

--- a/definitions/pipelines/somatic_exome_mouse.cwl
+++ b/definitions/pipelines/somatic_exome_mouse.cwl
@@ -72,7 +72,9 @@ inputs:
         type: int
         default: 400
     vep_cache_dir:
-        type: string
+        type:
+            - string
+            - Directory
     vep_ensembl_assembly:
         type: string
         doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"

--- a/definitions/pipelines/somatic_wgs.cwl
+++ b/definitions/pipelines/somatic_wgs.cwl
@@ -99,7 +99,9 @@ inputs:
         type: boolean?
         default: true
     vep_cache_dir:
-        type: string
+        type:
+            - string
+            - Directory
     vep_ensembl_assembly:
         type: string
         doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"

--- a/definitions/pipelines/tumor_only_detect_variants.cwl
+++ b/definitions/pipelines/tumor_only_detect_variants.cwl
@@ -40,7 +40,9 @@ inputs:
         type: float?
         default: 0.001
     vep_cache_dir:
-        type: string
+        type:
+            - string
+            - Directory
     vep_ensembl_assembly:
         type: string
         doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"

--- a/definitions/pipelines/tumor_only_exome.cwl
+++ b/definitions/pipelines/tumor_only_exome.cwl
@@ -63,7 +63,9 @@ inputs:
         type: float?
         default: 0.001
     vep_cache_dir:
-        type: string
+        type:
+            - string
+            - Directory
     vep_ensembl_assembly:
         type: string
         doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"

--- a/definitions/pipelines/tumor_only_wgs.cwl
+++ b/definitions/pipelines/tumor_only_wgs.cwl
@@ -37,7 +37,9 @@ inputs:
     variant_detection_intervals:
         type: File
     vep_cache_dir:
-        type: string
+        type:
+            - string
+            - Directory
     vep_ensembl_assembly:
         type: string
         doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"

--- a/definitions/subworkflows/germline_detect_variants.cwl
+++ b/definitions/subworkflows/germline_detect_variants.cwl
@@ -32,7 +32,9 @@ inputs:
     contamination_fraction:
         type: string?
     vep_cache_dir:
-        type: string
+        type:
+            - string
+            - Directory
     vep_ensembl_assembly:
         type: string
         doc: "genome assembly to use in vep. Examples: GRCh38 or GRCm38"

--- a/definitions/tools/vep.cwl
+++ b/definitions/tools/vep.cwl
@@ -32,7 +32,9 @@ inputs:
             prefix: "-i"
             position: 1
     cache_dir:
-        type: string
+        type:
+            - string
+            - Directory
         inputBinding:
             prefix: "--dir"
             position: 4


### PR DESCRIPTION
This is a follow up to #774, and should address issue #832. Internally, both the reference fasta and vep cache are located in a central directory that Cromwell is configured to mount in each step's docker container, so they are always accessible. Passing the cache directory as a string prevents Cromwell from staging it into the working directory and saves space. However, adding in the option to specify this as a Directory type allows for more portable workflows; notably, example yamls can now exclusively use relative paths, allowing us to package them alongside example data for easy distribution and usage.