### PR TITLE
use small bcftools image for remove_end_tags.cwl

### DIFF
--- a/definitions/tools/remove_end_tags.cwl
+++ b/definitions/tools/remove_end_tags.cwl
@@ -13,7 +13,7 @@ requirements:
     - class: ResourceRequirement
       ramMin: 4000
     - class: DockerRequirement
-      dockerPull: "mgibio/cle:v1.3.1"
+      dockerPull: "mgibio/bcftools-cwl:1.3.1"
 inputs:
     vcf:
         type: File


### PR DESCRIPTION
using the small bcftools version 1.3.1 image for `remove_end_tags.cwl` tool
similar to #856 