### PR TITLE
ensure unique output names to prevent gms staging failures

### DIFF
--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -696,15 +696,9 @@ outputs:
     annotated_tsv:
         type: File
         outputSource: pvacseq/annotated_tsv
-    mhc_i_epitopes:
-        type: Directory?
-        outputSource: pvacseq/mhc_i_epitopes
-    mhc_ii_epitopes:
-        type: Directory?
-        outputSource: pvacseq/mhc_ii_epitopes
-    combined_epitopes:
-        type: Directory?
-        outputSource: pvacseq/combined_epitopes
+    pvacseq_epitopes:
+        type: Directory
+        outputSource: pvacseq/pvacseq_epitopes
 steps:
     rnaseq:
         run: rnaseq.cwl
@@ -885,4 +879,4 @@ steps:
             variants_to_table_genotype_fields: variants_to_table_genotype_fields
             vep_to_table_fields: vep_to_table_fields
         out:
-            [annotated_vcf, annotated_tsv, mhc_i_epitopes, mhc_ii_epitopes, combined_epitopes]
+            [annotated_vcf, annotated_tsv, pvacseq_epitopes]

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -696,33 +696,15 @@ outputs:
     annotated_tsv:
         type: File
         outputSource: pvacseq/annotated_tsv
-    mhc_i_all_epitopes:
-        type: File?
-        outputSource: pvacseq/mhc_i_all_epitopes
-    mhc_i_filtered_epitopes:
-        type: File?
-        outputSource: pvacseq/mhc_i_filtered_epitopes
-    mhc_i_ranked_epitopes:
-        type: File?
-        outputSource: pvacseq/mhc_i_ranked_epitopes
-    mhc_ii_all_epitopes:
-        type: File?
-        outputSource: pvacseq/mhc_ii_all_epitopes
-    mhc_ii_filtered_epitopes:
-        type: File?
-        outputSource: pvacseq/mhc_ii_filtered_epitopes
-    mhc_ii_ranked_epitopes:
-        type: File?
-        outputSource: pvacseq/mhc_ii_ranked_epitopes
-    combined_all_epitopes:
-        type: File?
-        outputSource: pvacseq/combined_all_epitopes
-    combined_filtered_epitopes:
-        type: File?
-        outputSource: pvacseq/combined_filtered_epitopes
-    combined_ranked_epitopes:
-        type: File?
-        outputSource: pvacseq/combined_ranked_epitopes
+    mhc_i_epitopes:
+        type: Directory?
+        outputSource: pvacseq/mhc_i_epitopes
+    mhc_ii_epitopes:
+        type: Directory?
+        outputSource: pvacseq/mhc_ii_epitopes
+    combined_epitopes:
+        type: Directory?
+        outputSource: pvacseq/combined_epitopes
 steps:
     rnaseq:
         run: rnaseq.cwl
@@ -903,4 +885,4 @@ steps:
             variants_to_table_genotype_fields: variants_to_table_genotype_fields
             vep_to_table_fields: vep_to_table_fields
         out:
-            [annotated_vcf, annotated_tsv, mhc_i_all_epitopes, mhc_i_filtered_epitopes, mhc_i_ranked_epitopes, mhc_ii_all_epitopes, mhc_ii_filtered_epitopes, mhc_ii_ranked_epitopes, combined_all_epitopes, combined_filtered_epitopes, combined_ranked_epitopes]
+            [annotated_vcf, annotated_tsv, mhc_i_epitopes, mhc_ii_epitopes, combined_epitopes]

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -696,9 +696,9 @@ outputs:
     annotated_tsv:
         type: File
         outputSource: pvacseq/annotated_tsv
-    pvacseq_epitopes:
+    pvacseq_predictions:
         type: Directory
-        outputSource: pvacseq/pvacseq_epitopes
+        outputSource: pvacseq/pvacseq_predictions
 steps:
     rnaseq:
         run: rnaseq.cwl
@@ -879,4 +879,4 @@ steps:
             variants_to_table_genotype_fields: variants_to_table_genotype_fields
             vep_to_table_fields: vep_to_table_fields
         out:
-            [annotated_vcf, annotated_tsv, pvacseq_epitopes]
+            [annotated_vcf, annotated_tsv, pvacseq_predictions]

--- a/definitions/subworkflows/pvacseq.cwl
+++ b/definitions/subworkflows/pvacseq.cwl
@@ -113,33 +113,15 @@ outputs:
     annotated_tsv:
         type: File
         outputSource: add_vep_fields_to_table/annotated_variants_tsv
-    mhc_i_all_epitopes:
-        type: File?
-        outputSource: pvacseq/mhc_i_all_epitopes
-    mhc_i_filtered_epitopes:
-        type: File?
-        outputSource: pvacseq/mhc_i_filtered_epitopes
-    mhc_i_ranked_epitopes:
-        type: File?
-        outputSource: pvacseq/mhc_i_ranked_epitopes
-    mhc_ii_all_epitopes:
-        type: File?
-        outputSource: pvacseq/mhc_ii_all_epitopes
-    mhc_ii_filtered_epitopes:
-        type: File?
-        outputSource: pvacseq/mhc_ii_filtered_epitopes
-    mhc_ii_ranked_epitopes:
-        type: File?
-        outputSource: pvacseq/mhc_ii_ranked_epitopes
-    combined_all_epitopes:
-        type: File?
-        outputSource: pvacseq/combined_all_epitopes
-    combined_filtered_epitopes:
-        type: File?
-        outputSource: pvacseq/combined_filtered_epitopes
-    combined_ranked_epitopes:
-        type: File?
-        outputSource: pvacseq/combined_ranked_epitopes
+    mhc_i_epitopes:
+        type: Directory?
+        outputSource: pvacseq/mhc_i_epitopes
+    mhc_ii_epitopes:
+        type: Directory?
+        outputSource: pvacseq/mhc_ii_epitopes
+    combined_epitopes:
+        type: Directory?
+        outputSource: pvacseq/combined_epitopes
 steps:
     tumor_rna_bam_readcount:
         run: bam_readcount.cwl
@@ -221,17 +203,7 @@ steps:
             netmhc_stab: netmhc_stab
             n_threads: n_threads
         out:
-            [
-                mhc_i_all_epitopes,
-                mhc_i_filtered_epitopes,
-                mhc_i_ranked_epitopes,
-                mhc_ii_all_epitopes,
-                mhc_ii_filtered_epitopes,
-                mhc_ii_ranked_epitopes,
-                combined_all_epitopes,
-                combined_filtered_epitopes,
-                combined_ranked_epitopes,
-            ]
+            [mhc_i_epitopes, mhc_ii_epitopes, combined_epitopes]
     variants_to_table:
         run: ../tools/variants_to_table.cwl
         in:

--- a/definitions/subworkflows/pvacseq.cwl
+++ b/definitions/subworkflows/pvacseq.cwl
@@ -113,15 +113,9 @@ outputs:
     annotated_tsv:
         type: File
         outputSource: add_vep_fields_to_table/annotated_variants_tsv
-    mhc_i_epitopes:
-        type: Directory?
-        outputSource: pvacseq/mhc_i_epitopes
-    mhc_ii_epitopes:
-        type: Directory?
-        outputSource: pvacseq/mhc_ii_epitopes
-    combined_epitopes:
-        type: Directory?
-        outputSource: pvacseq/combined_epitopes
+    pvacseq_epitopes:
+        type: Directory
+        outputSource: pvacseq/pvacseq_epitopes
 steps:
     tumor_rna_bam_readcount:
         run: bam_readcount.cwl
@@ -203,7 +197,7 @@ steps:
             netmhc_stab: netmhc_stab
             n_threads: n_threads
         out:
-            [mhc_i_epitopes, mhc_ii_epitopes, combined_epitopes]
+            [pvacseq_epitopes]
     variants_to_table:
         run: ../tools/variants_to_table.cwl
         in:

--- a/definitions/subworkflows/pvacseq.cwl
+++ b/definitions/subworkflows/pvacseq.cwl
@@ -113,9 +113,9 @@ outputs:
     annotated_tsv:
         type: File
         outputSource: add_vep_fields_to_table/annotated_variants_tsv
-    pvacseq_epitopes:
+    pvacseq_predictions:
         type: Directory
-        outputSource: pvacseq/pvacseq_epitopes
+        outputSource: pvacseq/pvacseq_predictions
 steps:
     tumor_rna_bam_readcount:
         run: bam_readcount.cwl
@@ -197,7 +197,7 @@ steps:
             netmhc_stab: netmhc_stab
             n_threads: n_threads
         out:
-            [pvacseq_epitopes]
+            [pvacseq_predictions]
     variants_to_table:
         run: ../tools/variants_to_table.cwl
         in:

--- a/definitions/tools/pvacseq.cwl
+++ b/definitions/tools/pvacseq.cwl
@@ -16,7 +16,7 @@ arguments: [
     "/opt/conda/bin/pvacseq", "run",
     "--iedb-install-directory", "/opt/iedb",
     "--pass-only",
-    { position: 5, valueFrom: "pvacseq_epitopes" },
+    { position: 5, valueFrom: "pvacseq_predictions" },
 ]
 requirements:
     - class: ShellCommandRequirement
@@ -167,7 +167,7 @@ inputs:
             prefix: "--n-threads"
         default: 8
 outputs:
-    pvacseq_epitopes:
+    pvacseq_predictions:
         type: Directory
         outputBinding:
-            glob: "pvacseq_epitopes"
+            glob: "pvacseq_predictions"

--- a/definitions/tools/pvacseq.cwl
+++ b/definitions/tools/pvacseq.cwl
@@ -16,7 +16,7 @@ arguments: [
     "/opt/conda/bin/pvacseq", "run",
     "--iedb-install-directory", "/opt/iedb",
     "--pass-only",
-    { position: 5, valueFrom: $(runtime.outdir) },
+    { position: 5, valueFrom: "pvacseq_epitopes" },
 ]
 requirements:
     - class: ShellCommandRequirement
@@ -167,15 +167,7 @@ inputs:
             prefix: "--n-threads"
         default: 8
 outputs:
-    mhc_i_epitopes:
-        type: Directory?
+    pvacseq_epitopes:
+        type: Directory
         outputBinding:
-            glob: "MHC_Class_I"
-    mhc_ii_epitopes:
-        type: Directory?
-        outputBinding:
-            glob: "MHC_Class_II"
-    combined_epitopes:
-        type: Directory?
-        outputBinding:
-            glob: "combined"
+            glob: "pvacseq_epitopes"

--- a/definitions/tools/pvacseq.cwl
+++ b/definitions/tools/pvacseq.cwl
@@ -167,6 +167,42 @@ inputs:
             prefix: "--n-threads"
         default: 8
 outputs:
+    mhc_i_all_epitopes:
+        type: File?
+        outputBinding:
+            glob: "pvacseq_predictions/MHC_Class_I/$(inputs.sample_name).all_epitopes.tsv"
+    mhc_i_filtered_epitopes:
+        type: File?
+        outputBinding:
+            glob: "pvacseq_predictions/MHC_Class_I/$(inputs.sample_name).filtered.tsv"
+    mhc_i_ranked_epitopes:
+        type: File?
+        outputBinding:
+            glob: "pvacseq_predictions/MHC_Class_I/$(inputs.sample_name).filtered.condensed.ranked.tsv"
+    mhc_ii_all_epitopes:
+        type: File?
+        outputBinding:
+            glob: "pvacseq_predictions/MHC_Class_II/$(inputs.sample_name).all_epitopes.tsv"
+    mhc_ii_filtered_epitopes:
+        type: File?
+        outputBinding:
+            glob: "pvacseq_predictions/MHC_Class_II/$(inputs.sample_name).filtered.tsv"
+    mhc_ii_ranked_epitopes:
+        type: File?
+        outputBinding:
+            glob: "pvacseq_predictions/MHC_Class_II/$(inputs.sample_name).filtered.condensed.ranked.tsv"
+    combined_all_epitopes:
+        type: File?
+        outputBinding:
+            glob: "pvacseq_predictions/combined/$(inputs.sample_name).all_epitopes.tsv"
+    combined_filtered_epitopes:
+        type: File?
+        outputBinding:
+            glob: "pvacseq_predictions/combined/$(inputs.sample_name).filtered.tsv"
+    combined_ranked_epitopes:
+        type: File?
+        outputBinding:
+            glob: "pvacseq_predictions/combined/$(inputs.sample_name).filtered.condensed.ranked.tsv"
     pvacseq_predictions:
         type: Directory
         outputBinding:

--- a/definitions/tools/pvacseq.cwl
+++ b/definitions/tools/pvacseq.cwl
@@ -167,39 +167,15 @@ inputs:
             prefix: "--n-threads"
         default: 8
 outputs:
-    mhc_i_all_epitopes:
-        type: File?
+    mhc_i_epitopes:
+        type: Directory?
         outputBinding:
-            glob: "MHC_Class_I/$(inputs.sample_name).all_epitopes.tsv"
-    mhc_i_filtered_epitopes:
-        type: File?
+            glob: "MHC_Class_I"
+    mhc_ii_epitopes:
+        type: Directory?
         outputBinding:
-            glob: "MHC_Class_I/$(inputs.sample_name).filtered.tsv"
-    mhc_i_ranked_epitopes:
-        type: File?
+            glob: "MHC_Class_II"
+    combined_epitopes:
+        type: Directory?
         outputBinding:
-            glob: "MHC_Class_I/$(inputs.sample_name).filtered.condensed.ranked.tsv"
-    mhc_ii_all_epitopes:
-        type: File?
-        outputBinding:
-            glob: "MHC_Class_II/$(inputs.sample_name).all_epitopes.tsv"
-    mhc_ii_filtered_epitopes:
-        type: File?
-        outputBinding:
-            glob: "MHC_Class_II/$(inputs.sample_name).filtered.tsv"
-    mhc_ii_ranked_epitopes:
-        type: File?
-        outputBinding:
-            glob: "MHC_Class_II/$(inputs.sample_name).filtered.condensed.ranked.tsv"
-    combined_all_epitopes:
-        type: File?
-        outputBinding:
-            glob: "combined/$(inputs.sample_name).all_epitopes.tsv"
-    combined_filtered_epitopes:
-        type: File?
-        outputBinding:
-            glob: "combined/$(inputs.sample_name).filtered.tsv"
-    combined_ranked_epitopes:
-        type: File?
-        outputBinding:
-            glob: "combined/$(inputs.sample_name).filtered.condensed.ranked.tsv"
+            glob: "combined"


### PR DESCRIPTION
Current GMS immuno builds are failing because pvacseq outputs 3 sets of 3 files, where each set contains files with identical names. Pvacseq outputs these into 3 subdirectories, but the cwl extracts each file individually, causing naming collisions. Renaming the files could work, as described in the "Rename an output file" section [here](https://www.commonwl.org/user_guide/misc/); however, Cromwell does not support this option. In order to avoid sending each of these 9 files to a tool just to rename, I opted to instead just grab each of the 3 output directories. They do include some additional temp and log files, but they aren't very large and can easily be cleaned up later.