### PR TITLE
use small sambamba image for position_sort.cwl

### DIFF
--- a/definitions/tools/position_sort.cwl
+++ b/definitions/tools/position_sort.cwl
@@ -13,7 +13,7 @@ requirements:
       ramMin: 12000
       coresMin: 8
     - class: DockerRequirement
-      dockerPull: "mgibio/cle:v1.3.1"
+      dockerPull: "mgibio/sambamba-cwl:0.6.4"
 inputs:
     bam:
         type: File


### PR DESCRIPTION
cle image `1.3.1` uses sambamba version `0.6.4`
`mgibio/sambamba-cwl:0.6.4` has sambamba version `0.6.4` installed in the same location
(`/usr/bin/sambamba --version`)