### PR TITLE
used sample names instead of generic tumor and normal

### DIFF
--- a/definitions/pipelines/detect_variants_mouse.cwl
+++ b/definitions/pipelines/detect_variants_mouse.cwl
@@ -250,8 +250,7 @@ steps:
         run: ../tools/bam_readcount.cwl
         in:
             vcf: annotate_variants/annotated_vcf
-            sample:
-                default: 'TUMOR'
+            sample: tumor_sample_name
             reference_fasta: reference
             bam: tumor_bam
             min_base_quality: readcount_minimum_base_quality
@@ -262,8 +261,7 @@ steps:
         run: ../tools/bam_readcount.cwl
         in:
             vcf: annotate_variants/annotated_vcf
-            sample:
-                default: 'NORMAL'
+            sample: normal_sample_name
             reference_fasta: reference
             bam: normal_bam
             min_base_quality: readcount_minimum_base_quality
@@ -278,8 +276,7 @@ steps:
             indel_bam_readcount_tsv: tumor_bam_readcount/indel_bam_readcount_tsv
             data_type:
                 default: 'DNA'
-            sample_name:
-                default: 'TUMOR'
+            sample_name: tumor_sample_name
         out:
             [annotated_bam_readcount_vcf]
     add_normal_bam_readcount_to_vcf:
@@ -290,8 +287,7 @@ steps:
             indel_bam_readcount_tsv: normal_bam_readcount/indel_bam_readcount_tsv
             data_type:
                 default: 'DNA'
-            sample_name:
-                default: 'NORMAL'
+            sample_name: normal_sample_name
         out:
             [annotated_bam_readcount_vcf]
     index:


### PR DESCRIPTION
@johnegarza and @susannasiebert helped me sort this out.  The mouse detect variants pipeline was not working due to changes elsewhere. This fix allows me to get complete builds. 

Before this fix I was getting errors like this

```
  File "bam_readcount_helper.py", line 52, in <module>
    sample_index = vcf_file.samples.index(sample)
ValueError: 'TUMOR' is not in list
Traceback (most recent call last):
  File "bam_readcount_helper.py", line 52, in <module>
    sample_index = vcf_file.samples.index(sample)
ValueError: 'TUMOR' is not in list
ln: failed to access '/cromwell-executions/somatic_exome_mouse.cwl/4620f4e7-d06a-4d23-a695-5c21e5ed7555/call-detect_variants/detect_variants_mouse.cwl/520d5353-a6f8-4c07-ba14-6670b72c2d01/call-tumor_bam_readcount/execution/cwl.output.json': No such file or directory
```
