### PR TITLE
Updating tool path to work in new docker image

### DIFF
--- a/definitions/tools/sort_vcf.cwl
+++ b/definitions/tools/sort_vcf.cwl
@@ -4,7 +4,7 @@ cwlVersion: v1.0
 class: CommandLineTool
 label: "Sort VCF"
 
-baseCommand: ["/usr/bin/java", "-Xmx16g", "-jar", "/opt/picard/picard.jar", "SortVcf"]
+baseCommand: ["/usr/bin/java", "-Xmx16g", "-jar", "/usr/picard/picard.jar", "SortVcf"]
 arguments:
     ["O=", { valueFrom: $(runtime.outdir)/sorted.vcf }]
 requirements:


### PR DESCRIPTION
#963 switched Picard docker images from an mgibio maintained image to the official Broad image. The mgibio image included the Picard jar in two different locations, but it's only present in one in the Broad image. This patch updates the path to the one present in the Broad image; all other Picard cwls use the path present in both images.