### PR TITLE
Globally update VEP version from 93 to 95 for consistency

### DIFF
--- a/definitions/tools/filter_vcf_coding_variant.cwl
+++ b/definitions/tools/filter_vcf_coding_variant.cwl
@@ -6,7 +6,7 @@ label: "Coding Variant filter"
 baseCommand: ["/usr/bin/perl", "/usr/bin/vcf_check.pl"]
 requirements:
     - class: DockerRequirement
-      dockerPull: "mgibio/vep_helper-cwl:1.0.0"
+      dockerPull: "mgibio/vep_helper-cwl:1.1.0"
     - class: ResourceRequirement
       ramMin: 4000
 arguments:

--- a/definitions/tools/filter_vcf_custom_allele_freq.cwl
+++ b/definitions/tools/filter_vcf_custom_allele_freq.cwl
@@ -7,7 +7,7 @@ baseCommand: ["/usr/bin/perl", "/usr/bin/vcf_check.pl"]
 requirements:
     - class: InlineJavascriptRequirement
     - class: DockerRequirement
-      dockerPull: "mgibio/vep_helper-cwl:1.0.0"
+      dockerPull: "mgibio/vep_helper-cwl:1.1.0"
     - class: ResourceRequirement
       ramMin: 4000
     - class: StepInputExpressionRequirement


### PR DESCRIPTION
By default, VEP attempts to use a cache version corresponding to VEP's version. `mgibio/vep_helper-cwl:1.0.0` contains VEP v93, while `mgibio/vep_helper-cwl:1.1.0` contains VEP v95. Our main VEP tool, `tools/vep.cwl`, was updated to version 95 some time ago, but `tools/filter_vcf_coding_variant.cwl` and `tools/filter_vcf_custom_allele_freq.cwl` were not. This means any pipeline using both `tools/vep.cwl` and one of the two above was using different VEP caches at different steps; I'm not sure what effect this will have had. `vep.cwl` is already explicitly using VEP's `--cache_version` option; we may want to add it to these 2 tools as well.