### PR TITLE
use small gatk3.6 image combine_variants.cwl

### DIFF
--- a/definitions/tools/combine_variants.cwl
+++ b/definitions/tools/combine_variants.cwl
@@ -9,7 +9,7 @@ requirements:
       ramMin: 9000
       tmpdirMin: 25000
     - class: DockerRequirement
-      dockerPull: mgibio/cle:v1.3.1
+      dockerPull: mgibio/gatk-cwl:3.6.0
 arguments:
     ["-genotypeMergeOptions", "PRIORITIZE",
      "--rod_priority_list", "mutect,varscan,strelka,pindel",


### PR DESCRIPTION
cle 1.3.1 has gatk `3.6-0-gf185a75`
gatk-cwl:3.6.0 has `3.6-0-g89b7209`
similar to #857 and other linked PRs
