### PR TITLE
use small picard 2.18.1 image collect_gc_bias_metrics.cwl

### DIFF
--- a/definitions/tools/collect_gc_bias_metrics.cwl
+++ b/definitions/tools/collect_gc_bias_metrics.cwl
@@ -12,7 +12,7 @@ requirements:
     - class: ResourceRequirement
       ramMin: 18000
     - class: DockerRequirement
-      dockerPull: mgibio/cle:v1.3.1
+      dockerPull: mgibio/picard-cwl:2.18.1
 inputs:
     sample_name:
         type: string?


### PR DESCRIPTION
cle image 1.3.1 has picard version `2.18.1-SNAPSHOT`
picard-cwl:2.18.1 has version `2.18.1-SNAPSHOT` installed in the same location
(`/usr/bin/java -jar /usr/picard/picard.jar CollectGcBiasMetrics --version`)
