### PR TITLE
use small gatk 3.6 image for docm_add_variants.cwl

### DIFF
--- a/definitions/tools/docm_add_variants.cwl
+++ b/definitions/tools/docm_add_variants.cwl
@@ -9,7 +9,7 @@ requirements:
       ramMin: 9000
       tmpdirMin: 25000
     - class: DockerRequirement
-      dockerPull: mgibio/cle:v1.4.2
+      dockerPull: mgibio/gatk-cwl:3.6.0
 arguments:
     ["-genotypeMergeOptions", "PRIORITIZE",
      "--rod_priority_list", "callers,docm",


### PR DESCRIPTION
cle image version `1.4.2` uses gatk version `3.6-0-gf185a75` which is the same gatk version found in cle image version `1.3.1`
using gatk-cwl:3.6.0 which is version `3.6-0-g89b7209`
similar to #857 and others