### PR TITLE
Trimming: avoid using ${...} syntax in our shell script.

### DIFF
--- a/definitions/tools/sequence_align_and_tag.cwl
+++ b/definitions/tools/sequence_align_and_tag.cwl
@@ -24,6 +24,8 @@ requirements:
             set -o errexit
             set -o nounset
 
+            RUN_TRIMMING="false"
+
             while getopts "b:?1:?2:?g:r:n:t:?o:?" opt; do
                 case "$opt" in
                     b)
@@ -48,16 +50,18 @@ requirements:
                         NTHREADS="$OPTARG"
                         ;;
                     t)
+                        RUN_TRIMMING="true"
                         TRIMMING_ADAPTERS="$OPTARG"
                         ;;
                     o)
+                        RUN_TRIMMING="true"
                         TRIMMING_ADAPTER_MIN_OVERLAP="$OPTARG"
                         ;;
                 esac
             done
 
             if [[ "$MODE" == 'fastq' ]]; then
-                if [[ -z \${TRIMMING_ADAPTERS-} || -z \${TRIMMING_ADAPTER_MIN_OVERLAP-} ]]; then
+                if [[ "$RUN_TRIMMING" == 'false' ]]; then
                     /usr/local/bin/bwa mem -K 100000000 -t "$NTHREADS" -Y -R "$READGROUP" "$REFERENCE" "$FASTQ1" "$FASTQ2" | /usr/local/bin/samblaster -a --addMateTags | /opt/samtools/bin/samtools view -b -S /dev/stdin
                 else
                     /opt/flexbar/flexbar --adapters "$TRIMMING_ADAPTERS" --reads "$FASTQ1" --reads2 "$FASTQ2" --adapter-trim-end LTAIL --adapter-min-overlap "$TRIMMING_ADAPTER_MIN_OVERLAP" --adapter-error-rate 0.1 --max-uncalled 300 --stdout-reads \
@@ -65,7 +69,7 @@ requirements:
                 fi
             fi
             if [[ "$MODE" == 'bam' ]]; then
-                if [[ -z \${TRIMMING_ADAPTERS-} || -z \${TRIMMING_ADAPTER_MIN_OVERLAP-} ]]; then
+                if [[ "$RUN_TRIMMING" == 'false' ]]; then
                     /usr/bin/java -Xmx4g -jar /opt/picard/picard.jar SamToFastq I="$BAM" INTERLEAVE=true INCLUDE_NON_PF_READS=true FASTQ=/dev/stdout | /usr/local/bin/bwa mem -K 100000000 -t "$NTHREADS" -Y -p -R "$READGROUP" "$REFERENCE" /dev/stdin | /usr/local/bin/samblaster -a --addMateTags | /opt/samtools/bin/samtools view -b -S /dev/stdin
                 else
                    /usr/bin/java -Xmx4g -jar /opt/picard/picard.jar SamToFastq I="$BAM" INTERLEAVE=true INCLUDE_NON_PF_READS=true FASTQ=/dev/stdout \


### PR DESCRIPTION
cwltool wants the $ to be escaped but Cromwell doesn't, so it's impossible to make one version that works with both tools.