### PR TITLE
add germline_exome_gvcf pipeline

### DIFF
--- a/definitions/pipelines/alignment_exome.cwl
+++ b/definitions/pipelines/alignment_exome.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/trimming_options.yml
     - class: SubworkflowFeatureRequirement
 inputs:
     reference:
@@ -17,6 +18,10 @@ inputs:
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+    trimming:
+        type:
+            - ../types/trimming_options.yml#trimming_options
+            - "null"
     mills:
         type: File
         secondaryFiles: [.tbi]
@@ -99,6 +104,7 @@ steps:
         in:
             reference: reference
             unaligned: sequence
+            trimming: trimming
             mills: mills
             known_indels: known_indels
             dbsnp_vcf: dbsnp_vcf

--- a/definitions/pipelines/alignment_wgs.cwl
+++ b/definitions/pipelines/alignment_wgs.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/trimming_options.yml
     - class: SubworkflowFeatureRequirement
 inputs:
     reference:
@@ -17,6 +18,10 @@ inputs:
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+    trimming:
+        type:
+            - ../types/trimming_options.yml#trimming_options
+            - "null"
     mills:
         type: File
         secondaryFiles: [.tbi]
@@ -105,6 +110,7 @@ steps:
         in:
             reference: reference
             unaligned: sequence
+            trimming: trimming
             mills: mills
             known_indels: known_indels
             dbsnp_vcf: dbsnp_vcf

--- a/definitions/pipelines/alignment_wgs_mouse.cwl
+++ b/definitions/pipelines/alignment_wgs_mouse.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/trimming_options.yml
     - class: SubworkflowFeatureRequirement
     - class: StepInputExpressionRequirement
 inputs:
@@ -18,6 +19,10 @@ inputs:
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+    trimming:
+        type:
+            - ../types/trimming_options.yml#trimming_options
+            - "null"
     final_name:
         type: string?
     per_base_intervals:
@@ -91,6 +96,7 @@ steps:
         in:
             reference: reference
             unaligned: sequence
+            trimming: trimming
             final_name: final_name
         out: [final_bam,mark_duplicates_metrics_file]
     qc:

--- a/definitions/pipelines/aml_trio_cle.cwl
+++ b/definitions/pipelines/aml_trio_cle.cwl
@@ -440,7 +440,7 @@ steps:
             reference: reference
             tumor_bam: tumor_alignment_and_qc/bam
             normal_bam: normal_alignment_and_qc/bam
-            interval_list: interval_list
+            roi_intervals: interval_list
             strelka_exome_mode:
                 default: true
             strelka_cpu_reserved: strelka_cpu_reserved

--- a/definitions/pipelines/chipseq_alignment_mouse.cwl
+++ b/definitions/pipelines/chipseq_alignment_mouse.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/trimming_options.yml
     - class: SubworkflowFeatureRequirement
     - class: StepInputExpressionRequirement
 inputs:
@@ -20,6 +21,10 @@ inputs:
         type: string?
     chipseq_sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+    trimming:
+        type:
+            - ../types/trimming_options.yml#trimming_options
+            - "null"
     per_base_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
         default: []
@@ -94,6 +99,7 @@ steps:
         in:
             reference: reference
             unaligned: chipseq_sequence
+            trimming: trimming
             final_name: final_name
         out: [final_bam,mark_duplicates_metrics_file]
 

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -22,8 +22,10 @@ inputs:
     normal_bam:
         type: File
         secondaryFiles: [.bai,^.bai]
-    interval_list:
+    roi_intervals:
         type: File
+        label: "roi_intervals: regions of interest in which variants will be called"
+        doc: "a list of regions (in interval_list format) within which to call somatic variants"
     strelka_exome_mode:
         type: boolean
     strelka_cpu_reserved:
@@ -189,7 +191,7 @@ steps:
             reference: reference
             tumor_bam: tumor_bam
             normal_bam: normal_bam
-            interval_list: interval_list
+            interval_list: roi_intervals
             scatter_count: mutect_scatter_count
             tumor_sample_name: tumor_sample_name
         out:
@@ -200,7 +202,7 @@ steps:
             reference: reference
             tumor_bam: tumor_bam
             normal_bam: normal_bam
-            interval_list: interval_list
+            interval_list: roi_intervals
             exome_mode: strelka_exome_mode
             cpu_reserved: strelka_cpu_reserved
             normal_sample_name: normal_sample_name
@@ -213,7 +215,7 @@ steps:
             reference: reference
             tumor_bam: tumor_bam
             normal_bam: normal_bam
-            interval_list: interval_list
+            interval_list: roi_intervals
             strand_filter: varscan_strand_filter
             min_coverage: varscan_min_coverage
             min_var_freq: varscan_min_var_freq
@@ -229,7 +231,7 @@ steps:
             reference: reference
             tumor_bam: tumor_bam
             normal_bam: normal_bam
-            interval_list: interval_list
+            interval_list: roi_intervals
             insert_size: pindel_insert_size
             tumor_sample_name: tumor_sample_name
             normal_sample_name: normal_sample_name
@@ -242,7 +244,7 @@ steps:
             tumor_bam: tumor_bam
             normal_bam: normal_bam
             docm_vcf: docm_vcf
-            interval_list: interval_list
+            interval_list: roi_intervals
             filter_docm_variants: filter_docm_variants
         out:
             [docm_variants_vcf]

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -25,7 +25,7 @@ inputs:
     roi_intervals:
         type: File
         label: "roi_intervals: regions of interest in which variants will be called"
-        doc: "a list of regions (in interval_list format) within which to call somatic variants"
+        doc: "roi_intervals is a list of regions (in interval_list format) within which to call somatic variants"
     strelka_exome_mode:
         type: boolean
     strelka_cpu_reserved:

--- a/definitions/pipelines/detect_variants_mouse.cwl
+++ b/definitions/pipelines/detect_variants_mouse.cwl
@@ -17,8 +17,10 @@ inputs:
     normal_bam:
         type: File
         secondaryFiles: [.bai,^.bai]
-    interval_list:
+    roi_intervals:
         type: File
+        label: "roi_intervals: regions of interest in which variants will be called"
+        doc: "a list of regions (in interval_list format) within which to call somatic variants"
     strelka_exome_mode:
         type: boolean
     strelka_cpu_reserved:
@@ -163,7 +165,7 @@ steps:
             reference: reference
             tumor_bam: tumor_bam
             normal_bam: normal_bam
-            interval_list: interval_list
+            interval_list: roi_intervals
             scatter_count: mutect_scatter_count
             tumor_sample_name: tumor_sample_name
         out:
@@ -174,7 +176,7 @@ steps:
             reference: reference
             tumor_bam: tumor_bam
             normal_bam: normal_bam
-            interval_list: interval_list
+            interval_list: roi_intervals
             exome_mode: strelka_exome_mode
             cpu_reserved: strelka_cpu_reserved
             tumor_sample_name: tumor_sample_name
@@ -187,7 +189,7 @@ steps:
             reference: reference
             tumor_bam: tumor_bam
             normal_bam: normal_bam
-            interval_list: interval_list
+            interval_list: roi_intervals
             strand_filter: varscan_strand_filter
             min_coverage: varscan_min_coverage
             min_var_freq: varscan_min_var_freq
@@ -203,7 +205,7 @@ steps:
             reference: reference
             tumor_bam: tumor_bam
             normal_bam: normal_bam
-            interval_list: interval_list
+            interval_list: roi_intervals
             insert_size: pindel_insert_size
             tumor_sample_name: tumor_sample_name
             normal_sample_name: normal_sample_name

--- a/definitions/pipelines/detect_variants_mouse.cwl
+++ b/definitions/pipelines/detect_variants_mouse.cwl
@@ -20,7 +20,7 @@ inputs:
     roi_intervals:
         type: File
         label: "roi_intervals: regions of interest in which variants will be called"
-        doc: "a list of regions (in interval_list format) within which to call somatic variants"
+        doc: "roi_intervals is a list of regions (in interval_list format) within which to call somatic variants"
     strelka_exome_mode:
         type: boolean
     strelka_cpu_reserved:

--- a/definitions/pipelines/detect_variants_wgs.cwl
+++ b/definitions/pipelines/detect_variants_wgs.cwl
@@ -19,7 +19,7 @@ inputs:
     normal_bam:
         type: File
         secondaryFiles: [.bai,^.bai]
-    interval_list:
+    roi_intervals:
         type: File
     strelka_exome_mode:
         type: boolean
@@ -177,7 +177,7 @@ steps:
             reference: reference
             tumor_bam: tumor_bam
             normal_bam: normal_bam
-            interval_list: interval_list
+            interval_list: roi_intervals
             scatter_count: mutect_scatter_count
             tumor_sample_name: tumor_sample_name
         out:
@@ -188,7 +188,7 @@ steps:
             reference: reference
             tumor_bam: tumor_bam
             normal_bam: normal_bam
-            interval_list: interval_list
+            interval_list: roi_intervals
             exome_mode: strelka_exome_mode
             cpu_reserved: strelka_cpu_reserved
             tumor_sample_name: tumor_sample_name
@@ -201,7 +201,7 @@ steps:
             reference: reference
             tumor_bam: tumor_bam
             normal_bam: normal_bam
-            interval_list: interval_list
+            interval_list: roi_intervals
             strand_filter: varscan_strand_filter
             min_coverage: varscan_min_coverage
             min_var_freq: varscan_min_var_freq
@@ -218,7 +218,7 @@ steps:
             tumor_bam: tumor_bam
             normal_bam: normal_bam
             docm_vcf: docm_vcf
-            interval_list: interval_list
+            interval_list: roi_intervals
             filter_docm_variants: filter_docm_variants
         out:
             [docm_variants_vcf]

--- a/definitions/pipelines/germline_exome.cwl
+++ b/definitions/pipelines/germline_exome.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/trimming_options.yml
           - $import: ../types/vep_custom_annotation.yml
     - class: SubworkflowFeatureRequirement
 inputs:
@@ -18,6 +19,10 @@ inputs:
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+    trimming:
+        type:
+            - ../types/trimming_options.yml#trimming_options
+            - "null"
     mills:
         type: File
         secondaryFiles: [.tbi]
@@ -164,6 +169,7 @@ steps:
         in:
             reference: reference
             sequence: sequence
+            trimming: trimming
             mills: mills
             known_indels: known_indels
             dbsnp_vcf: dbsnp_vcf

--- a/definitions/pipelines/germline_exome_gvcf.cwl
+++ b/definitions/pipelines/germline_exome_gvcf.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/trimming_options.yml
     - class: SubworkflowFeatureRequirement
 inputs:
     reference:
@@ -17,6 +18,10 @@ inputs:
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+    trimming:
+        type:
+            - ../types/trimming_options.yml#trimming_options
+            - "null"
     mills:
         type: File
         secondaryFiles: [.tbi]
@@ -115,6 +120,7 @@ steps:
         in:
             reference: reference
             sequence: sequence
+            trimming: trimming
             mills: mills
             known_indels: known_indels
             dbsnp_vcf: dbsnp_vcf

--- a/definitions/pipelines/germline_exome_gvcf.cwl
+++ b/definitions/pipelines/germline_exome_gvcf.cwl
@@ -1,0 +1,183 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+label: "exome alignment and germline variant detection"
+requirements:
+    - class: SchemaDefRequirement
+      types:
+          - $import: ../types/labelled_file.yml
+          - $import: ../types/sequence_data.yml
+    - class: SubworkflowFeatureRequirement
+inputs:
+    reference:
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
+    sequence:
+        type: ../types/sequence_data.yml#sequence_data[]
+    mills:
+        type: File
+        secondaryFiles: [.tbi]
+    known_indels:
+        type: File
+        secondaryFiles: [.tbi]
+    dbsnp_vcf:
+        type: File
+        secondaryFiles: [.tbi]
+    bqsr_intervals:
+        type: string[]?
+    bait_intervals:
+        type: File
+    target_intervals:
+        type: File
+    per_base_intervals:
+        type: ../types/labelled_file.yml#labelled_file[]
+    per_target_intervals:
+        type: ../types/labelled_file.yml#labelled_file[]
+    summary_intervals:
+        type: ../types/labelled_file.yml#labelled_file[]
+    omni_vcf:
+        type: File
+        secondaryFiles: [.tbi]
+    picard_metric_accumulation_level:
+        type: string
+    emit_reference_confidence:
+        type:
+            type: enum
+            symbols: ['NONE', 'BP_RESOLUTION', 'GVCF']
+    gvcf_gq_bands:
+        type: string[]
+    intervals:
+        type:
+            type: array
+            items:
+                type: array
+                items: string
+    ploidy:
+        type: int?
+    synonyms_file:
+        type: File?
+    qc_minimum_mapping_quality:
+        type: int?
+    qc_minimum_base_quality:
+        type: int?
+outputs:
+    cram:
+        type: File
+        outputSource: index_cram/indexed_cram
+    mark_duplicates_metrics:
+        type: File
+        outputSource: alignment_and_qc/mark_duplicates_metrics
+    insert_size_metrics:
+        type: File
+        outputSource: alignment_and_qc/insert_size_metrics
+    insert_size_histogram:
+        type: File
+        outputSource: alignment_and_qc/insert_size_histogram
+    alignment_summary_metrics:
+        type: File
+        outputSource: alignment_and_qc/alignment_summary_metrics
+    hs_metrics:
+        type: File
+        outputSource: alignment_and_qc/hs_metrics
+    per_target_coverage_metrics:
+        type: File[]
+        outputSource: alignment_and_qc/per_target_coverage_metrics
+    per_target_hs_metrics:
+        type: File[]
+        outputSource: alignment_and_qc/per_target_hs_metrics
+    per_base_coverage_metrics:
+        type: File[]
+        outputSource: alignment_and_qc/per_base_coverage_metrics
+    per_base_hs_metrics:
+        type: File[]
+        outputSource: alignment_and_qc/per_base_hs_metrics
+    summary_hs_metrics:
+        type: File[]
+        outputSource: alignment_and_qc/summary_hs_metrics
+    flagstats:
+        type: File
+        outputSource: alignment_and_qc/flagstats
+    verify_bam_id_metrics:
+        type: File
+        outputSource: alignment_and_qc/verify_bam_id_metrics
+    verify_bam_id_depth:
+        type: File
+        outputSource: alignment_and_qc/verify_bam_id_depth
+    gvcf:
+        type: File[]
+        outputSource: generate_gvcfs/gvcf
+steps:
+    alignment_and_qc:
+        run: alignment_exome.cwl
+        in:
+            reference: reference
+            sequence: sequence
+            mills: mills
+            known_indels: known_indels
+            dbsnp_vcf: dbsnp_vcf
+            bqsr_intervals: bqsr_intervals
+            bait_intervals: bait_intervals
+            target_intervals: target_intervals
+            per_base_intervals: per_base_intervals
+            per_target_intervals: per_target_intervals
+            summary_intervals: summary_intervals
+            omni_vcf: omni_vcf
+            picard_metric_accumulation_level: picard_metric_accumulation_level   
+            qc_minimum_mapping_quality: qc_minimum_mapping_quality
+            qc_minimum_base_quality: qc_minimum_base_quality
+        out:
+            [bam, mark_duplicates_metrics, insert_size_metrics, insert_size_histogram, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, summary_hs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]
+    extract_freemix:
+        in:
+            verify_bam_id_metrics: alignment_and_qc/verify_bam_id_metrics
+        out:
+            [freemix_score]
+        run:
+            class: ExpressionTool
+            requirements:
+                - class: InlineJavascriptRequirement
+            inputs:
+                verify_bam_id_metrics:
+                    type: File
+                    inputBinding:
+                        loadContents: true
+            outputs:
+                freemix_score:
+                    type: string?
+            expression: |
+                        ${
+                            var metrics = inputs.verify_bam_id_metrics.contents.split("\n");
+                            if ( metrics[0].split("\t")[6] == 'FREEMIX' ) {
+                                return {'freemix_score': metrics[1].split("\t")[6]};
+                            } else {
+                                return {'freemix_score:': null };
+                            }
+                        }
+    generate_gvcfs:
+        run: ../subworkflows/gatk_haplotypecaller_iterator.cwl
+        in:
+            bam: alignment_and_qc/bam
+            reference: reference
+            emit_reference_confidence: emit_reference_confidence
+            gvcf_gq_bands: gvcf_gq_bands
+            intervals: intervals
+            contamination_fraction: extract_freemix/freemix_score
+            ploidy: ploidy
+        out:
+            [gvcf]
+    bam_to_cram:
+        run: ../tools/bam_to_cram.cwl
+        in:
+            bam: alignment_and_qc/bam
+            reference: reference
+        out:
+            [cram]
+    index_cram:
+         run: ../tools/index_cram.cwl
+         in:
+            cram: bam_to_cram/cram
+         out:
+            [indexed_cram]

--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/trimming_options.yml
           - $import: ../types/vep_custom_annotation.yml
     - class: SubworkflowFeatureRequirement
     - class: StepInputExpressionRequirement
@@ -19,6 +20,10 @@ inputs:
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+    trimming:
+        type:
+            - ../types/trimming_options.yml#trimming_options
+            - "null"
     mills:
         type: File
         secondaryFiles: [.tbi]
@@ -303,6 +308,7 @@ steps:
         in:
             reference: reference
             sequence: sequence
+            trimming: trimming
             mills: mills
             known_indels: known_indels
             dbsnp_vcf: dbsnp_vcf

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -146,7 +146,7 @@ inputs:
           bait_intervals is an interval_list corresponding to the baits used in sequencing reagent.
           These are essentially coordinates for regions you were able to design probes for in the reagent.
           Typically the reagent provider has this information available in bed format and it can be
-          converted to an interval_list with Picards BedToIntervalList. AstraZeneca also maintains a repo
+          converted to an interval_list with Picard BedToIntervalList. AstraZeneca also maintains a repo
           of baits for common sequencing reagents available at https://github.com/AstraZeneca-NGS/reference_data
     target_intervals:
         type: File

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -152,10 +152,17 @@ inputs:
         type: File
         label: "target_intervals: interval_list file of targets used in the sequencing experiment"
         doc: |
-          target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
-          These are essentially coordinates for regions you wanted to design probes for in the reagent.
-          Bed files with this information can be converted to interval_lists with Picards BedToIntervalList.
+          target_intervals is an interval_list corresponding to the targets for the capture reagent.
+          BED files with this information can be converted to interval_lists with Picard BedToIntervalList.
           In general for a WES exome reagent bait_intervals and target_intervals are the same.
+    target_interval_padding:
+        type: int
+        label: "target_interval_padding: number of bp flanking each target region in which to allow variant calls"
+        doc: |
+            The effective coverage of capture products generally extends out beyond the actual regions
+            targeted. This parameter allows variants to be called in these wingspan regions, extending
+            this many base pairs from each side of the target regions.
+        default: 100
     per_base_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
     per_target_intervals:
@@ -173,8 +180,6 @@ inputs:
     qc_minimum_base_quality:
         type: int?
         default: 0
-    interval_list:
-        type: File
     cosmic_vcf:
         type: File?
         secondaryFiles: [.tbi]
@@ -842,6 +847,7 @@ steps:
             bqsr_intervals: bqsr_intervals
             bait_intervals: bait_intervals
             target_intervals: target_intervals
+            target_interval_padding: target_interval_padding
             per_base_intervals: per_base_intervals
             per_target_intervals: per_target_intervals
             summary_intervals: summary_intervals
@@ -849,7 +855,6 @@ steps:
             picard_metric_accumulation_level: picard_metric_accumulation_level
             qc_minimum_mapping_quality: qc_minimum_mapping_quality
             qc_minimum_base_quality: qc_minimum_base_quality
-            interval_list: interval_list
             cosmic_vcf: cosmic_vcf
             panel_of_normals_vcf: panel_of_normals_vcf
             strelka_cpu_reserved: strelka_cpu_reserved

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -117,18 +117,17 @@ inputs:
           bait_intervals is an interval_list corresponding to the baits used in sequencing reagent.
           These are essentially coordinates for regions you were able to design probes for in the reagent.
           Typically the reagent provider has this information available in bed format and it can be
-          converted to an interval_list with Picards BedToIntervalList. Astrazeneca also maintains a repo
+          converted to an interval_list with Picard BedToIntervalList. Astrazeneca also maintains a repo
           of baits for common sequencing reagents available at https://github.com/AstraZeneca-NGS/reference_data
     target_intervals:
         type: File
         label: "target_intervals: interval_list file of targets used in the sequencing experiment"
         doc: |
-          target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
-          These are essentially coordinates for regions designed probes for in the reagent.
-          Bed files with this information can be converted to interval_lists with Picards BedToIntervalList.
+          target_intervals is an interval_list corresponding to the targets for the capture reagent.
+          Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
           In general for a WES exome reagent bait_intervals and target_intervals are the same.
     target_interval_padding:
-        type: int?
+        type: int
         label: "target_interval_padding: number of bp flanking each target region in which to allow variant calls"
         doc: |
             The effective coverage of capture products generally extends out beyond the actual regions
@@ -138,11 +137,11 @@ inputs:
     per_base_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
         label: "per_base_intervals: additional intervals over which to summarize coverage/QC at a per-base resolution"
-        doc: "takes a list of regions (in interval_list format) over which to summarize coverage/QC at a per-base resolution"
+        doc: "per_base_intervals is a list of regions (in interval_list format) over which to summarize coverage/QC at a per-base resolution"
     per_target_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
         label: "per_target_intervals: additional intervals over which to summarize coverage/QC at a per-target resolution"
-        doc: "takes a list of regions (in interval_list format) over which to summarize coverage/QC at a per-target resolution"
+        doc: "per_target_intervals list of regions (in interval_list format) over which to summarize coverage/QC at a per-target resolution"
     summary_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
     omni_vcf:
@@ -522,7 +521,6 @@ steps:
             vcf: somalier_vcf
         out:
             [somalier_pairs, somalier_samples]
-
     pad_target_intervals:
         run: ../tools/interval_list_expand.cwl
         in: 
@@ -530,7 +528,6 @@ steps:
             roi_padding: target_interval_padding
         out:
             [expanded_interval_list]
-
     detect_variants:
         run: detect_variants.cwl
         in:

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -124,13 +124,25 @@ inputs:
         label: "target_intervals: interval_list file of targets used in the sequencing experiment"
         doc: |
           target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
-          These are essentially coordinates for regions you wanted to design probes for in the reagent.
+          These are essentially coordinates for regions designed probes for in the reagent.
           Bed files with this information can be converted to interval_lists with Picards BedToIntervalList.
           In general for a WES exome reagent bait_intervals and target_intervals are the same.
+    target_interval_padding:
+        type: int?
+        label: "target_interval_padding: number of bp flanking each target region in which to allow variant calls"
+        doc: |
+            The effective coverage of capture products generally extends out beyond the actual regions
+            targeted. This parameter allows variants to be called in these wingspan regions, extending
+            this many base pairs from each side of the target regions.
+        default: 100
     per_base_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
+        label: "per_base_intervals: additional intervals over which to summarize coverage/QC at a per-base resolution"
+        doc: "takes a list of regions (in interval_list format) over which to summarize coverage/QC at a per-base resolution"
     per_target_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
+        label: "per_target_intervals: additional intervals over which to summarize coverage/QC at a per-target resolution"
+        doc: "takes a list of regions (in interval_list format) over which to summarize coverage/QC at a per-target resolution"
     summary_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
     omni_vcf:
@@ -144,8 +156,6 @@ inputs:
     qc_minimum_base_quality:
         type: int?
         default: 0
-    interval_list:
-        type: File
     cosmic_vcf:
         type: File?
         secondaryFiles: [.tbi]
@@ -512,13 +522,22 @@ steps:
             vcf: somalier_vcf
         out:
             [somalier_pairs, somalier_samples]
+
+    pad_target_intervals:
+        run: ../tools/interval_list_expand.cwl
+        in: 
+            interval_list: target_intervals
+            roi_padding: target_interval_padding
+        out:
+            [expanded_interval_list]
+
     detect_variants:
         run: detect_variants.cwl
         in:
             reference: reference
             tumor_bam: tumor_alignment_and_qc/bam
             normal_bam: normal_alignment_and_qc/bam
-            interval_list: interval_list
+            roi_intervals: pad_target_intervals/expanded_interval_list
             strelka_exome_mode:
                 default: true
             strelka_cpu_reserved: strelka_cpu_reserved

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -137,11 +137,11 @@ inputs:
     per_base_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
         label: "per_base_intervals: additional intervals over which to summarize coverage/QC at a per-base resolution"
-        doc: "per_base_intervals is a list of regions (in interval_list format) over which to summarize coverage/QC at a per-base resolution"
+        doc: "per_base_intervals is a list of regions (in interval_list format) over which to summarize coverage/QC at a per-base resolution."
     per_target_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
         label: "per_target_intervals: additional intervals over which to summarize coverage/QC at a per-target resolution"
-        doc: "per_target_intervals list of regions (in interval_list format) over which to summarize coverage/QC at a per-target resolution"
+        doc: "per_target_intervals list of regions (in interval_list format) over which to summarize coverage/QC at a per-target resolution."
     summary_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
     omni_vcf:

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -7,6 +7,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/trimming_options.yml
           - $import: ../types/vep_custom_annotation.yml
     - class: SubworkflowFeatureRequirement
     - class: StepInputExpressionRequirement
@@ -66,6 +67,10 @@ inputs:
         doc: |
           normal_name provides a string for what the WT sample will be referred to in the various
           outputs, for exmaple the VCF files.
+    trimming:
+        type:
+            - ../types/trimming_options.yml#trimming_options
+            - "null"
     mills:
         type: File
         secondaryFiles: [.tbi]
@@ -455,6 +460,7 @@ steps:
         in:
             reference: reference
             sequence: tumor_sequence
+            trimming: trimming
             mills: mills
             known_indels: known_indels
             dbsnp_vcf: dbsnp_vcf
@@ -478,6 +484,7 @@ steps:
         in:
             reference: reference
             sequence: normal_sequence
+            trimming: trimming
             mills: mills
             known_indels: known_indels
             dbsnp_vcf: dbsnp_vcf

--- a/definitions/pipelines/somatic_exome_cle.cwl
+++ b/definitions/pipelines/somatic_exome_cle.cwl
@@ -40,9 +40,8 @@ inputs:
         type: File
         label: "target_intervals: interval_list file of targets used in the sequencing experiment"
         doc: |
-          target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
-          These are essentially coordinates for regions designed probes for in the reagent.
-          Bed files with this information can be converted to interval_lists with Picards BedToIntervalList.
+          target_intervals is an interval_list corresponding to the targets for the capture reagent.
+          BED files with this information can be converted to interval_lists with Picard BedToIntervalList.
           In general for a WES exome reagent bait_intervals and target_intervals are the same.
     target_interval_padding:
         type int?
@@ -351,7 +350,6 @@ steps:
             vcf: somalier_vcf
         out:
             [somalier_pairs, somalier_samples]
-
     pad_target_intervals:
         run: ../tools/interval_list_expand.cwl
         in:
@@ -359,7 +357,6 @@ steps:
             roi_padding: target_interval_padding
         out:
             [expanded_interval_list]
-
     detect_variants:
         run: detect_variants.cwl
         in:

--- a/definitions/pipelines/somatic_exome_cle.cwl
+++ b/definitions/pipelines/somatic_exome_cle.cwl
@@ -40,11 +40,11 @@ inputs:
         type: File
         label: "target_intervals: interval_list file of targets used in the sequencing experiment"
         doc: |
-          target_intervals is an interval_list corresponding to the targets for the capture reagent.
-          BED files with this information can be converted to interval_lists with Picard BedToIntervalList.
-          In general for a WES exome reagent bait_intervals and target_intervals are the same.
+            target_intervals is an interval_list corresponding to the targets for the capture reagent.
+            BED files with this information can be converted to interval_lists with Picard BedToIntervalList.
+            In general for a WES exome reagent bait_intervals and target_intervals are the same.
     target_interval_padding:
-        type int?
+        type: int
         label: "target_interval_padding"
         doc: |
             The effective coverage of capture products generally extends out beyond the actual regions

--- a/definitions/pipelines/somatic_exome_cle_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_cle_gathered.cwl
@@ -45,7 +45,7 @@ inputs:
           Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
           In general for a WES exome reagent bait_intervals and target_intervals are the same.
     target_interval_padding:
-        type int?
+        type: int
         label: "target_interval_padding"
         doc: |
             The effective coverage of capture products generally extends out beyond the actual regions

--- a/definitions/pipelines/somatic_exome_cle_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_cle_gathered.cwl
@@ -42,7 +42,7 @@ inputs:
         doc: |
           target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
           These are essentially coordinates for regions designed probes for in the reagent.
-          Bed files with this information can be converted to interval_lists with Picards BedToIntervalList.
+          Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
           In general for a WES exome reagent bait_intervals and target_intervals are the same.
     target_interval_padding:
         type int?

--- a/definitions/pipelines/somatic_exome_cle_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_cle_gathered.cwl
@@ -40,8 +40,7 @@ inputs:
         type: File
         label: "target_intervals: interval_list file of targets used in the sequencing experiment"
         doc: |
-          target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
-          These are essentially coordinates for regions designed probes for in the reagent.
+          target_intervals is an interval_list corresponding to the targets for the capture reagent.
           Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
           In general for a WES exome reagent bait_intervals and target_intervals are the same.
     target_interval_padding:

--- a/definitions/pipelines/somatic_exome_cle_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_cle_gathered.cwl
@@ -38,6 +38,20 @@ inputs:
         type: File
     target_intervals:
         type: File
+        label: "target_intervals: interval_list file of targets used in the sequencing experiment"
+        doc: |
+          target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
+          These are essentially coordinates for regions designed probes for in the reagent.
+          Bed files with this information can be converted to interval_lists with Picards BedToIntervalList.
+          In general for a WES exome reagent bait_intervals and target_intervals are the same.
+    target_interval_padding:
+        type int?
+        label: "target_interval_padding"
+        doc: |
+            The effective coverage of capture products generally extends out beyond the actual regions
+            targeted. This parameter allows variants to be called in these wingspan regions, extending
+            this many base pairs from each side of the target regions.
+        default: 100
     per_base_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
     per_target_intervals:
@@ -55,8 +69,6 @@ inputs:
     qc_minimum_base_quality:
         type: int?
         default: 0
-    interval_list:
-        type: File
     strelka_cpu_reserved:
         type: int?
         default: 8
@@ -158,6 +170,7 @@ steps:
             bqsr_intervals: bqsr_intervals
             bait_intervals: bait_intervals
             target_intervals: target_intervals
+            target_interval_padding: target_interval_padding
             per_base_intervals: per_base_intervals
             per_target_intervals: per_target_intervals
             summary_intervals: summary_intervals
@@ -165,7 +178,6 @@ steps:
             picard_metric_accumulation_level: picard_metric_accumulation_level   
             qc_minimum_mapping_quality: qc_minimum_mapping_quality
             qc_minimum_base_quality: qc_minimum_base_quality
-            interval_list: interval_list
             strelka_cpu_reserved: strelka_cpu_reserved
             mutect_scatter_count: mutect_scatter_count
             varscan_strand_filter: varscan_strand_filter

--- a/definitions/pipelines/somatic_exome_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_gathered.cwl
@@ -44,8 +44,7 @@ inputs:
         type: File
         label: "target_intervals: interval_list file of targets used in the sequencing experiment"
         doc: |            
-            target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
-            These are essentially coordinates for regions designed probes for in the reagent.
+            target_intervals is an interval_list corresponding to the targets for the capture reagent.
             Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
             In general for a WES exome reagent bait_intervals and target_intervals are the same.
     target_interval_padding:

--- a/definitions/pipelines/somatic_exome_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_gathered.cwl
@@ -43,17 +43,15 @@ inputs:
     target_intervals:
         type: File
         label: "target_intervals: interval_list file of targets used in the sequencing experiment"
-        doc: |
-            
-          target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
-          These are essentially coordinates for regions designed probes for in the reagent.
-          Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
-          In general for a WES exome reagent bait_intervals and target_intervals are the same.
+        doc: |            
+            target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
+            These are essentially coordinates for regions designed probes for in the reagent.
+            Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
+            In general for a WES exome reagent bait_intervals and target_intervals are the same.
     target_interval_padding:
-        type int?
+        type: int
         label: "target_interval_padding"
         doc: |
-            
             The effective coverage of capture products generally extends out beyond the actual regions
             targeted. This parameter allows variants to be called in these wingspan regions, extending
             this many base pairs from each side of the target regions.

--- a/definitions/pipelines/somatic_exome_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_gathered.cwl
@@ -47,7 +47,7 @@ inputs:
             
           target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
           These are essentially coordinates for regions designed probes for in the reagent.
-          Bed files with this information can be converted to interval_lists with Picards BedToIntervalList.
+          Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
           In general for a WES exome reagent bait_intervals and target_intervals are the same.
     target_interval_padding:
         type int?

--- a/definitions/pipelines/somatic_exome_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_gathered.cwl
@@ -42,6 +42,22 @@ inputs:
         type: File
     target_intervals:
         type: File
+        label: "target_intervals: interval_list file of targets used in the sequencing experiment"
+        doc: |
+            
+          target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
+          These are essentially coordinates for regions designed probes for in the reagent.
+          Bed files with this information can be converted to interval_lists with Picards BedToIntervalList.
+          In general for a WES exome reagent bait_intervals and target_intervals are the same.
+    target_interval_padding:
+        type int?
+        label: "target_interval_padding"
+        doc: |
+            
+            The effective coverage of capture products generally extends out beyond the actual regions
+            targeted. This parameter allows variants to be called in these wingspan regions, extending
+            this many base pairs from each side of the target regions.
+        default: 100
     per_base_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
     per_target_intervals:
@@ -59,8 +75,6 @@ inputs:
     qc_minimum_base_quality:
         type: int?
         default: 0
-    interval_list:
-        type: File
     cosmic_vcf:
         type: File?
         secondaryFiles: [.tbi]
@@ -171,6 +185,7 @@ steps:
             bqsr_intervals: bqsr_intervals
             bait_intervals: bait_intervals
             target_intervals: target_intervals
+            target_interval_padding: target_interval_padding
             per_base_intervals: per_base_intervals
             per_target_intervals: per_target_intervals
             summary_intervals: summary_intervals
@@ -178,7 +193,6 @@ steps:
             picard_metric_accumulation_level: picard_metric_accumulation_level   
             qc_minimum_mapping_quality: qc_minimum_mapping_quality
             qc_minimum_base_quality: qc_minimum_base_quality
-            interval_list: interval_list
             cosmic_vcf: cosmic_vcf
             panel_of_normals_vcf: panel_of_normals_vcf
             strelka_cpu_reserved: strelka_cpu_reserved

--- a/definitions/pipelines/somatic_exome_mouse.cwl
+++ b/definitions/pipelines/somatic_exome_mouse.cwl
@@ -61,8 +61,6 @@ inputs:
     qc_minimum_base_quality:
         type: int?
         default: 0
-    interval_list:
-        type: File
     strelka_cpu_reserved:
         type: int?
         default: 8

--- a/definitions/pipelines/somatic_exome_mouse.cwl
+++ b/definitions/pipelines/somatic_exome_mouse.cwl
@@ -35,8 +35,7 @@ inputs:
         type: File
         label: "target_intervals: interval_list file of targets used in the sequencing experiment"
         doc: |
-            target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
-            These are essentially coordinates for regions designed probes for in the reagent.
+            target_intervals is an interval_list corresponding to the targets for the capture reagent.
             Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
             In general for a WES exome reagent bait_intervals and target_intervals are the same.
     target_interval_padding:

--- a/definitions/pipelines/somatic_exome_mouse.cwl
+++ b/definitions/pipelines/somatic_exome_mouse.cwl
@@ -37,7 +37,7 @@ inputs:
         doc: |
           target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
           These are essentially coordinates for regions designed probes for in the reagent.
-          Bed files with this information can be converted to interval_lists with Picards BedToIntervalList.
+          Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
           In general for a WES exome reagent bait_intervals and target_intervals are the same.
     target_interval_padding:
         type int?

--- a/definitions/pipelines/somatic_exome_mouse.cwl
+++ b/definitions/pipelines/somatic_exome_mouse.cwl
@@ -35,12 +35,12 @@ inputs:
         type: File
         label: "target_intervals: interval_list file of targets used in the sequencing experiment"
         doc: |
-          target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
-          These are essentially coordinates for regions designed probes for in the reagent.
-          Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
-          In general for a WES exome reagent bait_intervals and target_intervals are the same.
+            target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
+            These are essentially coordinates for regions designed probes for in the reagent.
+            Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
+            In general for a WES exome reagent bait_intervals and target_intervals are the same.
     target_interval_padding:
-        type int?
+        type: int
         label: "target_interval_padding: number of bp flanking each target region in which to allow variant calls"
         doc: |
             The effective coverage of capture products generally extends out beyond the actual regions

--- a/definitions/pipelines/somatic_exome_mouse.cwl
+++ b/definitions/pipelines/somatic_exome_mouse.cwl
@@ -285,7 +285,6 @@ steps:
                 valueFrom: "$(self).bam"
         out:
             [bam, mark_duplicates_metrics, insert_size_metrics, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, summary_hs_metrics, flagstats]
-
     pad_target_intervals:
         run: ../tools/interval_list_expand.cwl
         in:
@@ -293,7 +292,6 @@ steps:
             roi_padding: target_interval_padding
         out:
             [expanded_interval_list]
-
     detect_variants:
         run: detect_variants_mouse.cwl
         in:

--- a/definitions/pipelines/somatic_wgs.cwl
+++ b/definitions/pipelines/somatic_wgs.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/trimming_options.yml
           - $import: ../types/vep_custom_annotation.yml
     - class: SubworkflowFeatureRequirement
     - class: StepInputExpressionRequirement
@@ -23,6 +24,10 @@ inputs:
     normal_name:
         type: string?
         default: 'normal'
+    trimming:
+        type:
+            - ../types/trimming_options.yml#trimming_options
+            - "null"
     mills:
         type: File
         secondaryFiles: [.tbi]
@@ -346,6 +351,7 @@ steps:
         in:
             reference: reference
             sequence: tumor_sequence
+            trimming: trimming
             mills: mills
             known_indels: known_indels
             dbsnp_vcf: dbsnp_vcf
@@ -366,6 +372,7 @@ steps:
         in:
             reference: reference
             sequence: normal_sequence
+            trimming: trimming
             mills: mills
             known_indels: known_indels
             dbsnp_vcf: dbsnp_vcf

--- a/definitions/pipelines/somatic_wgs.cwl
+++ b/definitions/pipelines/somatic_wgs.cwl
@@ -60,8 +60,6 @@ inputs:
     qc_minimum_base_quality:
         type: int?
         default: 0
-    interval_list:
-        type: File
     cosmic_vcf:
         type: File?
         secondaryFiles: [.tbi]

--- a/definitions/pipelines/somatic_wgs.cwl
+++ b/definitions/pipelines/somatic_wgs.cwl
@@ -403,7 +403,7 @@ steps:
             reference: reference
             tumor_bam: tumor_alignment_and_qc/bam
             normal_bam: normal_alignment_and_qc/bam
-            interval_list: interval_list
+            roi_intervals: target_intervals
             dbsnp_vcf: dbsnp_vcf
             cosmic_vcf: cosmic_vcf
             panel_of_normals_vcf: panel_of_normals_vcf

--- a/definitions/pipelines/tumor_only_detect_variants.cwl
+++ b/definitions/pipelines/tumor_only_detect_variants.cwl
@@ -22,7 +22,7 @@ inputs:
     roi_intervals:
         type: File
         label: "roi_intervals: regions of interest in which variants will be called"
-        doc: "a list of regions (in interval_list format) within which to call somatic variants"
+        doc: "roi_intervals is a list of regions (in interval_list format) within which to call somatic variants"
     varscan_strand_filter:
         type: int?
         default: 0

--- a/definitions/pipelines/tumor_only_detect_variants.cwl
+++ b/definitions/pipelines/tumor_only_detect_variants.cwl
@@ -19,8 +19,10 @@ inputs:
     bam:
         type: File
         secondaryFiles: [^.bai,.bai]
-    interval_list:
+    roi_intervals:
         type: File
+        label: "roi_intervals: regions of interest in which variants will be called"
+        doc: "a list of regions (in interval_list format) within which to call somatic variants"
     varscan_strand_filter:
         type: int?
         default: 0
@@ -120,7 +122,7 @@ steps:
         in:
             reference: reference
             bam: bam
-            interval_list: interval_list
+            interval_list: roi_intervals
             strand_filter: varscan_strand_filter
             min_coverage: varscan_min_coverage
             min_var_freq: varscan_min_var_freq
@@ -134,7 +136,7 @@ steps:
         in:
             reference: reference
             bam: bam
-            interval_list: interval_list
+            interval_list: roi_intervals
             docm_vcf: docm_vcf
         out:
             [unfiltered_vcf, filtered_vcf]
@@ -201,7 +203,7 @@ steps:
         in:
             reference: reference
             vcf: index/indexed_vcf
-            interval_list: interval_list
+            interval_list: roi_intervals
             exclude_filtered:
                 default: true
         out:

--- a/definitions/pipelines/tumor_only_exome.cwl
+++ b/definitions/pipelines/tumor_only_exome.cwl
@@ -38,6 +38,20 @@ inputs:
         type: File
     target_intervals:
         type: File
+        label: "target_intervals: interval_list file of targets used in the sequencing experiment"
+        doc: |
+          target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
+          These are essentially coordinates for regions designed probes for in the reagent.
+          Bed files with this information can be converted to interval_lists with Picards BedToIntervalList.
+          In general for a WES exome reagent bait_intervals and target_intervals are the same.
+    target_interval_padding:
+        type int?
+        label: "target_interval_padding: number of bp flanking each target region in which to allow variant calls"
+        doc: |
+            The effective coverage of capture products generally extends out beyond the actual regions
+            targeted. This parameter allows variants to be called in these wingspan regions, extending
+            this many base pairs from each side of the target regions.
+        default: 100
     per_base_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
     per_target_intervals:
@@ -207,12 +221,21 @@ steps:
             qc_minimum_base_quality: qc_minimum_base_quality
         out:
             [bam, mark_duplicates_metrics, insert_size_metrics, insert_size_histogram, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, summary_hs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]
+
+    pad_target_intervals:
+        run: ../tools/interval_list_expand.cwl
+        in: 
+            interval_list: target_intervals
+            roi_padding: target_interval_padding
+        out:
+            [expanded_interval_list]
+
     detect_variants:
         run: tumor_only_detect_variants.cwl
         in:
             reference: reference
             bam: alignment_and_qc/bam
-            interval_list: target_intervals
+            roi_intervals: pad_target_intervals/expanded_interval_list
             varscan_strand_filter: varscan_strand_filter
             varscan_min_coverage: varscan_min_coverage
             varscan_min_var_freq: varscan_min_var_freq

--- a/definitions/pipelines/tumor_only_exome.cwl
+++ b/definitions/pipelines/tumor_only_exome.cwl
@@ -42,7 +42,7 @@ inputs:
         doc: |
           target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
           These are essentially coordinates for regions designed probes for in the reagent.
-          Bed files with this information can be converted to interval_lists with Picards BedToIntervalList.
+          Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
           In general for a WES exome reagent bait_intervals and target_intervals are the same.
     target_interval_padding:
         type int?

--- a/definitions/pipelines/tumor_only_exome.cwl
+++ b/definitions/pipelines/tumor_only_exome.cwl
@@ -40,12 +40,12 @@ inputs:
         type: File
         label: "target_intervals: interval_list file of targets used in the sequencing experiment"
         doc: |
-          target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
-          These are essentially coordinates for regions designed probes for in the reagent.
-          Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
-          In general for a WES exome reagent bait_intervals and target_intervals are the same.
+            target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
+            These are essentially coordinates for regions designed probes for in the reagent.
+            Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
+            In general for a WES exome reagent bait_intervals and target_intervals are the same.
     target_interval_padding:
-        type int?
+        type: int
         label: "target_interval_padding: number of bp flanking each target region in which to allow variant calls"
         doc: |
             The effective coverage of capture products generally extends out beyond the actual regions

--- a/definitions/pipelines/tumor_only_exome.cwl
+++ b/definitions/pipelines/tumor_only_exome.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/trimming_options.yml
           - $import: ../types/vep_custom_annotation.yml
     - class: SubworkflowFeatureRequirement
 inputs:
@@ -18,6 +19,10 @@ inputs:
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+    trimming:
+        type:
+            - ../types/trimming_options.yml#trimming_options
+            - "null"
     mills:
         type: File
         secondaryFiles: [.tbi]
@@ -186,6 +191,7 @@ steps:
         in:
             reference: reference
             sequence: sequence
+            trimming: trimming
             mills: mills
             known_indels: known_indels
             dbsnp_vcf: dbsnp_vcf

--- a/definitions/pipelines/tumor_only_exome.cwl
+++ b/definitions/pipelines/tumor_only_exome.cwl
@@ -221,7 +221,6 @@ steps:
             qc_minimum_base_quality: qc_minimum_base_quality
         out:
             [bam, mark_duplicates_metrics, insert_size_metrics, insert_size_histogram, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, summary_hs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]
-
     pad_target_intervals:
         run: ../tools/interval_list_expand.cwl
         in: 
@@ -229,7 +228,6 @@ steps:
             roi_padding: target_interval_padding
         out:
             [expanded_interval_list]
-
     detect_variants:
         run: tumor_only_detect_variants.cwl
         in:

--- a/definitions/pipelines/tumor_only_exome.cwl
+++ b/definitions/pipelines/tumor_only_exome.cwl
@@ -40,8 +40,7 @@ inputs:
         type: File
         label: "target_intervals: interval_list file of targets used in the sequencing experiment"
         doc: |
-            target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
-            These are essentially coordinates for regions designed probes for in the reagent.
+            target_intervals is an interval_list corresponding to the targets for the capture reagent.
             Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
             In general for a WES exome reagent bait_intervals and target_intervals are the same.
     target_interval_padding:

--- a/definitions/pipelines/tumor_only_wgs.cwl
+++ b/definitions/pipelines/tumor_only_wgs.cwl
@@ -39,8 +39,8 @@ inputs:
         type: File
     picard_metric_accumulation_level:
         type: string
-    variant_detection_intervals:
-        type: File
+    roi_intervals:
+       type: File        
     vep_cache_dir:
         type:
             - string
@@ -182,7 +182,7 @@ steps:
         in:
             reference: reference
             bam: alignment_and_qc/bam
-            interval_list: variant_detection_intervals
+            roi_intervals: roi_intervals
             #varscan_strand_filter:
             #varscan_min_coverage:
             #varscan_min_var_freq:

--- a/definitions/pipelines/tumor_only_wgs.cwl
+++ b/definitions/pipelines/tumor_only_wgs.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/trimming_options.yml
           - $import: ../types/vep_custom_annotation.yml
     - class: SubworkflowFeatureRequirement
 inputs:
@@ -18,6 +19,10 @@ inputs:
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+    trimming:
+        type:
+            - ../types/trimming_options.yml#trimming_options
+            - "null"
     mills:
         type: File
         secondaryFiles: [.tbi]
@@ -158,6 +163,7 @@ steps:
         in:
             reference: reference
             sequence: sequence
+            trimming: trimming
             mills: mills
             known_indels: known_indels
             dbsnp_vcf: dbsnp_vcf

--- a/definitions/pipelines/tumor_only_wgs.cwl
+++ b/definitions/pipelines/tumor_only_wgs.cwl
@@ -40,7 +40,7 @@ inputs:
     picard_metric_accumulation_level:
         type: string
     roi_intervals:
-       type: File        
+       type: File
     vep_cache_dir:
         type:
             - string

--- a/definitions/subworkflows/sequence_align_and_tag_adapter.cwl
+++ b/definitions/subworkflows/sequence_align_and_tag_adapter.cwl
@@ -9,6 +9,7 @@ requirements:
     - class: SchemaDefRequirement
       types:
           - $import: ../types/sequence_data.yml
+          - $import: ../types/trimming_options.yml
     - class: StepInputExpressionRequirement
     - class: SubworkflowFeatureRequirement
 inputs:
@@ -21,6 +22,10 @@ inputs:
             - File
         secondaryFiles: [.amb, .ann, .bwt, .pac, .sa]
         doc: 'bwa-indexed reference file'
+    trimming:
+        type:
+            - ../types/trimming_options.yml#trimming_options
+            - "null"
 outputs:
     aligned_bam:
         type: File
@@ -42,6 +47,6 @@ steps:
             readgroup:
                 source: unaligned
                 valueFrom: $(self.readgroup)
-
+            trimming: trimming
         out:
             [aligned_bam]

--- a/definitions/subworkflows/sequence_to_bqsr.cwl
+++ b/definitions/subworkflows/sequence_to_bqsr.cwl
@@ -7,6 +7,7 @@ requirements:
     - class: SchemaDefRequirement
       types:
           - $import: ../types/sequence_data.yml
+          - $import: ../types/trimming_options.yml
     - class: ScatterFeatureRequirement
     - class: SubworkflowFeatureRequirement
     - class: MultipleInputFeatureRequirement
@@ -21,6 +22,10 @@ inputs:
             - string
             - File
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
+    trimming:
+        type:
+            - ../types/trimming_options.yml#trimming_options
+            - "null"
     dbsnp_vcf:
         type: File
         secondaryFiles: [.tbi]
@@ -49,6 +54,7 @@ steps:
         in:
             unaligned: unaligned
             reference: reference
+            trimming: trimming
         out:
             [aligned_bam]
     merge:

--- a/definitions/subworkflows/sequence_to_bqsr_mouse.cwl
+++ b/definitions/subworkflows/sequence_to_bqsr_mouse.cwl
@@ -7,6 +7,7 @@ requirements:
     - class: SchemaDefRequirement
       types:
           - $import: ../types/sequence_data.yml
+          - $import: ../types/trimming_options.yml
     - class: ScatterFeatureRequirement
     - class: SubworkflowFeatureRequirement
     - class: MultipleInputFeatureRequirement
@@ -19,6 +20,10 @@ inputs:
             - string
             - File
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
+    trimming:
+        type:
+            - ../types/trimming_options.yml#trimming_options
+            - "null"
     final_name:
         type: string
         default: 'final.bam'
@@ -38,6 +43,7 @@ steps:
         in:
             unaligned: unaligned
             reference: reference
+            trimming: trimming
         out:
             [aligned_bam]
     merge:

--- a/definitions/tools/interval_list_expand.cwl
+++ b/definitions/tools/interval_list_expand.cwl
@@ -4,13 +4,13 @@ cwlVersion: v1.0
 class: CommandLineTool
 label: "expand interval list regions by a given number of basepairs"
 
-baseCommand: ["/usr/bin/java", "-Xmx16g", "-jar", "/usr/picard/picard.jar", "IntervalListTools"]
+baseCommand: ["/usr/bin/java", "-Xmx3g", "-jar", "/usr/picard/picard.jar", "IntervalListTools"]
 
 arguments:
-    ["OUTPUT=", { valueFrom: $(runtime.outdir)/expanded.interval_list }, "UNIQUE=TRUE"]
+    [valueFrom: "OUTPUT=$(runtime.outdir)/$(inputs.interval_list.nameroot).expanded.interval_list", "UNIQUE=TRUE"]
 requirements:
     - class: ResourceRequirement
-      ramMin: 16000
+      ramMin: 4000
     - class: DockerRequirement
       dockerPull: "mgibio/picard-cwl:2.18.1"
 inputs:
@@ -18,12 +18,14 @@ inputs:
         type: File
         inputBinding:
             prefix: "INPUT="
+            separate: false
     roi_padding:
         type: int
         inputBinding:
             prefix: "PADDING="
+            separate: false
 outputs:
     expanded_interval_list:
         type: File
         outputBinding:
-            glob: "expanded.interval_list"
+            glob: "$(inputs.interval_list.nameroot).expanded.interval_list"

--- a/definitions/tools/interval_list_expand.cwl
+++ b/definitions/tools/interval_list_expand.cwl
@@ -6,8 +6,6 @@ label: "expand interval list regions by a given number of basepairs"
 
 baseCommand: ["/usr/bin/java", "-Xmx16g", "-jar", "/usr/picard/picard.jar", "IntervalListTools"]
 
-#/usr/bin/java -Xmx16g -jar /usr/picard/picard.jar IntervalListTools INPUT=94b23d66f667472690a7ee165e2037b6.interval_list OUTPUT=expanded.interval_list PADDING=100 UNIQUE=TRUE
-
 arguments:
     ["OUTPUT=", { valueFrom: $(runtime.outdir)/expanded.interval_list }, "UNIQUE=TRUE"]
 requirements:

--- a/definitions/tools/interval_list_expand.cwl
+++ b/definitions/tools/interval_list_expand.cwl
@@ -1,0 +1,31 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: "expand interval list regions by a given number of basepairs"
+
+baseCommand: ["/usr/bin/java", "-Xmx16g", "-jar", "/usr/picard/picard.jar", "IntervalListTools"]
+
+#/usr/bin/java -Xmx16g -jar /usr/picard/picard.jar IntervalListTools INPUT=94b23d66f667472690a7ee165e2037b6.interval_list OUTPUT=expanded.interval_list PADDING=100 UNIQUE=TRUE
+
+arguments:
+    ["OUTPUT=", { valueFrom: $(runtime.outdir)/expanded.interval_list }, "UNIQUE=TRUE"]
+requirements:
+    - class: ResourceRequirement
+      ramMin: 16000
+    - class: DockerRequirement
+      dockerPull: "mgibio/picard-cwl:2.18.1"
+inputs:
+    interval_list:
+        type: File
+        inputBinding:
+            prefix: "INPUT="
+    roi_padding:
+        type: int
+        inputBinding:
+            prefix: "PADDING="
+outputs:
+    expanded_interval_list:
+        type: File
+        outputBinding:
+            glob: "expanded.interval_list"

--- a/definitions/tools/sequence_align_and_tag.cwl
+++ b/definitions/tools/sequence_align_and_tag.cwl
@@ -9,11 +9,13 @@ requirements:
     - class: SchemaDefRequirement
       types:
           - $import: ../types/sequence_data.yml
+          - $import: ../types/trimming_options.yml
     - class: ResourceRequirement
       coresMin: 8
       ramMin: 20000
+    - class: InlineJavascriptRequirement
     - class: DockerRequirement
-      dockerPull: "mgibio/alignment_helper-cwl:1.0.0"
+      dockerPull: "mgibio/alignment_helper-cwl:1.1.0"
     - class: InitialWorkDirRequirement
       listing:
       - entryname: 'sequence_alignment_helper.sh'
@@ -22,7 +24,7 @@ requirements:
             set -o errexit
             set -o nounset
 
-            while getopts "b:?1:?2:?g:r:n:" opt; do
+            while getopts "b:?1:?2:?g:r:n:t:?o:?" opt; do
                 case "$opt" in
                     b)
                         MODE=bam
@@ -45,14 +47,31 @@ requirements:
                     n)
                         NTHREADS="$OPTARG"
                         ;;
+                    t)
+                        TRIMMING_ADAPTERS="$OPTARG"
+                        ;;
+                    o)
+                        TRIMMING_ADAPTER_MIN_OVERLAP="$OPTARG"
+                        ;;
                 esac
             done
 
             if [[ "$MODE" == 'fastq' ]]; then
-                /usr/local/bin/bwa mem -K 100000000 -t "$NTHREADS" -Y -R "$READGROUP" "$REFERENCE" "$FASTQ1" "$FASTQ2" | /usr/local/bin/samblaster -a --addMateTags | /opt/samtools/bin/samtools view -b -S /dev/stdin
+                if [[ -z \${TRIMMING_ADAPTERS-} || -z \${TRIMMING_ADAPTER_MIN_OVERLAP-} ]]; then
+                    /usr/local/bin/bwa mem -K 100000000 -t "$NTHREADS" -Y -R "$READGROUP" "$REFERENCE" "$FASTQ1" "$FASTQ2" | /usr/local/bin/samblaster -a --addMateTags | /opt/samtools/bin/samtools view -b -S /dev/stdin
+                else
+                    /opt/flexbar/flexbar --adapters "$TRIMMING_ADAPTERS" --reads "FASTQ1" --reads2 "$FASTQ2" --adapter-trim-end LTAIL --adapter-min-overlap "$TRIMMING_ADAPTER_MIN_OVERLAP" --adapter-error-rate 0.1 --max-uncalled 300 --stdout-reads \
+                      | /usr/local/bin/bwa mem -K 100000000 -t "$NTHREADS" -Y -p -R "$READGROUP" "$REFERENCE" /dev/stdin | /usr/local/bin/samblaster -a --addMateTags | /opt/samtools/bin/samtools view -b -S /dev/stdin
+                fi
             fi
             if [[ "$MODE" == 'bam' ]]; then
-                /usr/bin/java -Xmx4g -jar /opt/picard/picard.jar SamToFastq I="$BAM" INTERLEAVE=true INCLUDE_NON_PF_READS=true FASTQ=/dev/stdout | /usr/local/bin/bwa mem -K 100000000 -t "$NTHREADS" -Y -p -R "$READGROUP" "$REFERENCE" /dev/stdin | /usr/local/bin/samblaster -a --addMateTags | /opt/samtools/bin/samtools view -b -S /dev/stdin
+                if [[ -z \${TRIMMING_ADAPTERS-} || -z \${TRIMMING_ADAPTER_MIN_OVERLAP-} ]]; then
+                    /usr/bin/java -Xmx4g -jar /opt/picard/picard.jar SamToFastq I="$BAM" INTERLEAVE=true INCLUDE_NON_PF_READS=true FASTQ=/dev/stdout | /usr/local/bin/bwa mem -K 100000000 -t "$NTHREADS" -Y -p -R "$READGROUP" "$REFERENCE" /dev/stdin | /usr/local/bin/samblaster -a --addMateTags | /opt/samtools/bin/samtools view -b -S /dev/stdin
+                else
+                   /usr/bin/java -Xmx4g -jar /opt/picard/picard.jar SamToFastq I="$BAM" INTERLEAVE=true INCLUDE_NON_PF_READS=true FASTQ=/dev/stdout \
+                     | /opt/flexbar/flexbar --adapters "$TRIMMING_ADAPTERS" --reads - --interleaved --adapter-trim-end LTAIL --adapter-min-overlap "$TRIMMING_ADAPTER_MIN_OVERLAP" --adapter-error-rate 0.1 --max-uncalled 300 --stdout-reads \
+                     | /usr/local/bin/bwa mem -K 100000000 -t "$NTHREADS" -Y -p -R "$READGROUP" "$REFERENCE" /dev/stdin | /usr/local/bin/samblaster -a --addMateTags | /opt/samtools/bin/samtools view -b -S /dev/stdin
+                fi
             fi
 stdout: "refAlign.bam"
 arguments:
@@ -85,6 +104,12 @@ inputs:
             position: 4
             prefix: '-r'
         doc: 'bwa-indexed reference file'
+    trimming:
+        type:
+          - ../types/trimming_options.yml#trimming_options
+          - "null"
+        inputBinding:
+            valueFrom: $( ['-t', self.adapters.path, '-o', self.min_overlap] )
 outputs:
     aligned_bam:
         type: stdout

--- a/definitions/tools/sequence_align_and_tag.cwl
+++ b/definitions/tools/sequence_align_and_tag.cwl
@@ -60,7 +60,7 @@ requirements:
                 if [[ -z \${TRIMMING_ADAPTERS-} || -z \${TRIMMING_ADAPTER_MIN_OVERLAP-} ]]; then
                     /usr/local/bin/bwa mem -K 100000000 -t "$NTHREADS" -Y -R "$READGROUP" "$REFERENCE" "$FASTQ1" "$FASTQ2" | /usr/local/bin/samblaster -a --addMateTags | /opt/samtools/bin/samtools view -b -S /dev/stdin
                 else
-                    /opt/flexbar/flexbar --adapters "$TRIMMING_ADAPTERS" --reads "FASTQ1" --reads2 "$FASTQ2" --adapter-trim-end LTAIL --adapter-min-overlap "$TRIMMING_ADAPTER_MIN_OVERLAP" --adapter-error-rate 0.1 --max-uncalled 300 --stdout-reads \
+                    /opt/flexbar/flexbar --adapters "$TRIMMING_ADAPTERS" --reads "$FASTQ1" --reads2 "$FASTQ2" --adapter-trim-end LTAIL --adapter-min-overlap "$TRIMMING_ADAPTER_MIN_OVERLAP" --adapter-error-rate 0.1 --max-uncalled 300 --stdout-reads \
                       | /usr/local/bin/bwa mem -K 100000000 -t "$NTHREADS" -Y -p -R "$READGROUP" "$REFERENCE" /dev/stdin | /usr/local/bin/samblaster -a --addMateTags | /opt/samtools/bin/samtools view -b -S /dev/stdin
                 fi
             fi

--- a/definitions/types/trimming_options.yml
+++ b/definitions/types/trimming_options.yml
@@ -1,0 +1,10 @@
+type: record
+name: trimming_options
+label: trimming adapter file and parameters
+fields:
+    adapters:
+        type: File
+        doc: 'Fasta file with adapters for removal that may contain N.'
+    min_overlap:
+        type: int
+        doc: 'Minimum overlap for removal without pair overlap.'


### PR DESCRIPTION
This PR adds a cwl pipeline for exome GVCF generation which can be used for downstream joint genotyping.