### PR TITLE
add raw vcf to outputs for germline pipelines

### DIFF
--- a/definitions/pipelines/germline_exome.cwl
+++ b/definitions/pipelines/germline_exome.cwl
@@ -137,6 +137,10 @@ outputs:
     gvcf:
         type: File[]
         outputSource: detect_variants/gvcf
+    raw_vcf:
+        type: File
+        outputSource: detect_variants/raw_vcf
+        secondaryFiles: [.tbi]
     final_vcf:
         type: File
         outputSource: detect_variants/final_vcf
@@ -224,7 +228,7 @@ steps:
             variants_to_table_fields: variants_to_table_fields
             variants_to_table_genotype_fields: variants_to_table_genotype_fields
         out:
-            [gvcf, final_vcf, filtered_vcf, vep_summary, final_tsv, filtered_tsv]
+            [gvcf, raw_vcf, final_vcf, filtered_vcf, vep_summary, final_tsv, filtered_tsv]
     bam_to_cram:
         run: ../tools/bam_to_cram.cwl
         in:

--- a/definitions/pipelines/germline_exome_hla_typing.cwl
+++ b/definitions/pipelines/germline_exome_hla_typing.cwl
@@ -130,6 +130,10 @@ outputs:
     gvcf:
         type: File[]
         outputSource: germline_exome/gvcf
+    raw_vcf:
+        type: File
+        outputSource: germline_exome/raw_vcf
+        secondaryFiles: [.tbi]
     final_vcf:
         type: File
         outputSource: germline_exome/final_vcf
@@ -178,7 +182,7 @@ steps:
             qc_minimum_mapping_quality: qc_minimum_mapping_quality
             qc_minimum_base_quality: qc_minimum_base_quality
         out:
-            [cram, mark_duplicates_metrics, insert_size_metrics, insert_size_histogram, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, summary_hs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth, gvcf, final_vcf, filtered_vcf, vep_summary]
+            [cram, mark_duplicates_metrics, insert_size_metrics, insert_size_histogram, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, summary_hs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth, gvcf, raw_vcf, final_vcf, filtered_vcf, vep_summary]
     optitype:
         run: ../tools/optitype_dna.cwl
         in:

--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -186,6 +186,10 @@ outputs:
     gvcf:
         type: File[]
         outputSource: detect_variants/gvcf
+    raw_vcf:
+        type: File
+        outputSource: detect_variants/raw_vcf
+        secondaryFiles: [.tbi]
     final_vcf:
         type: File
         outputSource: index_disclaimer_final_vcf/indexed_vcf
@@ -362,7 +366,7 @@ steps:
             variants_to_table_fields: variants_to_table_fields
             variants_to_table_genotype_fields: variants_to_table_genotype_fields
         out:
-            [gvcf, final_vcf, filtered_vcf, vep_summary, final_tsv, filtered_tsv]
+            [gvcf, raw_vcf, final_vcf, filtered_vcf, vep_summary, final_tsv, filtered_tsv]
     add_disclaimer_filtered_vcf:
         run: ../tools/add_string_at_line_bgzipped.cwl
         in:

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -758,6 +758,10 @@ outputs:
     gvcf:
         type: File[]
         outputSource: germline/gvcf
+    germline_raw_vcf:
+        type: File
+        outputSource: germline/raw_vcf
+        secondaryFiles: [.tbi]
     germline_final_vcf:
         type: File
         outputSource: germline/final_vcf
@@ -913,7 +917,7 @@ steps:
             qc_minimum_base_quality: qc_minimum_base_quality
             optitype_name: optitype_name
         out:
-            [cram,mark_duplicates_metrics,insert_size_metrics,insert_size_histogram,alignment_summary_metrics,hs_metrics,per_target_coverage_metrics,per_target_hs_metrics,per_base_coverage_metrics,per_base_hs_metrics,summary_hs_metrics,flagstats,verify_bam_id_metrics,verify_bam_id_depth,gvcf,final_vcf,filtered_vcf,vep_summary,optitype_tsv,optitype_plot]
+            [cram,mark_duplicates_metrics,insert_size_metrics,insert_size_histogram,alignment_summary_metrics,hs_metrics,per_target_coverage_metrics,per_target_hs_metrics,per_base_coverage_metrics,per_base_hs_metrics,summary_hs_metrics,flagstats,verify_bam_id_metrics,verify_bam_id_depth,gvcf,raw_vcf,final_vcf,filtered_vcf,vep_summary,optitype_tsv,optitype_plot]
 
     phase_vcf:
         run: ../subworkflows/phase_vcf.cwl

--- a/definitions/subworkflows/germline_detect_variants.cwl
+++ b/definitions/subworkflows/germline_detect_variants.cwl
@@ -77,6 +77,10 @@ outputs:
     gvcf:
         type: File[]
         outputSource: haplotype_caller/gvcf
+    raw_vcf:
+        type: File
+        outputSource: genotype_gvcfs/genotype_vcf
+        secondaryFiles: [.tbi]
     final_vcf:
         type: File
         outputSource: filter_vcf/final_vcf


### PR DESCRIPTION
this closes #906 
CWLs to potentially update:
```
  definitions/pipelines/aml_trio_cle.cwl:        run: ../subworkflows/germline_detect_variants.cwl
  definitions/pipelines/germline_exome.cwl:        run: ../subworkflows/germline_detect_variants.cwl
  definitions/pipelines/germline_wgs.cwl:        run: ../subworkflows/germline_detect_variants.cwl

  definitions/pipelines/germline_exome_hla_typing.cwl:        run: germline_exome.cwl
  definitions/pipelines/aml_trio_cle_gathered.cwl:        run: aml_trio_cle.cwl

  definitions/pipelines/immuno.cwl:        run: germline_exome_hla_typing.cwl
```

@dufeiyu let me know the aml pipeline does not need to change.