### PR TITLE
CNVkit and other SV updates

### DIFF
--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -89,7 +89,11 @@ inputs:
     cnvkit_drop_low_coverage: 
         type: boolean?
     cnvkit_method:
-        type: string? 
+        type:
+          - "null"
+          - type: enum
+            symbols: ["hybrid", "amplicon", "wgs"]
+        default: "wgs"
     cnvkit_reference_cnn: 
         type: File
     cnvkit_scatter_plot:

--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -95,7 +95,7 @@ inputs:
             symbols: ["hybrid", "amplicon", "wgs"]
         default: "wgs"
     cnvkit_reference_cnn: 
-        type: File
+        type: File?
     cnvkit_scatter_plot:
         type: boolean?
     cnvkit_male_reference:

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -545,8 +545,14 @@ steps:
         run: ../tools/cnvkit_batch.cwl
         in:
             tumor_bam: tumor_alignment_and_qc/bam
-            normal_bam: normal_alignment_and_qc/bam
-            reference: reference
+            reference:
+                source: [normal_alignment_and_qc/bam, reference]
+                valueFrom: |
+                    ${
+                      var normal = self[0];
+                      var fasta = self[1];
+                      return {'normal_bam': normal, 'fasta_file': fasta};
+                    }
             bait_intervals: bait_intervals
         out:
             [intervals_antitarget, intervals_target, normal_antitarget_coverage, normal_target_coverage, reference_coverage, cn_diagram, cn_scatter_plot, tumor_antitarget_coverage, tumor_target_coverage, tumor_bin_level_ratios, tumor_segmented_ratios]

--- a/definitions/subworkflows/cnvkit_single_sample.cwl
+++ b/definitions/subworkflows/cnvkit_single_sample.cwl
@@ -23,7 +23,7 @@ inputs:
     male_reference:
         type: boolean?
     reference_cnn:
-        type: File
+        type: File?
     cnvkit_vcf_name:
         type: string
         default: "cnvkit.vcf"

--- a/definitions/subworkflows/cnvkit_single_sample.cwl
+++ b/definitions/subworkflows/cnvkit_single_sample.cwl
@@ -76,7 +76,7 @@ steps:
                     ${
                       var cnn = self[0];
                       var fasta = self[1];
-                      return {'reference': {'reference_cnn': cnn, 'reference_fasta': fasta}};
+                      return {'cnn_file': cnn, 'fasta_file': fasta};
                     }
         out:
             [cn_diagram, cn_scatter_plot, tumor_antitarget_coverage, tumor_target_coverage, tumor_bin_level_ratios, tumor_segmented_ratios]            

--- a/definitions/subworkflows/cnvkit_single_sample.cwl
+++ b/definitions/subworkflows/cnvkit_single_sample.cwl
@@ -70,8 +70,14 @@ steps:
             scatter_plot: scatter_plot
             drop_low_coverage: drop_low_coverage
             male_reference: male_reference
-            reference_cnn: reference_cnn
-            reference: fasta_reference
+            reference:
+                source: [reference_cnn, fasta_reference]
+                valueFrom: |
+                    ${
+                      var cnn = self[0];
+                      var fasta = self[1];
+                      return {'reference': {'reference_cnn': cnn, 'reference_fasta': fasta}};
+                    }
         out:
             [cn_diagram, cn_scatter_plot, tumor_antitarget_coverage, tumor_target_coverage, tumor_bin_level_ratios, tumor_segmented_ratios]            
             

--- a/definitions/subworkflows/cnvkit_single_sample.cwl
+++ b/definitions/subworkflows/cnvkit_single_sample.cwl
@@ -10,8 +10,10 @@ inputs:
     tumor_bam:
         type: File
     method:
-        type: string?
-        default: "hybrid"
+        type:
+          - "null"
+          - type: enum
+            symbols: ["hybrid", "amplicon", "wgs"]
     diagram:
         type: boolean?
     scatter_plot:

--- a/definitions/subworkflows/cnvkit_single_sample.cwl
+++ b/definitions/subworkflows/cnvkit_single_sample.cwl
@@ -7,6 +7,11 @@ requirements:
     - class: StepInputExpressionRequirement
 
 inputs:
+    fasta_reference:
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai]
     tumor_bam:
         type: File
     method:
@@ -66,6 +71,7 @@ steps:
             drop_low_coverage: drop_low_coverage
             male_reference: male_reference
             reference_cnn: reference_cnn
+            reference: fasta_reference
         out:
             [cn_diagram, cn_scatter_plot, tumor_antitarget_coverage, tumor_target_coverage, tumor_bin_level_ratios, tumor_segmented_ratios]            
             

--- a/definitions/subworkflows/cram_to_cnvkit.cwl
+++ b/definitions/subworkflows/cram_to_cnvkit.cwl
@@ -77,9 +77,15 @@ steps:
         run: ../tools/cnvkit_batch.cwl
         in:
             tumor_bam: tumor_cram_to_bam/bam
-            normal_bam: normal_cram_to_bam/bam
+            reference:
+                source: [normal_cram_to_bam/bam, reference]
+                valueFrom: |
+                    ${
+                      var normal = self[0];
+                      var fasta = self[1];
+                      return {'normal_bam': normal, 'fasta_file': fasta};
+                    }
             bait_intervals: bait_intervals
-            reference: reference
             access: access
             method: method
             diagram: diagram

--- a/definitions/subworkflows/single_sample_sv_callers.cwl
+++ b/definitions/subworkflows/single_sample_sv_callers.cwl
@@ -24,7 +24,10 @@ inputs:
     cnvkit_drop_low_coverage:
         type: boolean?
     cnvkit_method:
-        type: string?
+        type:
+          - "null"
+          - type: enum
+            symbols: ["hybrid", "amplicon", "wgs"]
     cnvkit_reference_cnn:
         type: File
     cnvkit_scatter_plot:

--- a/definitions/subworkflows/single_sample_sv_callers.cwl
+++ b/definitions/subworkflows/single_sample_sv_callers.cwl
@@ -167,6 +167,7 @@ steps:
             cnvkit_vcf_name: cnvkit_vcf_name
             segment_filter:
                 default: "cn"
+            fasta_reference: reference
         out:
             [cn_diagram, cn_scatter_plot, tumor_antitarget_coverage, tumor_target_coverage, tumor_bin_level_ratios, tumor_segmented_ratios, cnvkit_vcf]
     run_cnvkit_raw_bgzip:

--- a/definitions/subworkflows/single_sample_sv_callers.cwl
+++ b/definitions/subworkflows/single_sample_sv_callers.cwl
@@ -29,7 +29,7 @@ inputs:
           - type: enum
             symbols: ["hybrid", "amplicon", "wgs"]
     cnvkit_reference_cnn:
-        type: File
+        type: File?
     cnvkit_scatter_plot:
         type: boolean?
     cnvkit_male_reference:

--- a/definitions/subworkflows/sv_depth_caller_filter.cwl
+++ b/definitions/subworkflows/sv_depth_caller_filter.cwl
@@ -9,8 +9,6 @@ inputs:
         type: double?
     duplication_depth:
         type: double?
-    reference:
-        type: string
     min_sv_size:
         type: int?
     output_vcf_name:

--- a/definitions/subworkflows/sv_paired_read_caller_filter.cwl
+++ b/definitions/subworkflows/sv_paired_read_caller_filter.cwl
@@ -16,7 +16,10 @@ inputs:
     output_vcf_name:
         type: string?
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
     snps_vcf:
         type: File?
     sv_paired_count:

--- a/definitions/tools/annotsv.cwl
+++ b/definitions/tools/annotsv.cwl
@@ -3,7 +3,7 @@
 cwlVersion: v1.0
 class: CommandLineTool
 
-arguments: ["AnnotSV", "-bedtools", "/usr/bin/bedtools", "-outputDir", "$(runtime.outdir)"]
+arguments: ["/opt/AnnotSV_2.1/bin/AnnotSV", "-bedtools", "/usr/bin/bedtools", "-outputDir", "$(runtime.outdir)"]
 requirements:
     - class: ResourceRequirement
       ramMin: 8000

--- a/definitions/tools/cnvkit_batch.cwl
+++ b/definitions/tools/cnvkit_batch.cwl
@@ -32,14 +32,25 @@ inputs:
             position: 3
             prefix: "--targets"
     reference:
-        type:
-            - "null"
-            - string
-            - File
-        secondaryFiles: [.fai, ^.dict]
-        inputBinding:
-            position: 4
-            prefix: "--fasta"
+      type:
+        - type: record
+          name: cnn_file
+          fields:
+            cnn_file:
+              type: File?
+              inputBinding:
+                position: 11
+                prefix: "--reference"
+              doc: "Previously generated reference.cnn file"
+        - type: record
+          name: fasta_file
+          fields:
+            fasta_file:
+              type:
+                - string
+                - File
+              inputBinding:
+                prefix: "--fasta"
     access:
         type: File?
         inputBinding:
@@ -80,12 +91,6 @@ inputs:
             position: 10
             prefix: "--male-reference"
         doc: "Use or assume a male reference (i.e. female samples will have +1 log-CNR of chrX; otherwise male samples would have -1 chrX)"
-    reference_cnn:
-        type: File?
-        inputBinding:
-            position: 11
-            prefix: "--reference"
-        doc: "Previously generated reference.cnn file"
     target_average_size:
         type: int?
         inputBinding:

--- a/definitions/tools/cnvkit_batch.cwl
+++ b/definitions/tools/cnvkit_batch.cwl
@@ -13,6 +13,8 @@ requirements:
       ramMin: 4000
       tmpdirMin: 10000
     - class: InlineJavascriptRequirement
+arguments:
+    ["--normal"]
 inputs:
     tumor_bam:
         type: File

--- a/definitions/tools/cnvkit_batch.cwl
+++ b/definitions/tools/cnvkit_batch.cwl
@@ -66,20 +66,22 @@ inputs:
     drop_low_coverage:
         type: boolean?
         inputBinding:
-            position: 10
+            position: 9
             prefix: "--drop-low-coverage"
     male_reference:
         type: boolean?
         inputBinding:
+            position: 10
             prefix: "-y"
     reference_cnn:
         type: File?
         inputBinding:
+            position: 11
             prefix: "-r"
     target_average_size:
         type: int?
         inputBinding:
-            position: 5
+            position: 12
             prefix: "--target-avg-size"
 outputs:
     intervals_antitarget:

--- a/definitions/tools/cnvkit_batch.cwl
+++ b/definitions/tools/cnvkit_batch.cwl
@@ -13,22 +13,16 @@ requirements:
       ramMin: 4000
       tmpdirMin: 10000
     - class: InlineJavascriptRequirement
-arguments:
-    ["--normal"]
+arguments: [{ valueFrom: "$((inputs.reference.hasOwnProperty('cnn_file'))? '' : '--normal')" }]
 inputs:
     tumor_bam:
         type: File
         inputBinding:
             position: -1
-    normal_bam:
-        type: File?
-        inputBinding:
-            position: 1
-        doc: "Normal samples (.bam) used to construct the pooled, paired, or flat reference. If this option is used but no filenames are given, a 'flat' reference will be built. Otherwise, all filenames following this option will be used."
     bait_intervals:
         type: File?
         inputBinding:
-            position: 2
+            position: 3
             prefix: "--targets"
     reference:
       type:
@@ -36,9 +30,9 @@ inputs:
           name: cnn_file
           fields:
             cnn_file:
-              type: File?
+              type: File
               inputBinding:
-                position: 3
+                position: 2
                 prefix: "--reference"
               doc: "Previously generated reference.cnn file"
         - type: record
@@ -49,8 +43,13 @@ inputs:
                 - string
                 - File
               inputBinding:
-                position: 3
+                position: 2
                 prefix: "--fasta"
+            normal_bam:
+              type: File?
+              inputBinding:
+                position: 1
+              doc: "Normal samples (.bam) used to construct the pooled, paired, or flat reference. If this option is used but no filenames are given, a 'flat' reference will be built. Otherwise, all filenames following this option will be used."
     access:
         type: File?
         inputBinding:

--- a/definitions/tools/cnvkit_batch.cwl
+++ b/definitions/tools/cnvkit_batch.cwl
@@ -19,7 +19,7 @@ inputs:
     tumor_bam:
         type: File
         inputBinding:
-            position: 1
+            position: -1
     normal_bam:
         type: File?
         inputBinding:

--- a/definitions/tools/cnvkit_batch.cwl
+++ b/definitions/tools/cnvkit_batch.cwl
@@ -76,6 +76,11 @@ inputs:
         type: File?
         inputBinding:
             prefix: "-r"
+    target_average_size:
+        type: int?
+        inputBinding:
+            position: 5
+            prefix: "--target-avg-size"
 outputs:
     intervals_antitarget:
         type: File?

--- a/definitions/tools/cnvkit_batch.cwl
+++ b/definitions/tools/cnvkit_batch.cwl
@@ -23,13 +23,12 @@ inputs:
     normal_bam:
         type: File?
         inputBinding:
-            position: 2
-            prefix: "--normal"
+            position: 1
         doc: "Normal samples (.bam) used to construct the pooled, paired, or flat reference. If this option is used but no filenames are given, a 'flat' reference will be built. Otherwise, all filenames following this option will be used."
     bait_intervals:
         type: File?
         inputBinding:
-            position: 3
+            position: 2
             prefix: "--targets"
     reference:
       type:
@@ -39,7 +38,7 @@ inputs:
             cnn_file:
               type: File?
               inputBinding:
-                position: 11
+                position: 3
                 prefix: "--reference"
               doc: "Previously generated reference.cnn file"
         - type: record
@@ -50,11 +49,12 @@ inputs:
                 - string
                 - File
               inputBinding:
+                position: 3
                 prefix: "--fasta"
     access:
         type: File?
         inputBinding:
-            position: 5
+            position: 4
             prefix: "--access"
         doc: "Regions of accessible sequence on chromosomes (.bed), as output by the 'access' command"
     method:
@@ -64,37 +64,37 @@ inputs:
               symbols: ["hybrid", "amplicon", "wgs"]
         default: "hybrid"
         inputBinding:
-            position: 6
+            position: 5
             prefix: "--method"
         doc: "Sequencing protocol used for input data"
     diagram:
         type: boolean?
         inputBinding:
-            position: 7
+            position: 6
             prefix: "--diagram"
         doc: "Create an ideogram of copy ratios on chromosomes as a PDF"
     scatter_plot:
         type: boolean?
         inputBinding:
-            position: 8
+            position: 7
             prefix: "--scatter"
         doc: "Create a whole-genome copy ratio profile as a PDF scatter plot"
     drop_low_coverage:
         type: boolean?
         inputBinding:
-            position: 9
+            position: 8
             prefix: "--drop-low-coverage"
         doc: "Drop very-low-coverage bins before segmentation to avoid false-positive deletions in poor-quality tumor samples"
     male_reference:
         type: boolean?
         inputBinding:
-            position: 10
+            position: 9
             prefix: "--male-reference"
         doc: "Use or assume a male reference (i.e. female samples will have +1 log-CNR of chrX; otherwise male samples would have -1 chrX)"
     target_average_size:
         type: int?
         inputBinding:
-            position: 12
+            position: 10
             prefix: "--target-avg-size"
         doc: "Average size of split target bins (results are approximate)"
 outputs:

--- a/definitions/tools/cnvkit_batch.cwl
+++ b/definitions/tools/cnvkit_batch.cwl
@@ -25,6 +25,7 @@ inputs:
         inputBinding:
             position: 2
             prefix: "--normal"
+        doc: "Normal samples (.bam) used to construct the pooled, paired, or flat reference. If this option is used but no filenames are given, a 'flat' reference will be built. Otherwise, all filenames following this option will be used."
     bait_intervals:
         type: File?
         inputBinding:
@@ -44,6 +45,7 @@ inputs:
         inputBinding:
             position: 5
             prefix: "--access"
+        doc: "Regions of accessible sequence on chromosomes (.bed), as output by the 'access' command"
     method:
         type:
             - "null"
@@ -53,36 +55,43 @@ inputs:
         inputBinding:
             position: 6
             prefix: "--method"
+        doc: "Sequencing protocol used for input data"
     diagram:
         type: boolean?
         inputBinding:
             position: 7
             prefix: "--diagram"
+        doc: "Create an ideogram of copy ratios on chromosomes as a PDF"
     scatter_plot:
         type: boolean?
         inputBinding:
             position: 8
             prefix: "--scatter"
+        doc: "Create a whole-genome copy ratio profile as a PDF scatter plot"
     drop_low_coverage:
         type: boolean?
         inputBinding:
             position: 9
             prefix: "--drop-low-coverage"
+        doc: "Drop very-low-coverage bins before segmentation to avoid false-positive deletions in poor-quality tumor samples"
     male_reference:
         type: boolean?
         inputBinding:
             position: 10
-            prefix: "-y"
+            prefix: "--male-reference"
+        doc: "Use or assume a male reference (i.e. female samples will have +1 log-CNR of chrX; otherwise male samples would have -1 chrX)"
     reference_cnn:
         type: File?
         inputBinding:
             position: 11
-            prefix: "-r"
+            prefix: "--reference"
+        doc: "Previously generated reference.cnn file"
     target_average_size:
         type: int?
         inputBinding:
             position: 12
             prefix: "--target-avg-size"
+        doc: "Average size of split target bins (results are approximate)"
 outputs:
     intervals_antitarget:
         type: File?

--- a/definitions/tools/cnvkit_batch.cwl
+++ b/definitions/tools/cnvkit_batch.cwl
@@ -43,7 +43,10 @@ inputs:
             position: 5
             prefix: "--access"
     method:
-        type: string?
+        type:
+            - "null"
+            - type: enum
+              symbols: ["hybrid", "amplicon", "wgs"]
         default: "hybrid"
         inputBinding:
             position: 6

--- a/definitions/tools/cnvkit_batch.cwl
+++ b/definitions/tools/cnvkit_batch.cwl
@@ -13,7 +13,7 @@ requirements:
       ramMin: 4000
       tmpdirMin: 10000
     - class: InlineJavascriptRequirement
-arguments: [{ valueFrom: "$((inputs.reference.hasOwnProperty('cnn_file'))? '' : '--normal')" }]
+arguments: [{ valueFrom: "$((inputs.reference.hasOwnProperty('cnn_file'))? null : '--normal')" }]
 inputs:
     tumor_bam:
         type: File

--- a/definitions/tools/cnvnator.cwl
+++ b/definitions/tools/cnvnator.cwl
@@ -70,7 +70,10 @@ inputs:
            itemSeparator: " "
         doc: "List of chromosomes to run CNVnator on"
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai]
         inputBinding:
             position: 4
         doc: "Reference used to generate the alignments"

--- a/definitions/tools/duphold.cwl
+++ b/definitions/tools/duphold.cwl
@@ -27,7 +27,10 @@ inputs:
             prefix: "--output"
         doc: "output vcf file name"
     reference:
-        type: string
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
         inputBinding:
             position: 3
             prefix: "--fasta"

--- a/example_data/germline_wgs.yaml
+++ b/example_data/germline_wgs.yaml
@@ -41,9 +41,14 @@ synonyms_file:
   class: File
   path: exome_workflow/chromAlias.ensembl.txt
 variant_reporting_intervals:
-    class: File
-    path: exome_workflow/chr17_test_genes.interval_list
-vep_cache_dir: /gscmnt/gc2764/cad/jgarza/shared/exome_workflow
+  class: File
+  path: exome_workflow/chr17_test_genes.interval_list
+vep_cache_dir:
+  class: Directory
+  path: 'exome_workflow'
+vep_ensembl_species: 'homo_sapiens'
+vep_ensembl_version: '95'
+vep_ensembl_assembly: 'GRCh38'
 vep_custom_annotations:
 - method: 'exact'
   force_report_coordinates: true
@@ -57,3 +62,10 @@ vep_custom_annotations:
     vcf_fields: ['AF','AF_AFR','AF_AMR','AF_ASJ','AF_EAS','AF_FIN','AF_NFE','AF_OTH','AF_SAS']
     gnomad_filter: true
     check_existing: true
+manta_output_contigs: 'true'
+merge_estimate_sv_distance: 'true'
+merge_max_distance: 1000
+merge_min_sv_size: 1
+merge_min_svs: 1
+merge_same_strand: 'true'
+merge_same_type: 'true'


### PR DESCRIPTION
This PR has multiple updates:
* updates cnvkit to default to flat reference
  this allows the SV callers to run without providing a `reference.cnn` input (#726)
* adds cnvkit input `target_average_size `
  I have not linked this in with the pipeline. 
* makes the cnvkit `method` input an enum
* remove default method for cnvkit single sample
  the cnvkit batch tool already has the `hybrid` default
* make `wgs` default method for cnvkit in wgs pipeline
* add some cnvkit input doc lines at the tool level
* update AnnotSV tool to use full path
* update some reference inputs in sv tools to allow `File` or `string`
* updated example `germline_wgs.yaml`
  the exome bams used previously cannot succeed in Smoove (#837)
  the somatic wgs example yaml references `/gscmnt/gc2560/core/cwl/example_data/HCC1395_normal_downsampled_wgs.bam` 
  The workflow is able to succeed using that bam and full GRCh38 reference. Should it be added to the repo or hosted elsewhere? 
