### PR TITLE
slim bcftools image

### DIFF
--- a/definitions/tools/merge_vcf.cwl
+++ b/definitions/tools/merge_vcf.cwl
@@ -6,7 +6,7 @@ label: "vcf merge"
 baseCommand: ["/opt/bcftools/bin/bcftools", "concat"]
 requirements:
     - class: DockerRequirement
-      dockerPull: mgibio/cle:v1.3.1
+      dockerPull: mgibio/bcftools-cwl:1.3.1
     - class: ResourceRequirement
       ramMin: 4000
 arguments:


### PR DESCRIPTION
bcftools is installed in the same location. using the same version of bcftools found in the cle v1.3.1 image. 
Could update to bcftools version 1.9 but decided to keep it the same version