### PR TITLE
Restrict input VCFs with ROI bed first

### DIFF
--- a/definitions/subworkflows/vcf_eval_concordance.cwl
+++ b/definitions/subworkflows/vcf_eval_concordance.cwl
@@ -82,6 +82,25 @@ steps:
                 default: true
         out:
             [filtered_vcf]
+    base_vcf_pass_roi:
+        run: ../tools/bedtools_intersect.cwl
+        in:
+            file_a: base_vcf_pass/filtered_vcf
+            file_b: roi_bed
+            output_file_a:
+                default: false
+            unique_result:
+                default: false
+            output_name:
+                default: 'base_pass_roi.vcf'
+        out:
+            [intersect_result]
+    bgzip_and_index_base_pass_roi:
+        run: bgzip_and_index.cwl
+        in:
+            vcf: base_vcf_pass_roi/intersect_result
+        out:
+            [indexed_vcf]
     query_vcf_pass:
         run: ../tools/select_variants.cwl
         in:
@@ -91,12 +110,31 @@ steps:
                 default: true
         out:
             [filtered_vcf]
+    query_vcf_pass_roi:
+        run: ../tools/bedtools_intersect.cwl
+        in:
+            file_a: query_vcf_pass/filtered_vcf
+            file_b: roi_bed
+            output_file_a:
+                default: false
+            unique_result:
+                default: false
+            output_name:
+                default: 'query_pass_roi.vcf'
+        out:
+            [intersect_result]
+    bgzip_and_index_query_pass_roi:
+        run: bgzip_and_index.cwl
+        in:
+            vcf: query_vcf_pass_roi/intersect_result
+        out:
+            [indexed_vcf]
     combine_vcf:
         run: ../tools/combine_variants_concordance.cwl
         in:
             reference: reference
-            base_vcf: base_vcf_pass/filtered_vcf
-            query_vcf:  query_vcf_pass/filtered_vcf
+            base_vcf: bgzip_and_index_base_pass_roi/indexed_vcf
+            query_vcf: bgzip_and_index_query_pass_roi/indexed_vcf
         out:
             [combined_vcf]
     base_normal_bam_readcount:


### PR DESCRIPTION
Input VCFs (gold vcf, query vcf, base vcf) need to be restricted with ROI bed first before further process. This change is tested ok with real data in https://jira.ris.wustl.edu/browse/CI-433. Also refer to https://jira.ris.wustl.edu/browse/CI-421 for workflow development.