### PR TITLE
Better handling of MHC Class II alleles

### DIFF
--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -288,11 +288,14 @@ inputs:
     reference_dict:
         type: File
 
-    clinical_hla_alleles:
+    clinical_MHCcI_alleles:
         type: string[]?
-        label: "clinical_calls: Clinical HLA typing results; element format: HLA-X*01:02[/HLA-X...]"
-        doc: |
-          clinical_calls is used to provide clinical HLA typing results in the format HLA-X*01:02[/HLA-X...] when available.
+        label: "Clinical HLA typing results, limited to MHC Class I alleles; element format: HLA-X*01:02[/HLA-X...]"
+        doc: "used to provide clinical HLA typing results in the format HLA-X*01:02[/HLA-X...] when available."
+    clinical_MHCcII_alleles:
+        type: string[]?
+        label: "Clinical HLA typing results, limited to MHC Class II alleles"
+        doc: "clinical_calls is used to provide clinical HLA typing results; separated from class I due to nomenclature inconsistencies"
 
     #pvacseq inputs
     readcount_minimum_base_quality:
@@ -859,7 +862,8 @@ steps:
         run: ../tools/hla_consensus.cwl
         in:
             optitype_hla_alleles: extract_alleles/allele_string
-            clinical_hla_alleles: clinical_hla_alleles
+            clinical_MHCcI_alleles: clinical_MHCcI_alleles
+            clinical_MHCcII_alleles: clinical_MHCcII_alleles
         out:
             [consensus_alleles, hla_call_files]
     pvacseq:

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -288,14 +288,14 @@ inputs:
     reference_dict:
         type: File
 
-    clinical_MHCcI_alleles:
+    clinical_mhc_classI_alleles:
         type: string[]?
         label: "Clinical HLA typing results, limited to MHC Class I alleles; element format: HLA-X*01:02[/HLA-X...]"
         doc: "used to provide clinical HLA typing results in the format HLA-X*01:02[/HLA-X...] when available."
-    clinical_MHCcII_alleles:
+    clinical_mhc_classII_alleles:
         type: string[]?
         label: "Clinical HLA typing results, limited to MHC Class II alleles"
-        doc: "clinical_calls is used to provide clinical HLA typing results; separated from class I due to nomenclature inconsistencies"
+        doc: "used to provide clinical HLA typing results; separated from class I due to nomenclature inconsistencies"
 
     #pvacseq inputs
     readcount_minimum_base_quality:
@@ -862,8 +862,8 @@ steps:
         run: ../tools/hla_consensus.cwl
         in:
             optitype_hla_alleles: extract_alleles/allele_string
-            clinical_MHCcI_alleles: clinical_MHCcI_alleles
-            clinical_MHCcII_alleles: clinical_MHCcII_alleles
+            clinical_mhc_classI_alleles: clinical_mhc_classI_alleles
+            clinical_mhc_classII_alleles: clinical_mhc_classII_alleles
         out:
             [consensus_alleles, hla_call_files]
     pvacseq:

--- a/definitions/tools/hla_consensus.cwl
+++ b/definitions/tools/hla_consensus.cwl
@@ -88,12 +88,13 @@ requirements:
                         optitype_calls = sys.argv[1].split(",")
 
                         if clinical_exists:
-                            raw_clinical_calls = sys.argv[2].split(",")
+                            raw_clinical_i_calls = sys.argv[2].split(",") #MHC Class I clinical typing results
+                            raw_clinical_ii_calls = sys.argv[3].split(",") #MHC Class II clinical typing results
                             #Each clinical call may be a single high confidence call,
                             #or a list of uncertain calls separated by slashes
                             hc_clinical_calls = []
                             u_clinical_calls = []
-                            for call in raw_clinical_calls:
+                            for call in raw_clinical_i_calls:
                                 if "/" in call:
                                     u_clinical_calls.append(call)
                                 else:
@@ -180,7 +181,7 @@ requirements:
                         #other relevant files for convenience/later review.
                         if clinical_exists:
                             with open("hla_calls/clinical_calls.txt", "w") as c_c:
-                                c_c.write( ",".join(raw_clinical_calls) )
+                                c_c.write( ",".join(raw_clinical_i_calls + raw_clinical_ii_calls) )
 
                         #########################################################
                         ### Generate consensus (superset if callers disagree) ###
@@ -205,6 +206,7 @@ requirements:
                                 c_c.write( ",".join(optitype_calls) )
                         else:
                             consensus_calls = []
+                            consensus_calls.extend(raw_clinical_ii_calls)
                             mismatch_written = False
                             for gene in hla_calls:
                                 mismatches = {'optitype': [], 'clinical': []}
@@ -217,7 +219,7 @@ requirements:
                                         #resulting in leaves with empty sets; these can be ignored
                                         if callers:
                                             #there are now only 3 possibilities for the contents of $callers:
-                                            #{optitype, clinical}, {optitype}, {clinical}
+                                            #[optitype, clinical], [optitype], [clinical]
                                             #all will be added to the consensus, possibly creating a superset
                                             #those with only 1 caller represent mismatches between the 2
                                             consensus_calls.append( build_hla_str(gene, allele_group, spec_allele) )
@@ -237,7 +239,13 @@ inputs:
             position: 1
             itemSeparator: ','
             separate: false
-    clinical_hla_alleles:
+    clinical_MHCcI_alleles:
+        type: string[]?
+        inputBinding:
+            position: 2
+            itemSeparator: ','
+            separate: false
+    clinical_MHCcII_alleles:
         type: string[]?
         inputBinding:
             position: 2

--- a/definitions/tools/hla_consensus.cwl
+++ b/definitions/tools/hla_consensus.cwl
@@ -239,16 +239,16 @@ inputs:
             position: 1
             itemSeparator: ','
             separate: false
-    clinical_MHCcI_alleles:
+    clinical_mhc_classI_alleles:
         type: string[]?
         inputBinding:
             position: 2
             itemSeparator: ','
             separate: false
-    clinical_MHCcII_alleles:
+    clinical_mhc_classII_alleles:
         type: string[]?
         inputBinding:
-            position: 2
+            position: 3
             itemSeparator: ','
             separate: false
 outputs:


### PR DESCRIPTION
MHC class I alleles follow a standard nomenclature, but not all class II alleles follow it. This, in addition to the notation used for uncertain clinical calls and paired class II alleles, makes parsing a single input difficult. Breaking up the input into class I and class II allows most of the current parsing script to remain usable, while eliminating most of the edge cases caused by class II alleles.