### PR TITLE
Support Scattering in Varscan, too

### DIFF
--- a/definitions/pipelines/aml_trio_cle.cwl
+++ b/definitions/pipelines/aml_trio_cle.cwl
@@ -79,7 +79,7 @@ inputs:
     strelka_cpu_reserved:
         type: int?
         default: 8
-    mutect_scatter_count:
+    scatter_count:
         type: int
     varscan_strand_filter:
         type: int?
@@ -446,7 +446,7 @@ steps:
             strelka_exome_mode:
                 default: true
             strelka_cpu_reserved: strelka_cpu_reserved
-            mutect_scatter_count: mutect_scatter_count
+            scatter_count: scatter_count
             varscan_strand_filter: varscan_strand_filter
             varscan_min_coverage: varscan_min_coverage
             varscan_min_var_freq: varscan_min_var_freq

--- a/definitions/pipelines/aml_trio_cle.cwl
+++ b/definitions/pipelines/aml_trio_cle.cwl
@@ -81,6 +81,7 @@ inputs:
         default: 8
     scatter_count:
         type: int
+        doc: "scatters each supported variant detector (varscan, pindel, mutect) into this many parallel jobs"
     varscan_strand_filter:
         type: int?
         default: 0

--- a/definitions/pipelines/aml_trio_cle_gathered.cwl
+++ b/definitions/pipelines/aml_trio_cle_gathered.cwl
@@ -79,7 +79,7 @@ inputs:
     strelka_cpu_reserved:
         type: int?
         default: 8
-    mutect_scatter_count:
+    scatter_count:
         type: int
     varscan_strand_filter:
         type: int?
@@ -206,7 +206,7 @@ steps:
             qc_minimum_base_quality: qc_minimum_base_quality
             interval_list: interval_list
             strelka_cpu_reserved: strelka_cpu_reserved
-            mutect_scatter_count: mutect_scatter_count
+            scatter_count: scatter_count
             varscan_strand_filter: varscan_strand_filter
             varscan_min_coverage: varscan_min_coverage
             varscan_min_var_freq: varscan_min_var_freq

--- a/definitions/pipelines/aml_trio_cle_gathered.cwl
+++ b/definitions/pipelines/aml_trio_cle_gathered.cwl
@@ -81,6 +81,7 @@ inputs:
         default: 8
     scatter_count:
         type: int
+        doc: "scatters each supported variant detector (varscan, pindel, mutect) into this many parallel jobs"
     varscan_strand_filter:
         type: int?
         default: 0

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -35,7 +35,7 @@ inputs:
         type: int?
     readcount_minimum_mapping_quality:
         type: int?
-    mutect_scatter_count:
+    scatter_count:
         type: int
         default: 50
     varscan_strand_filter:
@@ -203,7 +203,7 @@ steps:
             tumor_bam: tumor_bam
             normal_bam: normal_bam
             interval_list: roi_intervals
-            scatter_count: mutect_scatter_count
+            scatter_count: scatter_count
             tumor_sample_name: tumor_sample_name
         out:
             [unfiltered_vcf, filtered_vcf]
@@ -227,6 +227,7 @@ steps:
             tumor_bam: tumor_bam
             normal_bam: normal_bam
             interval_list: roi_intervals
+            scatter_count: scatter_count
             strand_filter: varscan_strand_filter
             min_coverage: varscan_min_coverage
             min_var_freq: varscan_min_var_freq
@@ -243,6 +244,7 @@ steps:
             tumor_bam: tumor_bam
             normal_bam: normal_bam
             interval_list: roi_intervals
+            scatter_count: scatter_count
             insert_size: pindel_insert_size
             tumor_sample_name: tumor_sample_name
             normal_sample_name: normal_sample_name

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -38,6 +38,7 @@ inputs:
     scatter_count:
         type: int
         default: 50
+        doc: "scatters each supported variant detector (varscan, pindel, mutect) into this many parallel jobs"
     varscan_strand_filter:
         type: int?
         default: 0

--- a/definitions/pipelines/detect_variants_nonhuman.cwl
+++ b/definitions/pipelines/detect_variants_nonhuman.cwl
@@ -30,7 +30,7 @@ inputs:
         type: int?
     readcount_minimum_mapping_quality:
         type: int?
-    mutect_scatter_count:
+    scatter_count:
         type: int
     varscan_strand_filter:
         type: int?
@@ -175,7 +175,7 @@ steps:
             tumor_bam: tumor_bam
             normal_bam: normal_bam
             interval_list: roi_intervals
-            scatter_count: mutect_scatter_count
+            scatter_count: scatter_count
             tumor_sample_name: tumor_sample_name
         out:
             [unfiltered_vcf, filtered_vcf]
@@ -199,6 +199,7 @@ steps:
             tumor_bam: tumor_bam
             normal_bam: normal_bam
             interval_list: roi_intervals
+            scatter_count: scatter_count
             strand_filter: varscan_strand_filter
             min_coverage: varscan_min_coverage
             min_var_freq: varscan_min_var_freq
@@ -215,6 +216,7 @@ steps:
             tumor_bam: tumor_bam
             normal_bam: normal_bam
             interval_list: roi_intervals
+            scatter_count: scatter_count
             insert_size: pindel_insert_size
             tumor_sample_name: tumor_sample_name
             normal_sample_name: normal_sample_name

--- a/definitions/pipelines/detect_variants_nonhuman.cwl
+++ b/definitions/pipelines/detect_variants_nonhuman.cwl
@@ -32,6 +32,7 @@ inputs:
         type: int?
     scatter_count:
         type: int
+        doc: "scatters each supported variant detector (varscan, pindel, mutect) into this many parallel jobs"
     varscan_strand_filter:
         type: int?
         default: 0

--- a/definitions/pipelines/detect_variants_wgs.cwl
+++ b/definitions/pipelines/detect_variants_wgs.cwl
@@ -30,7 +30,7 @@ inputs:
         type: int?
     readcount_minimum_mapping_quality:
         type: int?
-    mutect_scatter_count:
+    scatter_count:
         type: int?
     varscan_strand_filter:
         type: int?
@@ -187,7 +187,7 @@ steps:
             tumor_bam: tumor_bam
             normal_bam: normal_bam
             interval_list: roi_intervals
-            scatter_count: mutect_scatter_count
+            scatter_count: scatter_count
             tumor_sample_name: tumor_sample_name
         out:
             [unfiltered_vcf, filtered_vcf]
@@ -211,6 +211,7 @@ steps:
             tumor_bam: tumor_bam
             normal_bam: normal_bam
             interval_list: roi_intervals
+            scatter_count: scatter_count
             strand_filter: varscan_strand_filter
             min_coverage: varscan_min_coverage
             min_var_freq: varscan_min_var_freq

--- a/definitions/pipelines/detect_variants_wgs.cwl
+++ b/definitions/pipelines/detect_variants_wgs.cwl
@@ -32,6 +32,7 @@ inputs:
         type: int?
     scatter_count:
         type: int?
+        doc: "scatters each supported variant detector (varscan, pindel, mutect) into this many parallel jobs"
     varscan_strand_filter:
         type: int?
         default: 0

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -183,7 +183,7 @@ inputs:
     strelka_cpu_reserved:
         type: int?
         default: 8
-    mutect_scatter_count:
+    scatter_count:
         type: int
     mutect_artifact_detection_mode:
         type: boolean
@@ -849,7 +849,7 @@ steps:
             qc_minimum_mapping_quality: qc_minimum_mapping_quality
             qc_minimum_base_quality: qc_minimum_base_quality
             strelka_cpu_reserved: strelka_cpu_reserved
-            mutect_scatter_count: mutect_scatter_count
+            scatter_count: scatter_count
             mutect_artifact_detection_mode: mutect_artifact_detection_mode
             mutect_max_alt_allele_in_normal_fraction: mutect_max_alt_allele_in_normal_fraction
             mutect_max_alt_alleles_in_normal_count: mutect_max_alt_alleles_in_normal_count

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -185,6 +185,7 @@ inputs:
         default: 8
     scatter_count:
         type: int
+        doc: "scatters each supported variant detector (varscan, pindel, mutect) into this many parallel jobs"
     mutect_artifact_detection_mode:
         type: boolean
         default: false

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -158,7 +158,7 @@ inputs:
     strelka_cpu_reserved:
         type: int?
         default: 8
-    mutect_scatter_count:
+    scatter_count:
         type: int
     mutect_artifact_detection_mode:
         type: boolean
@@ -544,7 +544,7 @@ steps:
             strelka_exome_mode:
                 default: true
             strelka_cpu_reserved: strelka_cpu_reserved
-            mutect_scatter_count: mutect_scatter_count
+            scatter_count: scatter_count
             varscan_strand_filter: varscan_strand_filter
             varscan_min_coverage: varscan_min_coverage
             varscan_min_var_freq: varscan_min_var_freq

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -161,6 +161,7 @@ inputs:
         default: 8
     scatter_count:
         type: int
+        doc: "scatters each supported variant detector (varscan, pindel, mutect) into this many parallel jobs"
     mutect_artifact_detection_mode:
         type: boolean
         default: false

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -9,6 +9,7 @@ requirements:
           - $import: ../types/sequence_data.yml
           - $import: ../types/trimming_options.yml
           - $import: ../types/vep_custom_annotation.yml
+    - class: MultipleInputFeatureRequirement
     - class: SubworkflowFeatureRequirement
     - class: StepInputExpressionRequirement
 label: "somatic_exome: exome alignment and somatic variant detection"

--- a/definitions/pipelines/somatic_exome_cle.cwl
+++ b/definitions/pipelines/somatic_exome_cle.cwl
@@ -71,7 +71,7 @@ inputs:
     strelka_cpu_reserved:
         type: int?
         default: 8
-    mutect_scatter_count:
+    scatter_count:
         type: int
     varscan_strand_filter:
         type: int?
@@ -379,7 +379,7 @@ steps:
             strelka_exome_mode:
                 default: true
             strelka_cpu_reserved: strelka_cpu_reserved
-            mutect_scatter_count: mutect_scatter_count
+            scatter_count: scatter_count
             varscan_strand_filter: varscan_strand_filter
             varscan_min_coverage: varscan_min_coverage
             varscan_min_var_freq: varscan_min_var_freq

--- a/definitions/pipelines/somatic_exome_cle.cwl
+++ b/definitions/pipelines/somatic_exome_cle.cwl
@@ -73,6 +73,7 @@ inputs:
         default: 8
     scatter_count:
         type: int
+        doc: "scatters each supported variant detector (varscan, pindel, mutect) into this many parallel jobs"
     varscan_strand_filter:
         type: int?
         default: 0

--- a/definitions/pipelines/somatic_exome_cle_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_cle_gathered.cwl
@@ -71,7 +71,7 @@ inputs:
     strelka_cpu_reserved:
         type: int?
         default: 8
-    mutect_scatter_count:
+    scatter_count:
         type: int
     varscan_strand_filter:
         type: int?
@@ -190,7 +190,7 @@ steps:
             qc_minimum_mapping_quality: qc_minimum_mapping_quality
             qc_minimum_base_quality: qc_minimum_base_quality
             strelka_cpu_reserved: strelka_cpu_reserved
-            mutect_scatter_count: mutect_scatter_count
+            scatter_count: scatter_count
             varscan_strand_filter: varscan_strand_filter
             varscan_min_coverage: varscan_min_coverage
             varscan_min_var_freq: varscan_min_var_freq

--- a/definitions/pipelines/somatic_exome_cle_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_cle_gathered.cwl
@@ -73,6 +73,7 @@ inputs:
         default: 8
     scatter_count:
         type: int
+        doc: "scatters each supported variant detector (varscan, pindel, mutect) into this many parallel jobs"
     varscan_strand_filter:
         type: int?
         default: 0

--- a/definitions/pipelines/somatic_exome_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_gathered.cwl
@@ -75,7 +75,7 @@ inputs:
     strelka_cpu_reserved:
         type: int?
         default: 8
-    mutect_scatter_count:
+    scatter_count:
         type: int
     mutect_artifact_detection_mode:
         type: boolean
@@ -199,7 +199,7 @@ steps:
             qc_minimum_mapping_quality: qc_minimum_mapping_quality
             qc_minimum_base_quality: qc_minimum_base_quality
             strelka_cpu_reserved: strelka_cpu_reserved
-            mutect_scatter_count: mutect_scatter_count
+            scatter_count: scatter_count
             mutect_artifact_detection_mode: mutect_artifact_detection_mode
             mutect_max_alt_allele_in_normal_fraction: mutect_max_alt_allele_in_normal_fraction
             mutect_max_alt_alleles_in_normal_count: mutect_max_alt_alleles_in_normal_count

--- a/definitions/pipelines/somatic_exome_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_gathered.cwl
@@ -77,6 +77,7 @@ inputs:
         default: 8
     scatter_count:
         type: int
+        doc: "scatters each supported variant detector (varscan, pindel, mutect) into this many parallel jobs"
     mutect_artifact_detection_mode:
         type: boolean
     mutect_max_alt_allele_in_normal_fraction:

--- a/definitions/pipelines/somatic_exome_nonhuman.cwl
+++ b/definitions/pipelines/somatic_exome_nonhuman.cwl
@@ -65,6 +65,7 @@ inputs:
         default: 8
     scatter_count:
         type: int
+        doc: "scatters each supported variant detector (varscan, pindel, mutect) into this many parallel jobs"
     varscan_strand_filter:
         type: int?
         default: 0

--- a/definitions/pipelines/somatic_exome_nonhuman.cwl
+++ b/definitions/pipelines/somatic_exome_nonhuman.cwl
@@ -63,7 +63,7 @@ inputs:
     strelka_cpu_reserved:
         type: int?
         default: 8
-    mutect_scatter_count:
+    scatter_count:
         type: int
     varscan_strand_filter:
         type: int?
@@ -313,7 +313,7 @@ steps:
             strelka_exome_mode:
                 default: true
             strelka_cpu_reserved: strelka_cpu_reserved
-            mutect_scatter_count: mutect_scatter_count
+            scatter_count: scatter_count
             varscan_strand_filter: varscan_strand_filter
             varscan_min_coverage: varscan_min_coverage
             varscan_min_var_freq: varscan_min_var_freq

--- a/definitions/pipelines/somatic_wgs.cwl
+++ b/definitions/pipelines/somatic_wgs.cwl
@@ -63,7 +63,7 @@ inputs:
     strelka_cpu_reserved:
         type: int?
         default: 8
-    mutect_scatter_count:
+    scatter_count:
         type: int
     mutect_artifact_detection_mode:
         type: boolean
@@ -412,7 +412,7 @@ steps:
             strelka_exome_mode:
                 default: false
             strelka_cpu_reserved: strelka_cpu_reserved
-            mutect_scatter_count: mutect_scatter_count
+            scatter_count: scatter_count
             mutect_artifact_detection_mode: mutect_artifact_detection_mode
             mutect_max_alt_allele_in_normal_fraction: mutect_max_alt_allele_in_normal_fraction
             mutect_max_alt_alleles_in_normal_count: mutect_max_alt_alleles_in_normal_count

--- a/definitions/pipelines/somatic_wgs.cwl
+++ b/definitions/pipelines/somatic_wgs.cwl
@@ -65,6 +65,7 @@ inputs:
         default: 8
     scatter_count:
         type: int
+        doc: "scatters each supported variant detector (varscan, pindel, mutect) into this many parallel jobs"
     mutect_artifact_detection_mode:
         type: boolean
         default: false

--- a/definitions/subworkflows/germline_detect_variants.cwl
+++ b/definitions/subworkflows/germline_detect_variants.cwl
@@ -111,7 +111,7 @@ steps:
     merge_vcfs:
         run: ../tools/picard_merge_vcfs.cwl
         in:
-            gvcfs: haplotype_caller/gvcf
+            vcfs: haplotype_caller/gvcf
         out:
             [merged_vcf]
     annotate_variants:

--- a/definitions/tools/picard_merge_vcfs.cwl
+++ b/definitions/tools/picard_merge_vcfs.cwl
@@ -3,28 +3,35 @@
 cwlVersion: v1.0
 class: CommandLineTool
 label: "Picard MergeVcfs"
-baseCommand: ["/usr/bin/java", "-jar", "-Xmx38g", "/opt/picard/picard.jar", "MergeVcfs"]
+baseCommand: ["/usr/bin/java", "-Xmx38g", "-jar", "/gatk/gatk.jar", "MergeVcfs"]
 requirements:
     - class: ResourceRequirement
       ramMin: 40000
     - class: InlineJavascriptRequirement
     - class: DockerRequirement
-      dockerPull: "mgibio/picard-cwl:2.18.1"
+      dockerPull: "broadinstitute/gatk:4.1.8.1"
 arguments:
-    ["O=$(inputs.merged_vcf_basename).vcf.gz"]
+    ["-O", "$(inputs.merged_vcf_basename).vcf.gz"]
 inputs:
     merged_vcf_basename:
         type: string?
         default: "merged"
-    gvcfs:
+    sequence_dictionary:
+        type:
+            - string
+            - File
+            - 'null'
+        inputBinding:
+            position: 1
+            prefix: "-D"
+    vcfs:
         type:
             type: array
             items: File
             inputBinding:
-                prefix: "I="
-                separate: false
+                prefix: "-I"
         inputBinding:
-            position: 0
+            position: 2
 outputs:
     merged_vcf:
         type: File

--- a/example_data/cle_IDT_exome_template.yml
+++ b/example_data/cle_IDT_exome_template.yml
@@ -18,7 +18,7 @@ panel_of_normals_vcf:
   class: File
   path: /gscmnt/gc2709/info/production_reference_GRCh38DH/CLE/IDTExome/panel_of_normals.vcf.gz
 strelka_exome_mode: true
-mutect_scatter_count: 50
+scatter_count: 50
 mutect_artifact_detection_mode: false
 mutect_max_alt_allele_in_normal_fraction: 0.1
 mutect_max_alt_alleles_in_normal_count: 5

--- a/example_data/cle_IDT_somatic_exome_template.yaml
+++ b/example_data/cle_IDT_somatic_exome_template.yaml
@@ -43,7 +43,7 @@ known_indels:
 mills:
   class: File
   path: /gscmnt/gc2560/core/build_merged_alignments/detect-variants--linus2112.gsc.wustl.edu-jwalker-20211-26b393cc7ab04120ac68cc2cbd4a15df/indels.hq.vcf.gz
-mutect_scatter_count: 80
+scatter_count: 80
 mutect_artifact_detection_mode: false
 mutect_max_alt_allele_in_normal_fraction: 0.1
 mutect_max_alt_alleles_in_normal_count: 5

--- a/example_data/cle_aml_trio_template.yaml
+++ b/example_data/cle_aml_trio_template.yaml
@@ -95,7 +95,7 @@ known_indels:
 mills:
   class: File
   path: /gscmnt/gc2560/core/build_merged_alignments/detect-variants--linus2112.gsc.wustl.edu-jwalker-20211-26b393cc7ab04120ac68cc2cbd4a15df/indels.hq.vcf.gz
-mutect_scatter_count: 80
+scatter_count: 80
 mutect_artifact_detection_mode: false
 mutect_max_alt_allele_in_normal_fraction: 0.1
 mutect_max_alt_alleles_in_normal_count: 5

--- a/example_data/detect_variants/detect_variants.yaml
+++ b/example_data/detect_variants/detect_variants.yaml
@@ -18,7 +18,7 @@ known_indels:
   class: File
   path: ../exome_workflow/chr17_test_known_indels.vcf.gz
 strelka_exome_mode: true
-mutect_scatter_count: 50
+scatter_count: 50
 mutect_artifact_detection_mode: false
 mutect_max_alt_allele_in_normal_fraction: 0.1
 mutect_max_alt_alleles_in_normal_count: 5

--- a/example_data/detect_variants/detect_variants_chr22.yaml
+++ b/example_data/detect_variants/detect_variants_chr22.yaml
@@ -16,7 +16,7 @@ tumor_cram:
   class: File
   path: H_NJ-HCC1395-HCC1395_exome.cram
 strelka_exome_mode: true
-mutect_scatter_count: 50
+scatter_count: 50
 vep_cache_dir: /gscmnt/gc2764/cad/ssiebert/toil_test/inputs/VEP_cache
 synonyms_file:
   class: File

--- a/example_data/somatic_exome.yaml
+++ b/example_data/somatic_exome.yaml
@@ -87,7 +87,7 @@ vep_custom_annotations:
     gnomad_filter: true
     check_existing: true
 vep_ensembl_assembly: GRCh38
-vep_ensembl_version: 95
+vep_ensembl_version: '95'
 vep_ensembl_species: homo_sapiens
 bqsr_intervals:
 - chr17

--- a/example_data/somatic_exome.yaml
+++ b/example_data/somatic_exome.yaml
@@ -94,7 +94,7 @@ bqsr_intervals:
 interval_list:
   class: File
   path: exome_workflow/chr17_test_genes.interval_list
-mutect_scatter_count: 2
+scatter_count: 2
 mutect_artifact_detection_mode: false
 somalier_vcf:
   class: File 

--- a/example_data/somatic_exome_mouse.yaml
+++ b/example_data/somatic_exome_mouse.yaml
@@ -49,4 +49,4 @@ vep_cache_dir: "/gscmnt/gc2560/core/cwl/inputs/VEP_cache/"
 vep_ensembl_assembly: "GRCm38"
 vep_ensembl_version: "96"
 vep_ensembl_species: "mus_musculus"
-mutect_scatter_count: 2
+scatter_count: 2

--- a/example_data/somatic_wgs.yaml
+++ b/example_data/somatic_wgs.yaml
@@ -37,7 +37,7 @@ omni_vcf:
   class: File
   path: /gscmnt/gc2709/info/production_reference_GRCh38DH/accessory_vcf/omni25-ld-pruned-20000-2000-0.5-annotated.wchr.sites_only.b38.autosomes_only.vcf.gz
 picard_metric_accumulation_level: LIBRARY
-mutect_scatter_count: 5
+scatter_count: 5
 vep_cache_dir: /gscmnt/gc2560/core/cwl/inputs/VEP_cache/
 synonyms_file:
   class: File


### PR DESCRIPTION
* Upgrades Picard Merge VCFs to the version in GATK 4.1.8.1.
* Exposes a generic scatter parameter for all variant detectors.
* Scatters Varscan by region like other detectors.

Closes #921.

