### PR TITLE
use small gatk image

### DIFF
--- a/definitions/tools/set_filter_status.cwl
+++ b/definitions/tools/set_filter_status.cwl
@@ -9,7 +9,7 @@ requirements:
       ramMin: 6000
       tmpdirMin: 25000
     - class: DockerRequirement
-      dockerPull: "mgibio/cle:v1.3.1"
+      dockerPull: "mgibio/gatk-cwl:3.6.0"
 arguments:
     ["--maskName", "processSomatic",
     "--filterNotInMask",


### PR DESCRIPTION
small gatk image. continue using the gatk 3.6 version. 
basically the same as #857 