### PR TITLE
VCF Sanitize: JS fixes

### DIFF
--- a/definitions/tools/vcf_sanitize.cwl
+++ b/definitions/tools/vcf_sanitize.cwl
@@ -5,6 +5,7 @@ class: CommandLineTool
 label: "Sanitize a VCF"
 baseCommand: ["/bin/bash","sanitize.sh"]
 requirements:
+    - class: InlineJavascriptRequirement
     - class: ResourceRequirement
       ramMin: 4000
       coresMin: 1

--- a/definitions/tools/vcf_sanitize.cwl
+++ b/definitions/tools/vcf_sanitize.cwl
@@ -45,7 +45,7 @@ outputs:
         outputBinding:
             glob: |
                   ${
-                    if(inputs.vcf.nameext.equals(".gz")){
+                    if(inputs.vcf.nameext === ".gz"){
                       return inputs.vcf.nameroot.replace(/.vcf$/, "") + ".sanitized.vcf.gz";
                     }
                     return inputs.vcf.nameroot + ".sanitized.vcf.gz";


### PR DESCRIPTION
Closes #895 by adding in the missing requirement and using the `===` seen elsewhere in our code instead of `.equals` (which my browser tells me is not a function on strings :smile:).