### PR TITLE
Add padding to target regions in somatic variant calling workflows

### DIFF
--- a/definitions/pipelines/aml_trio_cle.cwl
+++ b/definitions/pipelines/aml_trio_cle.cwl
@@ -440,7 +440,7 @@ steps:
             reference: reference
             tumor_bam: tumor_alignment_and_qc/bam
             normal_bam: normal_alignment_and_qc/bam
-            interval_list: interval_list
+            roi_intervals: interval_list
             strelka_exome_mode:
                 default: true
             strelka_cpu_reserved: strelka_cpu_reserved

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -22,8 +22,10 @@ inputs:
     normal_bam:
         type: File
         secondaryFiles: [.bai,^.bai]
-    interval_list:
+    roi_intervals:
         type: File
+        label: "roi_intervals: regions of interest in which variants will be called"
+        doc: "a list of regions (in interval_list format) within which to call somatic variants"
     strelka_exome_mode:
         type: boolean
     strelka_cpu_reserved:
@@ -189,7 +191,7 @@ steps:
             reference: reference
             tumor_bam: tumor_bam
             normal_bam: normal_bam
-            interval_list: interval_list
+            interval_list: roi_intervals
             scatter_count: mutect_scatter_count
             tumor_sample_name: tumor_sample_name
         out:
@@ -200,7 +202,7 @@ steps:
             reference: reference
             tumor_bam: tumor_bam
             normal_bam: normal_bam
-            interval_list: interval_list
+            interval_list: roi_intervals
             exome_mode: strelka_exome_mode
             cpu_reserved: strelka_cpu_reserved
             normal_sample_name: normal_sample_name
@@ -213,7 +215,7 @@ steps:
             reference: reference
             tumor_bam: tumor_bam
             normal_bam: normal_bam
-            interval_list: interval_list
+            interval_list: roi_intervals
             strand_filter: varscan_strand_filter
             min_coverage: varscan_min_coverage
             min_var_freq: varscan_min_var_freq
@@ -229,7 +231,7 @@ steps:
             reference: reference
             tumor_bam: tumor_bam
             normal_bam: normal_bam
-            interval_list: interval_list
+            interval_list: roi_intervals
             insert_size: pindel_insert_size
             tumor_sample_name: tumor_sample_name
             normal_sample_name: normal_sample_name
@@ -242,7 +244,7 @@ steps:
             tumor_bam: tumor_bam
             normal_bam: normal_bam
             docm_vcf: docm_vcf
-            interval_list: interval_list
+            interval_list: roi_intervals
             filter_docm_variants: filter_docm_variants
         out:
             [docm_variants_vcf]

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -25,7 +25,7 @@ inputs:
     roi_intervals:
         type: File
         label: "roi_intervals: regions of interest in which variants will be called"
-        doc: "a list of regions (in interval_list format) within which to call somatic variants"
+        doc: "roi_intervals is a list of regions (in interval_list format) within which to call somatic variants"
     strelka_exome_mode:
         type: boolean
     strelka_cpu_reserved:

--- a/definitions/pipelines/detect_variants_mouse.cwl
+++ b/definitions/pipelines/detect_variants_mouse.cwl
@@ -17,8 +17,10 @@ inputs:
     normal_bam:
         type: File
         secondaryFiles: [.bai,^.bai]
-    interval_list:
+    roi_intervals:
         type: File
+        label: "roi_intervals: regions of interest in which variants will be called"
+        doc: "a list of regions (in interval_list format) within which to call somatic variants"
     strelka_exome_mode:
         type: boolean
     strelka_cpu_reserved:
@@ -163,7 +165,7 @@ steps:
             reference: reference
             tumor_bam: tumor_bam
             normal_bam: normal_bam
-            interval_list: interval_list
+            interval_list: roi_intervals
             scatter_count: mutect_scatter_count
             tumor_sample_name: tumor_sample_name
         out:
@@ -174,7 +176,7 @@ steps:
             reference: reference
             tumor_bam: tumor_bam
             normal_bam: normal_bam
-            interval_list: interval_list
+            interval_list: roi_intervals
             exome_mode: strelka_exome_mode
             cpu_reserved: strelka_cpu_reserved
             tumor_sample_name: tumor_sample_name
@@ -187,7 +189,7 @@ steps:
             reference: reference
             tumor_bam: tumor_bam
             normal_bam: normal_bam
-            interval_list: interval_list
+            interval_list: roi_intervals
             strand_filter: varscan_strand_filter
             min_coverage: varscan_min_coverage
             min_var_freq: varscan_min_var_freq
@@ -203,7 +205,7 @@ steps:
             reference: reference
             tumor_bam: tumor_bam
             normal_bam: normal_bam
-            interval_list: interval_list
+            interval_list: roi_intervals
             insert_size: pindel_insert_size
             tumor_sample_name: tumor_sample_name
             normal_sample_name: normal_sample_name

--- a/definitions/pipelines/detect_variants_mouse.cwl
+++ b/definitions/pipelines/detect_variants_mouse.cwl
@@ -20,7 +20,7 @@ inputs:
     roi_intervals:
         type: File
         label: "roi_intervals: regions of interest in which variants will be called"
-        doc: "a list of regions (in interval_list format) within which to call somatic variants"
+        doc: "roi_intervals is a list of regions (in interval_list format) within which to call somatic variants"
     strelka_exome_mode:
         type: boolean
     strelka_cpu_reserved:

--- a/definitions/pipelines/detect_variants_wgs.cwl
+++ b/definitions/pipelines/detect_variants_wgs.cwl
@@ -19,7 +19,7 @@ inputs:
     normal_bam:
         type: File
         secondaryFiles: [.bai,^.bai]
-    interval_list:
+    roi_intervals:
         type: File
     strelka_exome_mode:
         type: boolean
@@ -177,7 +177,7 @@ steps:
             reference: reference
             tumor_bam: tumor_bam
             normal_bam: normal_bam
-            interval_list: interval_list
+            interval_list: roi_intervals
             scatter_count: mutect_scatter_count
             tumor_sample_name: tumor_sample_name
         out:
@@ -188,7 +188,7 @@ steps:
             reference: reference
             tumor_bam: tumor_bam
             normal_bam: normal_bam
-            interval_list: interval_list
+            interval_list: roi_intervals
             exome_mode: strelka_exome_mode
             cpu_reserved: strelka_cpu_reserved
             tumor_sample_name: tumor_sample_name
@@ -201,7 +201,7 @@ steps:
             reference: reference
             tumor_bam: tumor_bam
             normal_bam: normal_bam
-            interval_list: interval_list
+            interval_list: roi_intervals
             strand_filter: varscan_strand_filter
             min_coverage: varscan_min_coverage
             min_var_freq: varscan_min_var_freq
@@ -218,7 +218,7 @@ steps:
             tumor_bam: tumor_bam
             normal_bam: normal_bam
             docm_vcf: docm_vcf
-            interval_list: interval_list
+            interval_list: roi_intervals
             filter_docm_variants: filter_docm_variants
         out:
             [docm_variants_vcf]

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -146,7 +146,7 @@ inputs:
           bait_intervals is an interval_list corresponding to the baits used in sequencing reagent.
           These are essentially coordinates for regions you were able to design probes for in the reagent.
           Typically the reagent provider has this information available in bed format and it can be
-          converted to an interval_list with Picards BedToIntervalList. AstraZeneca also maintains a repo
+          converted to an interval_list with Picard BedToIntervalList. AstraZeneca also maintains a repo
           of baits for common sequencing reagents available at https://github.com/AstraZeneca-NGS/reference_data
     target_intervals:
         type: File

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -152,10 +152,17 @@ inputs:
         type: File
         label: "target_intervals: interval_list file of targets used in the sequencing experiment"
         doc: |
-          target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
-          These are essentially coordinates for regions you wanted to design probes for in the reagent.
-          Bed files with this information can be converted to interval_lists with Picards BedToIntervalList.
+          target_intervals is an interval_list corresponding to the targets for the capture reagent.
+          BED files with this information can be converted to interval_lists with Picard BedToIntervalList.
           In general for a WES exome reagent bait_intervals and target_intervals are the same.
+    target_interval_padding:
+        type: int
+        label: "target_interval_padding: number of bp flanking each target region in which to allow variant calls"
+        doc: |
+            The effective coverage of capture products generally extends out beyond the actual regions
+            targeted. This parameter allows variants to be called in these wingspan regions, extending
+            this many base pairs from each side of the target regions.
+        default: 100
     per_base_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
     per_target_intervals:
@@ -173,8 +180,6 @@ inputs:
     qc_minimum_base_quality:
         type: int?
         default: 0
-    interval_list:
-        type: File
     cosmic_vcf:
         type: File?
         secondaryFiles: [.tbi]
@@ -842,6 +847,7 @@ steps:
             bqsr_intervals: bqsr_intervals
             bait_intervals: bait_intervals
             target_intervals: target_intervals
+            target_interval_padding: target_interval_padding
             per_base_intervals: per_base_intervals
             per_target_intervals: per_target_intervals
             summary_intervals: summary_intervals
@@ -849,7 +855,6 @@ steps:
             picard_metric_accumulation_level: picard_metric_accumulation_level
             qc_minimum_mapping_quality: qc_minimum_mapping_quality
             qc_minimum_base_quality: qc_minimum_base_quality
-            interval_list: interval_list
             cosmic_vcf: cosmic_vcf
             panel_of_normals_vcf: panel_of_normals_vcf
             strelka_cpu_reserved: strelka_cpu_reserved

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -112,18 +112,17 @@ inputs:
           bait_intervals is an interval_list corresponding to the baits used in sequencing reagent.
           These are essentially coordinates for regions you were able to design probes for in the reagent.
           Typically the reagent provider has this information available in bed format and it can be
-          converted to an interval_list with Picards BedToIntervalList. Astrazeneca also maintains a repo
+          converted to an interval_list with Picard BedToIntervalList. Astrazeneca also maintains a repo
           of baits for common sequencing reagents available at https://github.com/AstraZeneca-NGS/reference_data
     target_intervals:
         type: File
         label: "target_intervals: interval_list file of targets used in the sequencing experiment"
         doc: |
-          target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
-          These are essentially coordinates for regions designed probes for in the reagent.
-          Bed files with this information can be converted to interval_lists with Picards BedToIntervalList.
+          target_intervals is an interval_list corresponding to the targets for the capture reagent.
+          Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
           In general for a WES exome reagent bait_intervals and target_intervals are the same.
     target_interval_padding:
-        type: int?
+        type: int
         label: "target_interval_padding: number of bp flanking each target region in which to allow variant calls"
         doc: |
             The effective coverage of capture products generally extends out beyond the actual regions
@@ -133,11 +132,11 @@ inputs:
     per_base_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
         label: "per_base_intervals: additional intervals over which to summarize coverage/QC at a per-base resolution"
-        doc: "takes a list of regions (in interval_list format) over which to summarize coverage/QC at a per-base resolution"
+        doc: "per_base_intervals is a list of regions (in interval_list format) over which to summarize coverage/QC at a per-base resolution"
     per_target_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
         label: "per_target_intervals: additional intervals over which to summarize coverage/QC at a per-target resolution"
-        doc: "takes a list of regions (in interval_list format) over which to summarize coverage/QC at a per-target resolution"
+        doc: "per_target_intervals list of regions (in interval_list format) over which to summarize coverage/QC at a per-target resolution"
     summary_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
     omni_vcf:
@@ -515,7 +514,6 @@ steps:
             vcf: somalier_vcf
         out:
             [somalier_pairs, somalier_samples]
-
     pad_target_intervals:
         run: ../tools/interval_list_expand.cwl
         in: 
@@ -523,7 +521,6 @@ steps:
             roi_padding: target_interval_padding
         out:
             [expanded_interval_list]
-
     detect_variants:
         run: detect_variants.cwl
         in:

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -119,13 +119,25 @@ inputs:
         label: "target_intervals: interval_list file of targets used in the sequencing experiment"
         doc: |
           target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
-          These are essentially coordinates for regions you wanted to design probes for in the reagent.
+          These are essentially coordinates for regions designed probes for in the reagent.
           Bed files with this information can be converted to interval_lists with Picards BedToIntervalList.
           In general for a WES exome reagent bait_intervals and target_intervals are the same.
+    target_interval_padding:
+        type: int?
+        label: "target_interval_padding: number of bp flanking each target region in which to allow variant calls"
+        doc: |
+            The effective coverage of capture products generally extends out beyond the actual regions
+            targeted. This parameter allows variants to be called in these wingspan regions, extending
+            this many base pairs from each side of the target regions.
+        default: 100
     per_base_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
+        label: "per_base_intervals: additional intervals over which to summarize coverage/QC at a per-base resolution"
+        doc: "takes a list of regions (in interval_list format) over which to summarize coverage/QC at a per-base resolution"
     per_target_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
+        label: "per_target_intervals: additional intervals over which to summarize coverage/QC at a per-target resolution"
+        doc: "takes a list of regions (in interval_list format) over which to summarize coverage/QC at a per-target resolution"
     summary_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
     omni_vcf:
@@ -139,8 +151,6 @@ inputs:
     qc_minimum_base_quality:
         type: int?
         default: 0
-    interval_list:
-        type: File
     cosmic_vcf:
         type: File?
         secondaryFiles: [.tbi]
@@ -505,13 +515,22 @@ steps:
             vcf: somalier_vcf
         out:
             [somalier_pairs, somalier_samples]
+
+    pad_target_intervals:
+        run: ../tools/interval_list_expand.cwl
+        in: 
+            interval_list: target_intervals
+            roi_padding: target_interval_padding
+        out:
+            [expanded_interval_list]
+
     detect_variants:
         run: detect_variants.cwl
         in:
             reference: reference
             tumor_bam: tumor_alignment_and_qc/bam
             normal_bam: normal_alignment_and_qc/bam
-            interval_list: interval_list
+            roi_intervals: pad_target_intervals/expanded_interval_list
             strelka_exome_mode:
                 default: true
             strelka_cpu_reserved: strelka_cpu_reserved

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -132,11 +132,11 @@ inputs:
     per_base_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
         label: "per_base_intervals: additional intervals over which to summarize coverage/QC at a per-base resolution"
-        doc: "per_base_intervals is a list of regions (in interval_list format) over which to summarize coverage/QC at a per-base resolution"
+        doc: "per_base_intervals is a list of regions (in interval_list format) over which to summarize coverage/QC at a per-base resolution."
     per_target_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
         label: "per_target_intervals: additional intervals over which to summarize coverage/QC at a per-target resolution"
-        doc: "per_target_intervals list of regions (in interval_list format) over which to summarize coverage/QC at a per-target resolution"
+        doc: "per_target_intervals list of regions (in interval_list format) over which to summarize coverage/QC at a per-target resolution."
     summary_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
     omni_vcf:

--- a/definitions/pipelines/somatic_exome_cle.cwl
+++ b/definitions/pipelines/somatic_exome_cle.cwl
@@ -40,9 +40,8 @@ inputs:
         type: File
         label: "target_intervals: interval_list file of targets used in the sequencing experiment"
         doc: |
-          target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
-          These are essentially coordinates for regions designed probes for in the reagent.
-          Bed files with this information can be converted to interval_lists with Picards BedToIntervalList.
+          target_intervals is an interval_list corresponding to the targets for the capture reagent.
+          BED files with this information can be converted to interval_lists with Picard BedToIntervalList.
           In general for a WES exome reagent bait_intervals and target_intervals are the same.
     target_interval_padding:
         type int?
@@ -351,7 +350,6 @@ steps:
             vcf: somalier_vcf
         out:
             [somalier_pairs, somalier_samples]
-
     pad_target_intervals:
         run: ../tools/interval_list_expand.cwl
         in:
@@ -359,7 +357,6 @@ steps:
             roi_padding: target_interval_padding
         out:
             [expanded_interval_list]
-
     detect_variants:
         run: detect_variants.cwl
         in:

--- a/definitions/pipelines/somatic_exome_cle.cwl
+++ b/definitions/pipelines/somatic_exome_cle.cwl
@@ -40,11 +40,11 @@ inputs:
         type: File
         label: "target_intervals: interval_list file of targets used in the sequencing experiment"
         doc: |
-          target_intervals is an interval_list corresponding to the targets for the capture reagent.
-          BED files with this information can be converted to interval_lists with Picard BedToIntervalList.
-          In general for a WES exome reagent bait_intervals and target_intervals are the same.
+            target_intervals is an interval_list corresponding to the targets for the capture reagent.
+            BED files with this information can be converted to interval_lists with Picard BedToIntervalList.
+            In general for a WES exome reagent bait_intervals and target_intervals are the same.
     target_interval_padding:
-        type int?
+        type: int
         label: "target_interval_padding"
         doc: |
             The effective coverage of capture products generally extends out beyond the actual regions

--- a/definitions/pipelines/somatic_exome_cle_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_cle_gathered.cwl
@@ -45,7 +45,7 @@ inputs:
           Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
           In general for a WES exome reagent bait_intervals and target_intervals are the same.
     target_interval_padding:
-        type int?
+        type: int
         label: "target_interval_padding"
         doc: |
             The effective coverage of capture products generally extends out beyond the actual regions

--- a/definitions/pipelines/somatic_exome_cle_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_cle_gathered.cwl
@@ -42,7 +42,7 @@ inputs:
         doc: |
           target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
           These are essentially coordinates for regions designed probes for in the reagent.
-          Bed files with this information can be converted to interval_lists with Picards BedToIntervalList.
+          Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
           In general for a WES exome reagent bait_intervals and target_intervals are the same.
     target_interval_padding:
         type int?

--- a/definitions/pipelines/somatic_exome_cle_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_cle_gathered.cwl
@@ -40,8 +40,7 @@ inputs:
         type: File
         label: "target_intervals: interval_list file of targets used in the sequencing experiment"
         doc: |
-          target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
-          These are essentially coordinates for regions designed probes for in the reagent.
+          target_intervals is an interval_list corresponding to the targets for the capture reagent.
           Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
           In general for a WES exome reagent bait_intervals and target_intervals are the same.
     target_interval_padding:

--- a/definitions/pipelines/somatic_exome_cle_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_cle_gathered.cwl
@@ -38,6 +38,20 @@ inputs:
         type: File
     target_intervals:
         type: File
+        label: "target_intervals: interval_list file of targets used in the sequencing experiment"
+        doc: |
+          target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
+          These are essentially coordinates for regions designed probes for in the reagent.
+          Bed files with this information can be converted to interval_lists with Picards BedToIntervalList.
+          In general for a WES exome reagent bait_intervals and target_intervals are the same.
+    target_interval_padding:
+        type int?
+        label: "target_interval_padding"
+        doc: |
+            The effective coverage of capture products generally extends out beyond the actual regions
+            targeted. This parameter allows variants to be called in these wingspan regions, extending
+            this many base pairs from each side of the target regions.
+        default: 100
     per_base_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
     per_target_intervals:
@@ -55,8 +69,6 @@ inputs:
     qc_minimum_base_quality:
         type: int?
         default: 0
-    interval_list:
-        type: File
     strelka_cpu_reserved:
         type: int?
         default: 8
@@ -158,6 +170,7 @@ steps:
             bqsr_intervals: bqsr_intervals
             bait_intervals: bait_intervals
             target_intervals: target_intervals
+            target_interval_padding: target_interval_padding
             per_base_intervals: per_base_intervals
             per_target_intervals: per_target_intervals
             summary_intervals: summary_intervals
@@ -165,7 +178,6 @@ steps:
             picard_metric_accumulation_level: picard_metric_accumulation_level   
             qc_minimum_mapping_quality: qc_minimum_mapping_quality
             qc_minimum_base_quality: qc_minimum_base_quality
-            interval_list: interval_list
             strelka_cpu_reserved: strelka_cpu_reserved
             mutect_scatter_count: mutect_scatter_count
             varscan_strand_filter: varscan_strand_filter

--- a/definitions/pipelines/somatic_exome_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_gathered.cwl
@@ -44,8 +44,7 @@ inputs:
         type: File
         label: "target_intervals: interval_list file of targets used in the sequencing experiment"
         doc: |            
-            target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
-            These are essentially coordinates for regions designed probes for in the reagent.
+            target_intervals is an interval_list corresponding to the targets for the capture reagent.
             Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
             In general for a WES exome reagent bait_intervals and target_intervals are the same.
     target_interval_padding:

--- a/definitions/pipelines/somatic_exome_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_gathered.cwl
@@ -43,17 +43,15 @@ inputs:
     target_intervals:
         type: File
         label: "target_intervals: interval_list file of targets used in the sequencing experiment"
-        doc: |
-            
-          target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
-          These are essentially coordinates for regions designed probes for in the reagent.
-          Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
-          In general for a WES exome reagent bait_intervals and target_intervals are the same.
+        doc: |            
+            target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
+            These are essentially coordinates for regions designed probes for in the reagent.
+            Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
+            In general for a WES exome reagent bait_intervals and target_intervals are the same.
     target_interval_padding:
-        type int?
+        type: int
         label: "target_interval_padding"
         doc: |
-            
             The effective coverage of capture products generally extends out beyond the actual regions
             targeted. This parameter allows variants to be called in these wingspan regions, extending
             this many base pairs from each side of the target regions.

--- a/definitions/pipelines/somatic_exome_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_gathered.cwl
@@ -47,7 +47,7 @@ inputs:
             
           target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
           These are essentially coordinates for regions designed probes for in the reagent.
-          Bed files with this information can be converted to interval_lists with Picards BedToIntervalList.
+          Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
           In general for a WES exome reagent bait_intervals and target_intervals are the same.
     target_interval_padding:
         type int?

--- a/definitions/pipelines/somatic_exome_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_gathered.cwl
@@ -42,6 +42,22 @@ inputs:
         type: File
     target_intervals:
         type: File
+        label: "target_intervals: interval_list file of targets used in the sequencing experiment"
+        doc: |
+            
+          target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
+          These are essentially coordinates for regions designed probes for in the reagent.
+          Bed files with this information can be converted to interval_lists with Picards BedToIntervalList.
+          In general for a WES exome reagent bait_intervals and target_intervals are the same.
+    target_interval_padding:
+        type int?
+        label: "target_interval_padding"
+        doc: |
+            
+            The effective coverage of capture products generally extends out beyond the actual regions
+            targeted. This parameter allows variants to be called in these wingspan regions, extending
+            this many base pairs from each side of the target regions.
+        default: 100
     per_base_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
     per_target_intervals:
@@ -59,8 +75,6 @@ inputs:
     qc_minimum_base_quality:
         type: int?
         default: 0
-    interval_list:
-        type: File
     cosmic_vcf:
         type: File?
         secondaryFiles: [.tbi]
@@ -171,6 +185,7 @@ steps:
             bqsr_intervals: bqsr_intervals
             bait_intervals: bait_intervals
             target_intervals: target_intervals
+            target_interval_padding: target_interval_padding
             per_base_intervals: per_base_intervals
             per_target_intervals: per_target_intervals
             summary_intervals: summary_intervals
@@ -178,7 +193,6 @@ steps:
             picard_metric_accumulation_level: picard_metric_accumulation_level   
             qc_minimum_mapping_quality: qc_minimum_mapping_quality
             qc_minimum_base_quality: qc_minimum_base_quality
-            interval_list: interval_list
             cosmic_vcf: cosmic_vcf
             panel_of_normals_vcf: panel_of_normals_vcf
             strelka_cpu_reserved: strelka_cpu_reserved

--- a/definitions/pipelines/somatic_exome_mouse.cwl
+++ b/definitions/pipelines/somatic_exome_mouse.cwl
@@ -61,8 +61,6 @@ inputs:
     qc_minimum_base_quality:
         type: int?
         default: 0
-    interval_list:
-        type: File
     strelka_cpu_reserved:
         type: int?
         default: 8

--- a/definitions/pipelines/somatic_exome_mouse.cwl
+++ b/definitions/pipelines/somatic_exome_mouse.cwl
@@ -35,8 +35,7 @@ inputs:
         type: File
         label: "target_intervals: interval_list file of targets used in the sequencing experiment"
         doc: |
-            target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
-            These are essentially coordinates for regions designed probes for in the reagent.
+            target_intervals is an interval_list corresponding to the targets for the capture reagent.
             Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
             In general for a WES exome reagent bait_intervals and target_intervals are the same.
     target_interval_padding:

--- a/definitions/pipelines/somatic_exome_mouse.cwl
+++ b/definitions/pipelines/somatic_exome_mouse.cwl
@@ -37,7 +37,7 @@ inputs:
         doc: |
           target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
           These are essentially coordinates for regions designed probes for in the reagent.
-          Bed files with this information can be converted to interval_lists with Picards BedToIntervalList.
+          Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
           In general for a WES exome reagent bait_intervals and target_intervals are the same.
     target_interval_padding:
         type int?

--- a/definitions/pipelines/somatic_exome_mouse.cwl
+++ b/definitions/pipelines/somatic_exome_mouse.cwl
@@ -35,12 +35,12 @@ inputs:
         type: File
         label: "target_intervals: interval_list file of targets used in the sequencing experiment"
         doc: |
-          target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
-          These are essentially coordinates for regions designed probes for in the reagent.
-          Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
-          In general for a WES exome reagent bait_intervals and target_intervals are the same.
+            target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
+            These are essentially coordinates for regions designed probes for in the reagent.
+            Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
+            In general for a WES exome reagent bait_intervals and target_intervals are the same.
     target_interval_padding:
-        type int?
+        type: int
         label: "target_interval_padding: number of bp flanking each target region in which to allow variant calls"
         doc: |
             The effective coverage of capture products generally extends out beyond the actual regions

--- a/definitions/pipelines/somatic_exome_mouse.cwl
+++ b/definitions/pipelines/somatic_exome_mouse.cwl
@@ -285,7 +285,6 @@ steps:
                 valueFrom: "$(self).bam"
         out:
             [bam, mark_duplicates_metrics, insert_size_metrics, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, summary_hs_metrics, flagstats]
-
     pad_target_intervals:
         run: ../tools/interval_list_expand.cwl
         in:
@@ -293,7 +292,6 @@ steps:
             roi_padding: target_interval_padding
         out:
             [expanded_interval_list]
-
     detect_variants:
         run: detect_variants_mouse.cwl
         in:

--- a/definitions/pipelines/somatic_wgs.cwl
+++ b/definitions/pipelines/somatic_wgs.cwl
@@ -55,8 +55,6 @@ inputs:
     qc_minimum_base_quality:
         type: int?
         default: 0
-    interval_list:
-        type: File
     cosmic_vcf:
         type: File?
         secondaryFiles: [.tbi]

--- a/definitions/pipelines/somatic_wgs.cwl
+++ b/definitions/pipelines/somatic_wgs.cwl
@@ -396,7 +396,7 @@ steps:
             reference: reference
             tumor_bam: tumor_alignment_and_qc/bam
             normal_bam: normal_alignment_and_qc/bam
-            interval_list: interval_list
+            roi_intervals: target_intervals
             dbsnp_vcf: dbsnp_vcf
             cosmic_vcf: cosmic_vcf
             panel_of_normals_vcf: panel_of_normals_vcf

--- a/definitions/pipelines/tumor_only_detect_variants.cwl
+++ b/definitions/pipelines/tumor_only_detect_variants.cwl
@@ -22,7 +22,7 @@ inputs:
     roi_intervals:
         type: File
         label: "roi_intervals: regions of interest in which variants will be called"
-        doc: "a list of regions (in interval_list format) within which to call somatic variants"
+        doc: "roi_intervals is a list of regions (in interval_list format) within which to call somatic variants"
     varscan_strand_filter:
         type: int?
         default: 0

--- a/definitions/pipelines/tumor_only_detect_variants.cwl
+++ b/definitions/pipelines/tumor_only_detect_variants.cwl
@@ -19,8 +19,10 @@ inputs:
     bam:
         type: File
         secondaryFiles: [^.bai,.bai]
-    interval_list:
+    roi_intervals:
         type: File
+        label: "roi_intervals: regions of interest in which variants will be called"
+        doc: "a list of regions (in interval_list format) within which to call somatic variants"
     varscan_strand_filter:
         type: int?
         default: 0
@@ -120,7 +122,7 @@ steps:
         in:
             reference: reference
             bam: bam
-            interval_list: interval_list
+            interval_list: roi_intervals
             strand_filter: varscan_strand_filter
             min_coverage: varscan_min_coverage
             min_var_freq: varscan_min_var_freq
@@ -134,7 +136,7 @@ steps:
         in:
             reference: reference
             bam: bam
-            interval_list: interval_list
+            interval_list: roi_intervals
             docm_vcf: docm_vcf
         out:
             [unfiltered_vcf, filtered_vcf]
@@ -201,7 +203,7 @@ steps:
         in:
             reference: reference
             vcf: index/indexed_vcf
-            interval_list: interval_list
+            interval_list: roi_intervals
             exclude_filtered:
                 default: true
         out:

--- a/definitions/pipelines/tumor_only_exome.cwl
+++ b/definitions/pipelines/tumor_only_exome.cwl
@@ -215,7 +215,6 @@ steps:
             qc_minimum_base_quality: qc_minimum_base_quality
         out:
             [bam, mark_duplicates_metrics, insert_size_metrics, insert_size_histogram, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, summary_hs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]
-
     pad_target_intervals:
         run: ../tools/interval_list_expand.cwl
         in: 
@@ -223,7 +222,6 @@ steps:
             roi_padding: target_interval_padding
         out:
             [expanded_interval_list]
-
     detect_variants:
         run: tumor_only_detect_variants.cwl
         in:

--- a/definitions/pipelines/tumor_only_exome.cwl
+++ b/definitions/pipelines/tumor_only_exome.cwl
@@ -33,6 +33,20 @@ inputs:
         type: File
     target_intervals:
         type: File
+        label: "target_intervals: interval_list file of targets used in the sequencing experiment"
+        doc: |
+          target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
+          These are essentially coordinates for regions designed probes for in the reagent.
+          Bed files with this information can be converted to interval_lists with Picards BedToIntervalList.
+          In general for a WES exome reagent bait_intervals and target_intervals are the same.
+    target_interval_padding:
+        type int?
+        label: "target_interval_padding: number of bp flanking each target region in which to allow variant calls"
+        doc: |
+            The effective coverage of capture products generally extends out beyond the actual regions
+            targeted. This parameter allows variants to be called in these wingspan regions, extending
+            this many base pairs from each side of the target regions.
+        default: 100
     per_base_intervals:
         type: ../types/labelled_file.yml#labelled_file[]
     per_target_intervals:
@@ -201,12 +215,21 @@ steps:
             qc_minimum_base_quality: qc_minimum_base_quality
         out:
             [bam, mark_duplicates_metrics, insert_size_metrics, insert_size_histogram, alignment_summary_metrics, hs_metrics, per_target_coverage_metrics, per_target_hs_metrics, per_base_coverage_metrics, per_base_hs_metrics, summary_hs_metrics, flagstats, verify_bam_id_metrics, verify_bam_id_depth]
+
+    pad_target_intervals:
+        run: ../tools/interval_list_expand.cwl
+        in: 
+            interval_list: target_intervals
+            roi_padding: target_interval_padding
+        out:
+            [expanded_interval_list]
+
     detect_variants:
         run: tumor_only_detect_variants.cwl
         in:
             reference: reference
             bam: alignment_and_qc/bam
-            interval_list: target_intervals
+            roi_intervals: pad_target_intervals/expanded_interval_list
             varscan_strand_filter: varscan_strand_filter
             varscan_min_coverage: varscan_min_coverage
             varscan_min_var_freq: varscan_min_var_freq

--- a/definitions/pipelines/tumor_only_exome.cwl
+++ b/definitions/pipelines/tumor_only_exome.cwl
@@ -35,8 +35,7 @@ inputs:
         type: File
         label: "target_intervals: interval_list file of targets used in the sequencing experiment"
         doc: |
-            target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
-            These are essentially coordinates for regions designed probes for in the reagent.
+            target_intervals is an interval_list corresponding to the targets for the capture reagent.
             Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
             In general for a WES exome reagent bait_intervals and target_intervals are the same.
     target_interval_padding:

--- a/definitions/pipelines/tumor_only_exome.cwl
+++ b/definitions/pipelines/tumor_only_exome.cwl
@@ -37,7 +37,7 @@ inputs:
         doc: |
           target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
           These are essentially coordinates for regions designed probes for in the reagent.
-          Bed files with this information can be converted to interval_lists with Picards BedToIntervalList.
+          Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
           In general for a WES exome reagent bait_intervals and target_intervals are the same.
     target_interval_padding:
         type int?

--- a/definitions/pipelines/tumor_only_exome.cwl
+++ b/definitions/pipelines/tumor_only_exome.cwl
@@ -35,12 +35,12 @@ inputs:
         type: File
         label: "target_intervals: interval_list file of targets used in the sequencing experiment"
         doc: |
-          target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
-          These are essentially coordinates for regions designed probes for in the reagent.
-          Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
-          In general for a WES exome reagent bait_intervals and target_intervals are the same.
+            target_intervals is an interval_list corresponding to the targets for the sequencing reagent.
+            These are essentially coordinates for regions designed probes for in the reagent.
+            Bed files with this information can be converted to interval_lists with Picard BedToIntervalList.
+            In general for a WES exome reagent bait_intervals and target_intervals are the same.
     target_interval_padding:
-        type int?
+        type: int
         label: "target_interval_padding: number of bp flanking each target region in which to allow variant calls"
         doc: |
             The effective coverage of capture products generally extends out beyond the actual regions

--- a/definitions/pipelines/tumor_only_wgs.cwl
+++ b/definitions/pipelines/tumor_only_wgs.cwl
@@ -35,7 +35,7 @@ inputs:
     picard_metric_accumulation_level:
         type: string
     roi_intervals:
-       type: File        
+       type: File
     vep_cache_dir:
         type:
             - string

--- a/definitions/pipelines/tumor_only_wgs.cwl
+++ b/definitions/pipelines/tumor_only_wgs.cwl
@@ -34,8 +34,8 @@ inputs:
         type: File
     picard_metric_accumulation_level:
         type: string
-    variant_detection_intervals:
-        type: File
+    roi_intervals:
+       type: File        
     vep_cache_dir:
         type:
             - string
@@ -176,7 +176,7 @@ steps:
         in:
             reference: reference
             bam: alignment_and_qc/bam
-            interval_list: variant_detection_intervals
+            roi_intervals: roi_intervals
             #varscan_strand_filter:
             #varscan_min_coverage:
             #varscan_min_var_freq:


### PR DESCRIPTION
Closes #915

Removes requirement of a second interval list from somatic workflows, and instead bases the roi for variant calling on the target region plus some padding (configurable option)

