### PR TITLE
Slim image combine variants wgs.cwl

### DIFF
--- a/definitions/tools/combine_variants_wgs.cwl
+++ b/definitions/tools/combine_variants_wgs.cwl
@@ -9,7 +9,7 @@ requirements:
       ramMin: 9000
       tmpdirMin: 25000
     - class: DockerRequirement
-      dockerPull: mgibio/cle:v1.3.1
+      dockerPull: mgibio/gatk-cwl:3.6.0
 arguments:
     ["-genotypeMergeOptions", "PRIORITIZE",
      "--rod_priority_list", "mutect,varscan,strelka",

--- a/definitions/tools/combine_variants_wgs.cwl
+++ b/definitions/tools/combine_variants_wgs.cwl
@@ -38,12 +38,6 @@ inputs:
             prefix: "--variant:strelka"
             position: 4
         secondaryFiles: [.tbi]
-#    pindel_vcf:
-#        type: File
-#        inputBinding:
-#            prefix: "--variant:pindel"
-#            position: 5
-#        secondaryFiles: [.tbi]
 outputs:
     combined_vcf:
         type: File


### PR DESCRIPTION
* removes commented out input 
* uses small gatk 3.6.0 image

cle image has version `3.6-0-gf185a75` while the gatk image has `3.6-0-g89b7209` (found using `/usr/bin/java -jar /opt/GenomeAnalysisTK.jar --version` in both images)
is this an issue?