### PR TITLE
Adds cram support and new readcount merging tool

### DIFF
--- a/definitions/subworkflows/bam_readcount_multisample.cwl
+++ b/definitions/subworkflows/bam_readcount_multisample.cwl
@@ -6,15 +6,17 @@ label: "given a VCF, gets readcounts from each of a list of samples' bam/cram fi
 requirements:
     - class: SubworkflowFeatureRequirement
     - class: ScatterFeatureRequirement
+    - class: InlineJavascriptRequirement
 inputs:
     vcf:
         type: File
         secondaryFiles: [.tbi]
     sample_names:
-        type: [string]
+        type: string[]
     bams:
-        type: [File]
-        secondaryFiles: [.bai, .crai]
+        type: File[]
+        secondaryFiles: ${if (self.nameext === ".bam") {return self.basename + ".bai"} else {return self.basename + ".crai"}}
+        doc: accepts either bam or cram
     reference_fasta:
         type:
             - string
@@ -30,9 +32,9 @@ inputs:
               symbols: ["DNA", "RNA"]
         doc: for now, this only accepts either "DNA" or "RNA" and assumes it applies to all samples/bams to avoid having to pass in an array
 outputs:
-    merged_readcount_vcf:
+    readcount_vcf:
         type: File
-        outputSource: ##bam_readcount/indel_bam_readcount_tsv
+        outputSource: merge_vcfs/merged_vcf
 steps:
     get_readcounts:
         scatter: [bam, sample_name]
@@ -47,21 +49,21 @@ steps:
             min_mapping_quality: min_mapping_quality
             data_type: data_type
         out:
-            [readcount_vcfs, sample_names]
+            [readcount_vcf]
 
     subset_vcfs_by_sample:
         scatter: [vcf, sample_name]
         scatterMethod: dotproduct
-        run: tools/subset_vcf_by_sample.cwl
+        run: ../tools/subset_vcf_by_sample.cwl
         in:
-            vcf: get_readcounts/readcount_vcfs
-            sample_names: get_readcounts/sample_names
+            vcf: get_readcounts/readcount_vcf
+            sample_name: sample_names
         out:
-            [subset_vcfs]
+            [subset_vcf]
 
     merge_vcfs:
-        run: ../tools/merge.cwl
+        run: ../tools/merge_vcf.cwl
         in:
-            vcfs: subset_vcfs_by_sample/subset_vcfs
+            vcfs: subset_vcfs_by_sample/subset_vcf
         out:
             [merged_vcf]

--- a/definitions/subworkflows/bam_readcount_multisample.cwl
+++ b/definitions/subworkflows/bam_readcount_multisample.cwl
@@ -1,0 +1,67 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+label: "given a VCF, gets readcounts from each of a list of samples' bam/cram files and adds them to the VCF"
+requirements:
+    - class: SubworkflowFeatureRequirement
+    - class: ScatterFeatureRequirement
+inputs:
+    vcf:
+        type: File
+        secondaryFiles: [.tbi]
+    sample_names:
+        type: [string]
+    bams:
+        type: [File]
+        secondaryFiles: [.bai, .crai]
+    reference_fasta:
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
+    min_base_quality:
+        type: int?
+    min_mapping_quality:
+        type: int?
+    data_type:
+        type:
+            - type: enum
+              symbols: ["DNA", "RNA"]
+        doc: for now, this only accepts either "DNA" or "RNA" and assumes it applies to all samples/bams to avoid having to pass in an array
+outputs:
+    merged_readcount_vcf:
+        type: File
+        outputSource: ##bam_readcount/indel_bam_readcount_tsv
+steps:
+    get_readcounts:
+        scatter: [bam, sample_name]
+        scatterMethod: dotproduct
+        run: bam_readcount_to_vcf.cwl
+        in:
+            vcf: vcf
+            bam: bams
+            sample_name: sample_names
+            reference_fasta: reference_fasta
+            min_base_quality: min_base_quality
+            min_mapping_quality: min_mapping_quality
+            data_type: data_type
+        out:
+            [readcount_vcfs, sample_names]
+
+    subset_vcfs_by_sample:
+        scatter: [vcf, sample_name]
+        scatterMethod: dotproduct
+        run: tools/subset_vcf_by_sample.cwl
+        in:
+            vcf: get_readcounts/readcount_vcfs
+            sample_names: get_readcounts/sample_names
+        out:
+            [subset_vcfs]
+
+    merge_vcfs:
+        run: ../tools/merge.cwl
+        in:
+            vcfs: subset_vcfs_by_sample/subset_vcfs
+        out:
+            [merged_vcf]

--- a/definitions/subworkflows/bam_readcount_multisample.cwl
+++ b/definitions/subworkflows/bam_readcount_multisample.cwl
@@ -34,7 +34,9 @@ inputs:
 outputs:
     readcount_vcf:
         type: File
-        outputSource: merge_vcfs/merged_vcf
+        outputSource: index/indexed_vcf
+        secondaryFiles: [.tbi]
+
 steps:
     get_readcounts:
         scatter: [bam, sample_name]
@@ -67,3 +69,10 @@ steps:
             vcfs: subset_vcfs_by_sample/subset_vcf
         out:
             [merged_vcf]
+
+    index:
+        run: bgzip_and_index.cwl
+        in:
+            vcf: merge_vcfs/merged_vcf
+        out:
+            [indexed_vcf]

--- a/definitions/subworkflows/bam_readcount_to_vcf.cwl
+++ b/definitions/subworkflows/bam_readcount_to_vcf.cwl
@@ -5,6 +5,7 @@ class: Workflow
 label: "Get snv and indel readcounts for one sample and one bam and add them to a vcf"
 requirements:
     - class: SubworkflowFeatureRequirement
+    - class: InlineJavascriptRequirement
 inputs:
     vcf:
         type: File
@@ -18,7 +19,8 @@ inputs:
         secondaryFiles: [.fai, ^.dict]
     bam:
         type: File
-        secondaryFiles: [.bai, .crai]
+        secondaryFiles: ${if (self.nameext === ".bam") {return self.basename + ".bai"} else {return self.basename + ".crai"}}
+        doc: accepts either bam or cram
     min_base_quality:
         type: int?
     min_mapping_quality:
@@ -71,7 +73,7 @@ steps:
         run: ../tools/vcf_readcount_annotator.cwl
         in:
             vcf: add_snv_bam_readcount_to_vcf/annotated_bam_readcount_vcf
-            bam_readcount_tsv: indel_bam_readcount_tsv
+            bam_readcount_tsv: bam_readcount/indel_bam_readcount_tsv
             data_type: data_type
             sample_name: sample_name
             variant_type:

--- a/definitions/subworkflows/bam_readcount_to_vcf.cwl
+++ b/definitions/subworkflows/bam_readcount_to_vcf.cwl
@@ -1,0 +1,80 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+label: "Get snv and indel readcounts for one sample and one bam and add them to a vcf"
+requirements:
+    - class: SubworkflowFeatureRequirement
+inputs:
+    vcf:
+        type: File
+        secondaryFiles: [.tbi]
+    sample_name:
+        type: string
+    reference_fasta:
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
+    bam:
+        type: File
+        secondaryFiles: [.bai, .crai]
+    min_base_quality:
+        type: int?
+    min_mapping_quality:
+        type: int?
+    data_type:
+        type:
+            - type: enum
+              symbols: ["DNA", "RNA"]
+outputs:
+    readcount_vcf:
+        type: File
+        outputSource: add_indel_bam_readcount_to_vcf/annotated_bam_readcount_vcf
+steps:
+    normalize_variants:
+        run: ../tools/normalize_variants.cwl
+        in:
+            reference: reference_fasta
+            vcf: vcf
+        out:
+            [normalized_vcf]
+    decompose_variants:
+        run: ../tools/vt_decompose.cwl
+        in:
+            vcf: normalize_variants/normalized_vcf
+        out:
+            [decomposed_vcf]
+    bam_readcount:
+        run: ../tools/bam_readcount.cwl
+        in:
+            vcf: decompose_variants/decomposed_vcf
+            sample: sample_name
+            reference_fasta: reference_fasta
+            bam: bam
+            min_base_quality: min_base_quality
+            min_mapping_quality: min_mapping_quality
+        out:
+            [snv_bam_readcount_tsv, indel_bam_readcount_tsv]
+    add_snv_bam_readcount_to_vcf:
+        run: ../tools/vcf_readcount_annotator.cwl
+        in:
+            vcf: vcf
+            bam_readcount_tsv: bam_readcount/snv_bam_readcount_tsv
+            data_type: data_type
+            sample_name: sample_name
+            variant_type:
+                default: 'snv'
+        out:
+            [annotated_bam_readcount_vcf]
+    add_indel_bam_readcount_to_vcf:
+        run: ../tools/vcf_readcount_annotator.cwl
+        in:
+            vcf: add_snv_bam_readcount_to_vcf/annotated_bam_readcount_vcf
+            bam_readcount_tsv: indel_bam_readcount_tsv
+            data_type: data_type
+            sample_name: sample_name
+            variant_type:
+                default: 'indel'
+        out:
+            [annotated_bam_readcount_vcf]

--- a/definitions/subworkflows/merge_readcounts_somatic.cwl
+++ b/definitions/subworkflows/merge_readcounts_somatic.cwl
@@ -92,10 +92,8 @@ steps:
         run: bam_readcount_multisample.cwl
         in:
             vcf: merge_vcfs/merged_vcf
-            bams:
-                source: prepend_normal_bam/file_array
-            sample_names: 
-                source: prepend_normal_name/string_array
+            bams: prepend_normal_bam/file_array
+            sample_names: prepend_normal_name/string_array
             reference_fasta: reference_fasta
             min_base_quality: min_base_quality
             min_mapping_quality: min_mapping_quality

--- a/definitions/subworkflows/merge_readcounts_somatic.cwl
+++ b/definitions/subworkflows/merge_readcounts_somatic.cwl
@@ -1,0 +1,65 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+label: "given multiple somatic vcfs from the same individual, merges the vcfs, adds readcounts, and creates a table"
+requirements:
+    - class: SubworkflowFeatureRequirement
+    - class: ScatterFeatureRequirement
+    - class: MultipleInputFeatureRequirement
+inputs:
+    vcfs:
+        type: [File]
+        secondaryFiles: [.tbi]
+    tumor_bams:
+        type: [File]
+        secondaryFiles: [.bai, .crai]
+        doc: array of tumor bams or crams
+    tumor_sample_names:
+        type: [string]
+        doc: tumor sample names - assumes same order as the tumor bams
+    normal_bam:
+        type: File
+        secondaryFiles: [.bai, .crai]
+        doc: shared normal bam file
+    normal_sample_name:
+        type: string
+        doc: shared normal sample name
+    min_base_quality:
+        type: int?
+    min_mapping_quality:
+        type: int?
+    data_type:
+        type:
+            - type: enum
+              symbols: ["DNA", "RNA"]
+        doc: for now, this only accepts either "DNA" or "RNA" and assumes it applies to all samples/bams to avoid having to pass in an array
+outputs:
+    merged_readcount_vcf:
+        type: File
+        outputSource: ##bam_readcount/indel_bam_readcount_tsv
+steps:
+    merge_vcfs:
+        run: merge_somatic_vcfs.cwl
+        in:
+            vcfs: vcfs
+            sample_names: tumor_sample_names
+            normal_sample_name: normal_sample_name
+        out:
+            [merged_vcf]
+    add_readcounts:
+        run: bam_readcount_multisample.cwl
+        in:
+            vcf: merge_vcfs/merged_vcf
+            bams:
+                source: [normal_bam, bams]
+                linkMerge: merge_flattened
+            sample_name: 
+                source: [normal_sample_name, tumor_sample_names]
+                linkMerge: merge_flattened
+            reference_fasta: reference_fasta
+            min_base_quality: min_base_quality
+            min_mapping_quality: min_mapping_quality
+            data_type: data_type
+        out:
+            [readcount_vcfs]

--- a/definitions/subworkflows/mutect.cwl
+++ b/definitions/subworkflows/mutect.cwl
@@ -53,7 +53,7 @@ steps:
         out:
             [vcf]
     merge:
-        run: ../tools/merge_vcf.cwl
+        run: ../tools/concat_vcf.cwl
         in:
             vcfs: mutect/vcf
         out:

--- a/definitions/subworkflows/strelka_and_post_processing.cwl
+++ b/definitions/subworkflows/strelka_and_post_processing.cwl
@@ -59,7 +59,7 @@ steps:
         out:
             [processed_vcf]
     merge:
-        run: ../tools/merge_vcf.cwl
+        run: ../tools/concat_vcf.cwl
         in:
             vcfs: process/processed_vcf
         out:

--- a/definitions/subworkflows/varscan_pre_and_post_processing.cwl
+++ b/definitions/subworkflows/varscan_pre_and_post_processing.cwl
@@ -122,7 +122,7 @@ steps:
         out:
             [indexed_vcf]
     merge:
-        run: ../tools/merge_vcf.cwl
+        run: ../tools/concat_vcf.cwl
         in:
             vcfs: [index_snvs/indexed_vcf, index_indels/indexed_vcf]
         out:

--- a/definitions/tools/bam_readcount.cwl
+++ b/definitions/tools/bam_readcount.cwl
@@ -8,7 +8,7 @@ baseCommand: ["/usr/bin/python", "bam_readcount_helper.py"]
 requirements:
     - class: ShellCommandRequirement
     - class: DockerRequirement
-      dockerPull: "mgibio/bam_readcount_helper-cwl:1.1.1"
+      dockerPull: "mgibio/bam_readcount_helper-cwl:1.2"
     - class: ResourceRequirement
       ramMin: 16000
     - class: InlineJavascriptRequirement
@@ -147,7 +147,7 @@ inputs:
         type: File
         inputBinding:
             position: -5
-        secondaryFiles: [.bai]
+        secondaryFiles: [.bai, .crai]
     prefix:
         type: string?
         default: 'NOPREFIX'

--- a/definitions/tools/bam_readcount.cwl
+++ b/definitions/tools/bam_readcount.cwl
@@ -8,7 +8,8 @@ baseCommand: ["/usr/bin/python", "bam_readcount_helper.py"]
 requirements:
     - class: ShellCommandRequirement
     - class: DockerRequirement
-      dockerPull: "mgibio/bam_readcount_helper-cwl:1.2"
+      #dockerPull: "mgibio/bam_readcount_helper-cwl:1.2"
+      dockerPull: "chrisamiller/bam_readcount_helper-cwl:cramtest"
     - class: ResourceRequirement
       ramMin: 16000
     - class: InlineJavascriptRequirement
@@ -35,7 +36,7 @@ requirements:
                 return fh.name
 
             def filter_sites_in_hash(region_list, bam_file, ref_fasta, prefixed_sample, output_dir, insertion_centric, map_qual, base_qual):
-                bam_readcount_cmd = ['/usr/bin/bam-readcount', '-f', ref_fasta, '-l', region_list, '-w', '0', '-b', str(base_qual), '-q', str(map_qual)]
+                bam_readcount_cmd = ['/opt/bam-readcount/bam-readcount', '-f', ref_fasta, '-l', region_list, '-w', '0', '-b', str(base_qual), '-q', str(map_qual)]
                 if insertion_centric:
                     bam_readcount_cmd.append('-i')
                     output_file = os.path.join(output_dir, prefixed_sample + '_bam_readcount_indel.tsv')
@@ -147,7 +148,8 @@ inputs:
         type: File
         inputBinding:
             position: -5
-        secondaryFiles: [.bai, .crai]
+        secondaryFiles: ${if (self.nameext === ".bam") {return self.basename + ".bai"} else {return self.basename + ".crai"}}
+        doc: accepts either bam or cram
     prefix:
         type: string?
         default: 'NOPREFIX'

--- a/definitions/tools/concat_vcf.cwl
+++ b/definitions/tools/concat_vcf.cwl
@@ -2,14 +2,18 @@
 
 cwlVersion: v1.0
 class: CommandLineTool
-label: "merge VCF files from non-overlapping sample sets"
-baseCommand: ["/opt/bcftools/bin/bcftools", "merge"]
+label: "concatenate or combine multiple VCF files that contain variants from the same samples"
+baseCommand: ["/opt/bcftools/bin/bcftools", "concat"]
 requirements:
     - class: DockerRequirement
       dockerPull: mgibio/bcftools-cwl:1.3.1
     - class: ResourceRequirement
       ramMin: 4000
 arguments:
+    - "--allow-overlaps"
+    - "--remove-duplicates"
+    - "--output-type"
+    - "z"
     - "-o"
     - { valueFrom: $(runtime.outdir)/$(inputs.merged_vcf_basename).vcf.gz }
 inputs:

--- a/definitions/tools/merge_somatic_vcfs.cwl
+++ b/definitions/tools/merge_somatic_vcfs.cwl
@@ -44,13 +44,18 @@ requirements:
                 /usr/local/bin/tabix -p vcf "$i.normal_only.vcf.gz";
             done
                 
-            #create a merged normal vcf that includes all variants from all samples - this isn't strictly necessary,
-            #but gives us a more sane final vcf
+            # #create a merged normal vcf that includes all variants from all samples - this isn't strictly necessary,
+            # #but gives us a more sane final vcf
+            # /usr/local/bin/bcftools concat -a -D *.normal_only.vcf.gz | /usr/local/bin/bgzip -c >merged.normal.prenorm.vcf.gz
+            # /usr/local/bin/tabix -p vcf merged.normal.prenorm.vcf.gz
+            # #also have to normalize to prevent an edge case where multiallelic sites are split across multiple lines
+            # /usr/local/bin/bcftools annotate -x FORMAT/F1R2,FORMAT/F2R1 merged.normal.prenorm.vcf.gz | /usr/local/bin/bcftools norm -m+ | /usr/local/bin/bgzip -c >merged.normal.vcf.gz
+            # /usr/local/bin/tabix -p vcf merged.normal.vcf.gz
             /usr/local/bin/bcftools concat -a -D *.normal_only.vcf.gz | /usr/local/bin/bgzip -c >merged.normal.vcf.gz
             /usr/local/bin/tabix -p vcf merged.normal.vcf.gz
             
             #finally, merge them all into one big VCF, keeping FILTER field as PASS if it is PASS in any sample
-            cmd="/usr/local/bin/bcftools merge -F x merged.normal.vcf.gz"
+            cmd="/usr/local/bin/bcftools merge -F x -m none merged.normal.vcf.gz"
             for i in ${!sample_array[*]};do
                 cmd="$cmd $i.tumor_only.vcf.gz"
             done

--- a/definitions/tools/merge_somatic_vcfs.cwl
+++ b/definitions/tools/merge_somatic_vcfs.cwl
@@ -44,13 +44,6 @@ requirements:
                 /usr/local/bin/tabix -p vcf "$i.normal_only.vcf.gz";
             done
                 
-            # #create a merged normal vcf that includes all variants from all samples - this isn't strictly necessary,
-            # #but gives us a more sane final vcf
-            # /usr/local/bin/bcftools concat -a -D *.normal_only.vcf.gz | /usr/local/bin/bgzip -c >merged.normal.prenorm.vcf.gz
-            # /usr/local/bin/tabix -p vcf merged.normal.prenorm.vcf.gz
-            # #also have to normalize to prevent an edge case where multiallelic sites are split across multiple lines
-            # /usr/local/bin/bcftools annotate -x FORMAT/F1R2,FORMAT/F2R1 merged.normal.prenorm.vcf.gz | /usr/local/bin/bcftools norm -m+ | /usr/local/bin/bgzip -c >merged.normal.vcf.gz
-            # /usr/local/bin/tabix -p vcf merged.normal.vcf.gz
             /usr/local/bin/bcftools concat -a -D *.normal_only.vcf.gz | /usr/local/bin/bgzip -c >merged.normal.vcf.gz
             /usr/local/bin/tabix -p vcf merged.normal.vcf.gz
             

--- a/definitions/tools/merge_somatic_vcfs.cwl
+++ b/definitions/tools/merge_somatic_vcfs.cwl
@@ -19,44 +19,48 @@ requirements:
             vcfs="$1" #csv list of vcfs
             samples="$2" #csv list of tumor sample names
             normal_sample_name="$3"
-
-            IFS=',' read -ra vcf_array <<< "vcfs"
-            IFS=',' read -ra sample_array <<< "samples"
-
-            if [ "${#vcfs[@]}" != "${#samples[@]}" ]; then
-              echo "ERROR: the number of vcfs must be equal to the number of sample names provided";
-              exit 1
+            
+            IFS=',' read -ra vcf_array <<< "$vcfs"
+            IFS=',' read -ra sample_array <<< "$samples"
+            
+            if [ "${#vcf_array[@]}" != "${#sample_array[@]}" ]; then
+                echo "ERROR: the number of vcfs must be equal to the number of sample names provided";
+                exit 1
             fi
-
+            
             # prep all the tumor vcfs for merging
-            for i in "${!vcf_array[*]}"; do
-              samp=${sample_array[$i]};
-              vcf=${vcf_array[$i]};
-              #assumes the input VCF contains the samples in the order NORMAL TUMOR
-              normal_name_in_vcf=`gunzip -c "$vcf" | grep "^#CHROM" | cut -f 10`;
-              tumor_name_in_vcf=`gunzip -c "$vcf" | grep "^#CHROM" | cut -f 11`;
-              /usr/local/bin/bcftools view -s $tumor_name_in_vcf $vcf | /usr/local/bin/bcftools reheader -s <(echo $samp) | /usr/local/bin/bgzip -c >$samp.tumor_only.vcf.gz;
-              /usr/local/bin/tabix -p vcf $samp.tumor_only.vcf.gz;
-
-              #also create normal-only vcfs
-              /usr/local/bin/bcftools view -s $normal_name_in_vcf $vcf | /usr/local/bin/bcftools reheader -s <(echo $normal_sample_name) | /usr/local/bin/bgzip -c >$samp.normal_only.vcf.gz;
-              /usr/local/bin/tabix -p vcf $samp.normal_only.vcf.gz;
+            for i in ${!vcf_array[*]}; do
+                echo "loop: $i";
+                samp=${sample_array[$i]};
+                vcf=${vcf_array[$i]};
+                echo $samp
+                echo $vcf
+                #assumes the input VCF contains the samples in the order NORMAL TUMOR
+                normal_name_in_vcf=`gunzip -c "$vcf" | grep "^#CHROM" | cut -f 10`;
+                tumor_name_in_vcf=`gunzip -c "$vcf" | grep "^#CHROM" | cut -f 11`;
+                /usr/local/bin/bcftools view -s $tumor_name_in_vcf $vcf | /usr/local/bin/bcftools reheader -s <(echo $samp) | /usr/local/bin/bgzip -c >$samp.tumor_only.vcf.gz;
+                /usr/local/bin/tabix -p vcf $samp.tumor_only.vcf.gz;
+                
+                #also create normal-only vcfs
+                /usr/local/bin/bcftools view -s $normal_name_in_vcf $vcf | /usr/local/bin/bcftools reheader -s <(echo $normal_sample_name) | /usr/local/bin/bgzip -c >$samp.normal_only.vcf.gz;
+                /usr/local/bin/tabix -p vcf $samp.normal_only.vcf.gz;
             done
-
-            #create a merged normal vcf that includes all variants from all samples - this isn't strictly necessary, 
+                
+            #create a merged normal vcf that includes all variants from all samples - this isn't strictly necessary,
             #but gives us a more sane final vcf
-            /usr/local/bin/bcftools concat -a -D *.normal_only.vcf.gz | /usr/local/bin/bgzip -c >merged.normal_only.vcf.gz
-            /usr/local/bin/tabix -p vcf merged.normal_only.vcf.gz
-
+            /usr/local/bin/bcftools concat -a -D *.normal_only.vcf.gz | /usr/local/bin/bgzip -c >merged.normal.vcf.gz
+            /usr/local/bin/tabix -p vcf merged.normal.vcf.gz
+            
             #finally, merge them all into one big VCF, keeping FILTER field as PASS if it is PASS in any sample
-            cmd="/usr/local/bin/bcftools merge -F x merged.normal_only.vcf.gz"
-            for i in "${!vcf_array[*]}"; do
-              cmd="$cmd $samp.tumor_only.vcf.gz"
+            cmd="/usr/local/bin/bcftools merge -F x merged.normal.vcf.gz"
+            for samp in ${sample_array[@]};do
+                cmd="$cmd $samp.tumor_only.vcf.gz"
             done
-            cmd="$cmd | /usr/local/bin/bgzip -c >$merged.vcf.gz;
-            `$cmd`
-            /usr/local/bin/tabix -p vcf $merged.vcf.gz
-
+            #cmd | /usr/local/bin/bgzip -c >merged.vcf.gz";
+            echo $cmd;
+            `$cmd >merged.vcf`
+            /usr/local/bin/bgzip merged.vcf
+            /usr/local/bin/tabix -p vcf merged.vcf.gz
 
 #=========="
 
@@ -65,14 +69,18 @@ inputs:
         type: File[]
         inputBinding:
             position: 1
+            itemSeparator: ','
+            separate: false
         doc: "input somatic bgzipped tabix indexed vcfs to merge. Expects sample order in vcf to be normal/tumor"
     sample_names:
-        type: String[]
+        type: string[]
         inputBinding:
             position: 2
+            itemSeparator: ','
+            separate: false
         doc: "tumor sample names"
     normal_sample_name:
-        type: String
+        type: string
         inputBinding:
             position: 3
         doc: "sample name of the shared normal sample"

--- a/definitions/tools/merge_somatic_vcfs.cwl
+++ b/definitions/tools/merge_somatic_vcfs.cwl
@@ -1,0 +1,85 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: "merge several somatic VCFs into a multi-sample VCF"
+baseCommand: ["/bin/bash", "merge_somatic_vcfs.sh"]
+
+requirements:
+    - class: ResourceRequirement
+      ramMin: 4000
+    - class: DockerRequirement
+      dockerPull: 'zlskidmore/samtools:1.10'
+    - class: InitialWorkDirRequirement
+      listing:
+      - entryname: 'merge_somatic_vcfs.sh'
+        entry: |
+            set -eou pipefail
+
+            vcfs="$1" #csv list of vcfs
+            samples="$2" #csv list of tumor sample names
+            normal_sample_name="$3"
+
+            IFS=',' read -ra vcf_array <<< "vcfs"
+            IFS=',' read -ra sample_array <<< "samples"
+
+            if [ "${#vcfs[@]}" != "${#samples[@]}" ]; then
+              echo "ERROR: the number of vcfs must be equal to the number of sample names provided";
+              exit 1
+            fi
+
+            # prep all the tumor vcfs for merging
+            for i in "${!vcf_array[*]}"; do
+              samp=${sample_array[$i]};
+              vcf=${vcf_array[$i]};
+              #assumes the input VCF contains the samples in the order NORMAL TUMOR
+              normal_name_in_vcf=`gunzip -c "$vcf" | grep "^#CHROM" | cut -f 10`;
+              tumor_name_in_vcf=`gunzip -c "$vcf" | grep "^#CHROM" | cut -f 11`;
+              /usr/local/bin/bcftools view -s $tumor_name_in_vcf $vcf | /usr/local/bin/bcftools reheader -s <(echo $samp) | /usr/local/bin/bgzip -c >$samp.tumor_only.vcf.gz;
+              /usr/local/bin/tabix -p vcf $samp.tumor_only.vcf.gz;
+
+              #also create normal-only vcfs
+              /usr/local/bin/bcftools view -s $normal_name_in_vcf $vcf | /usr/local/bin/bcftools reheader -s <(echo $normal_sample_name) | /usr/local/bin/bgzip -c >$samp.normal_only.vcf.gz;
+              /usr/local/bin/tabix -p vcf $samp.normal_only.vcf.gz;
+            done
+
+            #create a merged normal vcf that includes all variants from all samples - this isn't strictly necessary, 
+            #but gives us a more sane final vcf
+            /usr/local/bin/bcftools concat -a -D *.normal_only.vcf.gz | /usr/local/bin/bgzip -c >merged.normal_only.vcf.gz
+            /usr/local/bin/tabix -p vcf merged.normal_only.vcf.gz
+
+            #finally, merge them all into one big VCF, keeping FILTER field as PASS if it is PASS in any sample
+            cmd="/usr/local/bin/bcftools merge -F x merged.normal_only.vcf.gz"
+            for i in "${!vcf_array[*]}"; do
+              cmd="$cmd $samp.tumor_only.vcf.gz"
+            done
+            cmd="$cmd | /usr/local/bin/bgzip -c >$merged.vcf.gz;
+            `$cmd`
+            /usr/local/bin/tabix -p vcf $merged.vcf.gz
+
+
+#=========="
+
+inputs:
+    vcfs:
+        type: File[]
+        inputBinding:
+            position: 1
+        doc: "input somatic bgzipped tabix indexed vcfs to merge. Expects sample order in vcf to be normal/tumor"
+    sample_names:
+        type: String[]
+        inputBinding:
+            position: 2
+        doc: "tumor sample names"
+    normal_sample_name:
+        type: String
+        inputBinding:
+            position: 3
+        doc: "sample name of the shared normal sample"
+
+outputs:
+    merged_vcf:
+        type: File
+        outputBinding:
+            glob: "merged.vcf.gz"
+        secondaryFiles: [".tbi"]

--- a/definitions/tools/merge_variants.cwl
+++ b/definitions/tools/merge_variants.cwl
@@ -1,0 +1,55 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: "combine variants from multiple samples into a single vcf"
+baseCommand: ["/usr/bin/java", "-Xmx8g", "-jar", "/opt/GenomeAnalysisTK.jar", "-T", "CombineVariants"]
+requirements:
+    - class: ResourceRequirement
+      ramMin: 9000
+      tmpdirMin: 25000
+    - class: DockerRequirement
+      dockerPull: mgibio/gatk-cwl:3.6.0
+arguments:
+    ["-genotypeMergeOptions", "PRIORITIZE",
+     "--rod_priority_list", "mutect,varscan,strelka,pindel",
+     "-o", { valueFrom: $(runtime.outdir)/combined.vcf.gz }]
+inputs:
+    reference:
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict]
+        inputBinding:
+            prefix: "-R"
+            position: 1
+    mutect_vcf:
+        type: File
+        inputBinding:
+            prefix: "--variant:mutect"
+            position: 2
+        secondaryFiles: [.tbi]
+    varscan_vcf:
+        type: File
+        inputBinding:
+            prefix: "--variant:varscan"
+            position: 3
+        secondaryFiles: [.tbi]
+    strelka_vcf:
+        type: File
+        inputBinding:
+            prefix: "--variant:strelka"
+            position: 4
+        secondaryFiles: [.tbi]
+    pindel_vcf:
+        type: File
+        inputBinding:
+            prefix: "--variant:pindel"
+            position: 5
+        secondaryFiles: [.tbi]
+outputs:
+    combined_vcf:
+        type: File
+        outputBinding:
+            glob: "combined.vcf.gz"
+

--- a/definitions/tools/merge_vcf.cwl
+++ b/definitions/tools/merge_vcf.cwl
@@ -11,7 +11,7 @@ requirements:
       ramMin: 4000
 arguments:
     - "-o"
-    - { valueFrom: $(runtime.outdir)/$(inputs.merged_vcf_basename).vcf.gz }
+    - { valueFrom: $(runtime.outdir)/$(inputs.merged_vcf_basename).vcf }
 inputs:
     vcfs:
         type: File[]
@@ -25,4 +25,4 @@ outputs:
     merged_vcf:
         type: File
         outputBinding:
-            glob: $(inputs.merged_vcf_basename).vcf.gz
+            glob: $(inputs.merged_vcf_basename).vcf

--- a/definitions/tools/prepend_file_to_array.cwl
+++ b/definitions/tools/prepend_file_to_array.cwl
@@ -9,7 +9,7 @@ inputs:
 outputs:
     file_array: File[]
 requirements:
-    InlineJavascriptRequirement: {}
+    - class: InlineJavascriptRequirement
 expression: |
    ${
       var afile = inputs.file;

--- a/definitions/tools/prepend_file_to_array.cwl
+++ b/definitions/tools/prepend_file_to_array.cwl
@@ -1,0 +1,19 @@
+class: ExpressionTool
+# takes a file and an array of files and prepends the file to the array
+cwlVersion: v1.0
+inputs:
+  file:
+    type: File
+  array:
+    type: File[]
+outputs:
+    file_array: File[]
+requirements:
+    InlineJavascriptRequirement: {}
+expression: |
+   ${
+      var afile = inputs.file;
+      var file_array = inputs.array;
+      file_array.unshift(afile);
+      return {"file_array": file_array}
+    }

--- a/definitions/tools/prepend_string_to_array.cwl
+++ b/definitions/tools/prepend_string_to_array.cwl
@@ -1,0 +1,19 @@
+class: ExpressionTool
+# takes a string and an array of strings and prepends the string to the array
+cwlVersion: v1.0
+inputs:
+  string:
+    type: string
+  array:
+    type: string[]
+outputs:
+    string_array: string[]
+requirements:
+    InlineJavascriptRequirement: {}
+expression: |
+   ${
+      var astring = inputs.string;
+      var string_array = inputs.array;
+      string_array.unshift(astring);
+      return {"string_array": string_array}
+    }

--- a/definitions/tools/prepend_string_to_array.cwl
+++ b/definitions/tools/prepend_string_to_array.cwl
@@ -9,7 +9,7 @@ inputs:
 outputs:
     string_array: string[]
 requirements:
-    InlineJavascriptRequirement: {}
+    - class: InlineJavascriptRequirement
 expression: |
    ${
       var astring = inputs.string;

--- a/definitions/tools/subset_vcf_by_sample.cwl
+++ b/definitions/tools/subset_vcf_by_sample.cwl
@@ -42,7 +42,7 @@ inputs:
             position: 1
         doc: "multi-sample vcf"
     sample_name:
-        type: String
+        type: string
         inputBinding:
             position: 2
         doc: "sample name to keep"

--- a/definitions/tools/subset_vcf_by_sample.cwl
+++ b/definitions/tools/subset_vcf_by_sample.cwl
@@ -1,0 +1,54 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: "subset a multi-sample vcf so that only a single sample is retained"
+baseCommand: ["/bin/bash", "subset_vcf.sh"]
+
+requirements:
+    - class: ResourceRequirement
+      ramMin: 4000
+    - class: DockerRequirement
+      dockerPull: 'zlskidmore/samtools:1.10'
+    - class: InitialWorkDirRequirement
+      listing:
+      - entryname: 'subset_vcf.sh'
+        entry: |
+            set -eou pipefail
+
+            vcf="$1" #csv list of vcfs
+            sample="$2" #csv list of tumor sample names
+
+            #die if the specified sample name doesn't exist
+            sample_exists="FALSE"
+            for i in `gunzip -c "$vcf" | grep "^#CHROM" | cut -f 10-`;do 
+              if [[ "$i" == "$sample" ]];then
+                sample_exists="TRUE"
+              fi
+            done
+            if [[ $sample_exists == "FALSE" ]];then
+              echo "ERROR: Sample $sample does not exist in the VCF provided";
+              exit 1
+            fi
+
+            /usr/local/bin/bcftools view -s $sample $vcf | /usr/local/bin/bgzip -c >subset.vcf.gz;
+            /usr/local/bin/tabix -p vcf subset.vcf.gz;
+
+
+inputs:
+    vcf:
+        type: File
+        inputBinding:
+            position: 1
+        doc: "multi-sample vcf"
+    sample_name:
+        type: String
+        inputBinding:
+            position: 2
+        doc: "sample name to keep"
+outputs:
+    subset_vcf:
+        type: File
+        outputBinding:
+            glob: "subset.vcf.gz"
+        secondaryFiles: [".tbi"]


### PR DESCRIPTION
- Adds cram support to the bam-readcount tools.  Right now, runs on a beta version of the new bam-readcount release, with plans to update to stable when it comes out

- Adds subworkflows that simplify some readcounting steps.  Used here for now, but in a later PR, we will also use these to simplify the detect-variants readcounting 

- Adds a merge-readcount tool that takes bams and vcfs from multiple somatic runs from the same patient and creates a merged VCF files with per-patient readcounts.