### PR TITLE
adding germline_wgs_gvcf pipeline

### DIFF
--- a/definitions/pipelines/germline_wgs_gvcf.cwl
+++ b/definitions/pipelines/germline_wgs_gvcf.cwl
@@ -1,0 +1,192 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+label: "wgs alignment and germline variant detection"
+requirements:
+    - class: SchemaDefRequirement
+      types:
+          - $import: ../types/labelled_file.yml
+          - $import: ../types/sequence_data.yml
+    - class: SubworkflowFeatureRequirement
+    - class: StepInputExpressionRequirement
+inputs:
+    reference:
+        type:
+            - string
+            - File
+        secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
+    sequence:
+        type: ../types/sequence_data.yml#sequence_data[]
+    mills:
+        type: File
+        secondaryFiles: [.tbi]
+    known_indels:
+        type: File
+        secondaryFiles: [.tbi]
+    dbsnp_vcf:
+        type: File
+        secondaryFiles: [.tbi]
+    omni_vcf:
+        type: File
+        secondaryFiles: [.tbi]
+    picard_metric_accumulation_level:
+        type: string
+    emit_reference_confidence:
+        type:
+            type: enum
+            symbols: ['NONE', 'BP_RESOLUTION', 'GVCF']
+    gvcf_gq_bands:
+        type: string[]
+    intervals:
+        type:
+            type: array
+            items:
+                type: array
+                items: string
+    ploidy:
+        type: int?
+    qc_intervals:
+        type: File
+    synonyms_file:
+        type: File?
+    annotate_coding_only:
+        type: boolean?
+    bqsr_intervals:
+        type: string[]?
+    minimum_mapping_quality:
+        type: int?
+    minimum_base_quality:
+        type: int?
+    per_base_intervals:
+        type: ../types/labelled_file.yml#labelled_file[]
+    per_target_intervals:
+        type: ../types/labelled_file.yml#labelled_file[]
+    summary_intervals:
+        type: ../types/labelled_file.yml#labelled_file[]
+outputs:
+    cram:
+        type: File
+        outputSource: index_cram/indexed_cram
+    mark_duplicates_metrics:
+        type: File
+        outputSource: alignment_and_qc/mark_duplicates_metrics
+    insert_size_metrics:
+        type: File
+        outputSource: alignment_and_qc/insert_size_metrics
+    insert_size_histogram:
+        type: File
+        outputSource: alignment_and_qc/insert_size_histogram
+    alignment_summary_metrics:
+        type: File
+        outputSource: alignment_and_qc/alignment_summary_metrics
+    gc_bias_metrics:
+        type: File
+        outputSource: alignment_and_qc/gc_bias_metrics
+    gc_bias_metrics_chart:
+        type: File
+        outputSource: alignment_and_qc/gc_bias_metrics_chart
+    gc_bias_metrics_summary:
+        type: File
+        outputSource: alignment_and_qc/gc_bias_metrics_summary
+    wgs_metrics:
+        type: File
+        outputSource: alignment_and_qc/wgs_metrics
+    flagstats:
+        type: File
+        outputSource: alignment_and_qc/flagstats
+    verify_bam_id_metrics:
+        type: File
+        outputSource: alignment_and_qc/verify_bam_id_metrics
+    verify_bam_id_depth:
+        type: File
+        outputSource: alignment_and_qc/verify_bam_id_depth
+    per_base_coverage_metrics:
+        type: File[]
+        outputSource: alignment_and_qc/per_base_coverage_metrics
+    per_base_hs_metrics:
+        type: File[]
+        outputSource: alignment_and_qc/per_base_hs_metrics
+    per_target_coverage_metrics:
+        type: File[]
+        outputSource: alignment_and_qc/per_target_coverage_metrics
+    per_target_hs_metrics:
+        type: File[]
+        outputSource: alignment_and_qc/per_target_hs_metrics
+    summary_hs_metrics:
+        type: File[]
+        outputSource: alignment_and_qc/summary_hs_metrics
+    gvcf:
+        type: File[]
+        outputSource: generate_gvcfs/gvcf
+steps:
+    alignment_and_qc:
+        run: alignment_wgs.cwl
+        in:
+            reference: reference
+            sequence: sequence
+            mills: mills
+            known_indels: known_indels
+            dbsnp_vcf: dbsnp_vcf
+            omni_vcf: omni_vcf
+            intervals: qc_intervals
+            picard_metric_accumulation_level: picard_metric_accumulation_level
+            bqsr_intervals: bqsr_intervals
+            minimum_mapping_quality: minimum_mapping_quality
+            minimum_base_quality: minimum_base_quality
+            per_base_intervals: per_base_intervals
+            per_target_intervals: per_target_intervals
+            summary_intervals: summary_intervals
+        out:
+            [bam, mark_duplicates_metrics, insert_size_metrics, insert_size_histogram, alignment_summary_metrics, gc_bias_metrics, gc_bias_metrics_chart, gc_bias_metrics_summary, wgs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth, per_base_coverage_metrics, per_base_hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, summary_hs_metrics]
+    extract_freemix:
+        in:
+            verify_bam_id_metrics: alignment_and_qc/verify_bam_id_metrics
+        out:
+            [freemix_score]
+        run:
+            class: ExpressionTool
+            requirements:
+                - class: InlineJavascriptRequirement
+            inputs:
+                verify_bam_id_metrics:
+                    type: File
+                    inputBinding:
+                        loadContents: true
+            outputs:
+                freemix_score:
+                    type: string?
+            expression: |
+                        ${
+                            var metrics = inputs.verify_bam_id_metrics.contents.split("\n");
+                            if ( metrics[0].split("\t")[6] == 'FREEMIX' ) {
+                                return {'freemix_score': metrics[1].split("\t")[6]};
+                            } else {
+                                return {'freemix_score:': null };
+                            }
+                        }
+    generate_gvcfs:
+        run: ../subworkflows/gatk_haplotypecaller_iterator.cwl
+        in:
+            bam: alignment_and_qc/bam
+            reference: reference
+            emit_reference_confidence: emit_reference_confidence
+            gvcf_gq_bands: gvcf_gq_bands
+            intervals: intervals
+            contamination_fraction: extract_freemix/freemix_score
+            ploidy: ploidy
+        out:
+            [gvcf]
+    bam_to_cram:
+        run: ../tools/bam_to_cram.cwl
+        in:
+            bam: alignment_and_qc/bam
+            reference: reference
+        out:
+            [cram]
+    index_cram:
+         run: ../tools/index_cram.cwl
+         in:
+            cram: bam_to_cram/cram
+         out:
+            [indexed_cram]

--- a/definitions/pipelines/germline_wgs_gvcf.cwl
+++ b/definitions/pipelines/germline_wgs_gvcf.cwl
@@ -8,6 +8,7 @@ requirements:
       types:
           - $import: ../types/labelled_file.yml
           - $import: ../types/sequence_data.yml
+          - $import: ../types/trimming_options.yml
     - class: SubworkflowFeatureRequirement
     - class: StepInputExpressionRequirement
 inputs:
@@ -18,6 +19,10 @@ inputs:
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+    trimming:
+        type:
+            - ../types/trimming_options.yml#trimming_options
+            - "null"
     mills:
         type: File
         secondaryFiles: [.tbi]
@@ -125,6 +130,7 @@ steps:
         in:
             reference: reference
             sequence: sequence
+            trimming: trimming
             mills: mills
             known_indels: known_indels
             dbsnp_vcf: dbsnp_vcf


### PR DESCRIPTION
very similar to #917 but for wgs. Will allow users to get aligned crams and GVCF files which can be used for downstream joint genotyping analysis.