### PR TITLE
Add Flexbar to Sequence Alignment Step

### DIFF
--- a/definitions/pipelines/alignment_exome.cwl
+++ b/definitions/pipelines/alignment_exome.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/trimming_options.yml
     - class: SubworkflowFeatureRequirement
 inputs:
     reference:
@@ -17,6 +18,10 @@ inputs:
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+    trimming:
+        type:
+            - ../types/trimming_options.yml#trimming_options
+            - "null"
     mills:
         type: File
         secondaryFiles: [.tbi]
@@ -99,6 +104,7 @@ steps:
         in:
             reference: reference
             unaligned: sequence
+            trimming: trimming
             mills: mills
             known_indels: known_indels
             dbsnp_vcf: dbsnp_vcf

--- a/definitions/pipelines/alignment_wgs.cwl
+++ b/definitions/pipelines/alignment_wgs.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/trimming_options.yml
     - class: SubworkflowFeatureRequirement
 inputs:
     reference:
@@ -17,6 +18,10 @@ inputs:
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+    trimming:
+        type:
+            - ../types/trimming_options.yml#trimming_options
+            - "null"
     mills:
         type: File
         secondaryFiles: [.tbi]
@@ -105,6 +110,7 @@ steps:
         in:
             reference: reference
             unaligned: sequence
+            trimming: trimming
             mills: mills
             known_indels: known_indels
             dbsnp_vcf: dbsnp_vcf

--- a/definitions/pipelines/germline_exome.cwl
+++ b/definitions/pipelines/germline_exome.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/trimming_options.yml
           - $import: ../types/vep_custom_annotation.yml
     - class: SubworkflowFeatureRequirement
 inputs:
@@ -18,6 +19,10 @@ inputs:
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+    trimming:
+        type:
+            - ../types/trimming_options.yml#trimming_options
+            - "null"
     mills:
         type: File
         secondaryFiles: [.tbi]
@@ -160,6 +165,7 @@ steps:
         in:
             reference: reference
             sequence: sequence
+            trimming: trimming
             mills: mills
             known_indels: known_indels
             dbsnp_vcf: dbsnp_vcf

--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/trimming_options.yml
           - $import: ../types/vep_custom_annotation.yml
     - class: SubworkflowFeatureRequirement
     - class: StepInputExpressionRequirement
@@ -19,6 +20,10 @@ inputs:
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+    trimming:
+        type:
+            - ../types/trimming_options.yml#trimming_options
+            - "null"
     mills:
         type: File
         secondaryFiles: [.tbi]
@@ -299,6 +304,7 @@ steps:
         in:
             reference: reference
             sequence: sequence
+            trimming: trimming
             mills: mills
             known_indels: known_indels
             dbsnp_vcf: dbsnp_vcf

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -7,6 +7,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/trimming_options.yml
           - $import: ../types/vep_custom_annotation.yml
     - class: SubworkflowFeatureRequirement
     - class: StepInputExpressionRequirement
@@ -66,6 +67,10 @@ inputs:
         doc: |
           normal_name provides a string for what the WT sample will be referred to in the various
           outputs, for exmaple the VCF files.
+    trimming:
+        type:
+            - ../types/trimming_options.yml#trimming_options
+            - "null"
     mills:
         type: File
         secondaryFiles: [.tbi]
@@ -455,6 +460,7 @@ steps:
         in:
             reference: reference
             sequence: tumor_sequence
+            trimming: trimming
             mills: mills
             known_indels: known_indels
             dbsnp_vcf: dbsnp_vcf
@@ -478,6 +484,7 @@ steps:
         in:
             reference: reference
             sequence: normal_sequence
+            trimming: trimming
             mills: mills
             known_indels: known_indels
             dbsnp_vcf: dbsnp_vcf

--- a/definitions/pipelines/somatic_wgs.cwl
+++ b/definitions/pipelines/somatic_wgs.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/trimming_options.yml
           - $import: ../types/vep_custom_annotation.yml
     - class: SubworkflowFeatureRequirement
     - class: StepInputExpressionRequirement
@@ -23,6 +24,10 @@ inputs:
     normal_name:
         type: string?
         default: 'normal'
+    trimming:
+        type:
+            - ../types/trimming_options.yml#trimming_options
+            - "null"
     mills:
         type: File
         secondaryFiles: [.tbi]
@@ -346,6 +351,7 @@ steps:
         in:
             reference: reference
             sequence: tumor_sequence
+            trimming: trimming
             mills: mills
             known_indels: known_indels
             dbsnp_vcf: dbsnp_vcf
@@ -366,6 +372,7 @@ steps:
         in:
             reference: reference
             sequence: normal_sequence
+            trimming: trimming
             mills: mills
             known_indels: known_indels
             dbsnp_vcf: dbsnp_vcf

--- a/definitions/pipelines/tumor_only_exome.cwl
+++ b/definitions/pipelines/tumor_only_exome.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/trimming_options.yml
           - $import: ../types/vep_custom_annotation.yml
     - class: SubworkflowFeatureRequirement
 inputs:
@@ -18,6 +19,10 @@ inputs:
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+    trimming:
+        type:
+            - ../types/trimming_options.yml#trimming_options
+            - "null"
     mills:
         type: File
         secondaryFiles: [.tbi]
@@ -186,6 +191,7 @@ steps:
         in:
             reference: reference
             sequence: sequence
+            trimming: trimming
             mills: mills
             known_indels: known_indels
             dbsnp_vcf: dbsnp_vcf

--- a/definitions/pipelines/tumor_only_wgs.cwl
+++ b/definitions/pipelines/tumor_only_wgs.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/trimming_options.yml
           - $import: ../types/vep_custom_annotation.yml
     - class: SubworkflowFeatureRequirement
 inputs:
@@ -18,6 +19,10 @@ inputs:
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+    trimming:
+        type:
+            - ../types/trimming_options.yml#trimming_options
+            - "null"
     mills:
         type: File
         secondaryFiles: [.tbi]
@@ -158,6 +163,7 @@ steps:
         in:
             reference: reference
             sequence: sequence
+            trimming: trimming
             mills: mills
             known_indels: known_indels
             dbsnp_vcf: dbsnp_vcf

--- a/definitions/subworkflows/sequence_align_and_tag_adapter.cwl
+++ b/definitions/subworkflows/sequence_align_and_tag_adapter.cwl
@@ -9,6 +9,7 @@ requirements:
     - class: SchemaDefRequirement
       types:
           - $import: ../types/sequence_data.yml
+          - $import: ../types/trimming_options.yml
     - class: StepInputExpressionRequirement
     - class: SubworkflowFeatureRequirement
 inputs:
@@ -21,6 +22,10 @@ inputs:
             - File
         secondaryFiles: [.amb, .ann, .bwt, .pac, .sa]
         doc: 'bwa-indexed reference file'
+    trimming:
+        type:
+            - ../types/trimming_options.yml#trimming_options
+            - "null"
 outputs:
     aligned_bam:
         type: File
@@ -42,6 +47,6 @@ steps:
             readgroup:
                 source: unaligned
                 valueFrom: $(self.readgroup)
-
+            trimming: trimming
         out:
             [aligned_bam]

--- a/definitions/subworkflows/sequence_to_bqsr.cwl
+++ b/definitions/subworkflows/sequence_to_bqsr.cwl
@@ -7,6 +7,7 @@ requirements:
     - class: SchemaDefRequirement
       types:
           - $import: ../types/sequence_data.yml
+          - $import: ../types/trimming_options.yml
     - class: ScatterFeatureRequirement
     - class: SubworkflowFeatureRequirement
     - class: MultipleInputFeatureRequirement
@@ -21,6 +22,10 @@ inputs:
             - string
             - File
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
+    trimming:
+        type:
+            - ../types/trimming_options.yml#trimming_options
+            - "null"
     dbsnp_vcf:
         type: File
         secondaryFiles: [.tbi]
@@ -49,6 +54,7 @@ steps:
         in:
             unaligned: unaligned
             reference: reference
+            trimming: trimming
         out:
             [aligned_bam]
     merge:

--- a/definitions/tools/sequence_align_and_tag.cwl
+++ b/definitions/tools/sequence_align_and_tag.cwl
@@ -9,11 +9,13 @@ requirements:
     - class: SchemaDefRequirement
       types:
           - $import: ../types/sequence_data.yml
+          - $import: ../types/trimming_options.yml
     - class: ResourceRequirement
       coresMin: 8
       ramMin: 20000
+    - class: InlineJavascriptRequirement
     - class: DockerRequirement
-      dockerPull: "mgibio/alignment_helper-cwl:1.0.0"
+      dockerPull: "mgibio/alignment_helper-cwl:1.1.0"
     - class: InitialWorkDirRequirement
       listing:
       - entryname: 'sequence_alignment_helper.sh'
@@ -22,7 +24,7 @@ requirements:
             set -o errexit
             set -o nounset
 
-            while getopts "b:?1:?2:?g:r:n:" opt; do
+            while getopts "b:?1:?2:?g:r:n:t:?o:?" opt; do
                 case "$opt" in
                     b)
                         MODE=bam
@@ -45,14 +47,31 @@ requirements:
                     n)
                         NTHREADS="$OPTARG"
                         ;;
+                    t)
+                        TRIMMING_ADAPTERS="$OPTARG"
+                        ;;
+                    o)
+                        TRIMMING_ADAPTER_MIN_OVERLAP="$OPTARG"
+                        ;;
                 esac
             done
 
             if [[ "$MODE" == 'fastq' ]]; then
-                /usr/local/bin/bwa mem -K 100000000 -t "$NTHREADS" -Y -R "$READGROUP" "$REFERENCE" "$FASTQ1" "$FASTQ2" | /usr/local/bin/samblaster -a --addMateTags | /opt/samtools/bin/samtools view -b -S /dev/stdin
+                if [[ -z \${TRIMMING_ADAPTERS-} || -z \${TRIMMING_ADAPTER_MIN_OVERLAP-} ]]; then
+                    /usr/local/bin/bwa mem -K 100000000 -t "$NTHREADS" -Y -R "$READGROUP" "$REFERENCE" "$FASTQ1" "$FASTQ2" | /usr/local/bin/samblaster -a --addMateTags | /opt/samtools/bin/samtools view -b -S /dev/stdin
+                else
+                    /opt/flexbar/flexbar --adapters "$TRIMMING_ADAPTERS" --reads "FASTQ1" --reads2 "$FASTQ2" --adapter-trim-end LTAIL --adapter-min-overlap "$TRIMMING_ADAPTER_MIN_OVERLAP" --adapter-error-rate 0.1 --max-uncalled 300 --stdout-reads \
+                      | /usr/local/bin/bwa mem -K 100000000 -t "$NTHREADS" -Y -p -R "$READGROUP" "$REFERENCE" /dev/stdin | /usr/local/bin/samblaster -a --addMateTags | /opt/samtools/bin/samtools view -b -S /dev/stdin
+                fi
             fi
             if [[ "$MODE" == 'bam' ]]; then
-                /usr/bin/java -Xmx4g -jar /opt/picard/picard.jar SamToFastq I="$BAM" INTERLEAVE=true INCLUDE_NON_PF_READS=true FASTQ=/dev/stdout | /usr/local/bin/bwa mem -K 100000000 -t "$NTHREADS" -Y -p -R "$READGROUP" "$REFERENCE" /dev/stdin | /usr/local/bin/samblaster -a --addMateTags | /opt/samtools/bin/samtools view -b -S /dev/stdin
+                if [[ -z \${TRIMMING_ADAPTERS-} || -z \${TRIMMING_ADAPTER_MIN_OVERLAP-} ]]; then
+                    /usr/bin/java -Xmx4g -jar /opt/picard/picard.jar SamToFastq I="$BAM" INTERLEAVE=true INCLUDE_NON_PF_READS=true FASTQ=/dev/stdout | /usr/local/bin/bwa mem -K 100000000 -t "$NTHREADS" -Y -p -R "$READGROUP" "$REFERENCE" /dev/stdin | /usr/local/bin/samblaster -a --addMateTags | /opt/samtools/bin/samtools view -b -S /dev/stdin
+                else
+                   /usr/bin/java -Xmx4g -jar /opt/picard/picard.jar SamToFastq I="$BAM" INTERLEAVE=true INCLUDE_NON_PF_READS=true FASTQ=/dev/stdout \
+                     | /opt/flexbar/flexbar --adapters "$TRIMMING_ADAPTERS" --reads - --interleaved --adapter-trim-end LTAIL --adapter-min-overlap "$TRIMMING_ADAPTER_MIN_OVERLAP" --adapter-error-rate 0.1 --max-uncalled 300 --stdout-reads \
+                     | /usr/local/bin/bwa mem -K 100000000 -t "$NTHREADS" -Y -p -R "$READGROUP" "$REFERENCE" /dev/stdin | /usr/local/bin/samblaster -a --addMateTags | /opt/samtools/bin/samtools view -b -S /dev/stdin
+                fi
             fi
 stdout: "refAlign.bam"
 arguments:
@@ -85,6 +104,12 @@ inputs:
             position: 4
             prefix: '-r'
         doc: 'bwa-indexed reference file'
+    trimming:
+        type:
+          - ../types/trimming_options.yml#trimming_options
+          - "null"
+        inputBinding:
+            valueFrom: $( ['-t', self.adapters.path, '-o', self.min_overlap] )
 outputs:
     aligned_bam:
         type: stdout

--- a/definitions/types/trimming_options.yml
+++ b/definitions/types/trimming_options.yml
@@ -1,0 +1,10 @@
+type: record
+name: trimming_options
+label: trimming adapter file and parameters
+fields:
+    adapters:
+        type: File
+        doc: 'Fasta file with adapters for removal that may contain N.'
+    min_overlap:
+        type: int
+        doc: 'Minimum overlap for removal without pair overlap.'


### PR DESCRIPTION
In this version only two options are exposed.  I suspect it'd be good to support all the options seen in the RNA version of trimming (and possibly to harmonize the two approaches to passing trimming parameters!) in order to add this to `immuno.cwl` as well:
https://github.com/genome/analysis-workflows/blob/700e73aaed6db1ad538dd27b2e1709f436ad3edb/definitions/pipelines/immuno.cwl#L32-L41
I thought it better to introduce this first and then tackle that as a separate step.

This is part of genome/covid-19#8 and should support the options currently required by that issue.
