### PR TITLE
Add SV blocklist vcf filter

### DIFF
--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -149,8 +149,7 @@ inputs:
     cnv_filter_min_size:
          type: int?
     blocklist_bedpe:
-        type: string?
-        default: 'NONE'
+        type: File?
     disclaimer_text:
         type: string?
         default: 'Workflow source can be found at https://github.com/genome/analysis-workflows'

--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -148,6 +148,9 @@ inputs:
          type: string[]?
     cnv_filter_min_size:
          type: int?
+    blocklist_bedpe:
+        type: string?
+        default: 'NONE'
     disclaimer_text:
         type: string?
         default: 'Workflow source can be found at https://github.com/genome/analysis-workflows'
@@ -468,6 +471,7 @@ steps:
             sv_paired_count: sv_filter_paired_count
             sv_split_count: sv_filter_split_count
             genome_build: vep_ensembl_assembly
+            blocklist_bedpe: blocklist_bedpe
         out: 
            [cn_diagram, cn_scatter_plot, tumor_antitarget_coverage, tumor_target_coverage, tumor_bin_level_ratios, tumor_segmented_ratios, cnvkit_vcf, cnvnator_cn_file, cnvnator_root, cnvnator_vcf, manta_diploid_variants, manta_somatic_variants, manta_all_candidates, manta_small_candidates, manta_tumor_only_variants, smoove_output_variants, cnvkit_filtered_vcf, cnvnator_filtered_vcf, manta_filtered_vcf, smoove_filtered_vcf, survivor_merged_vcf, survivor_merged_annotated_tsv, bcftools_merged_vcf, bcftools_merged_annotated_tsv, bcftools_merged_filtered_annotated_tsv]
     add_disclaimer_survivor_sv_vcf:

--- a/definitions/subworkflows/merge_svs.cwl
+++ b/definitions/subworkflows/merge_svs.cwl
@@ -31,7 +31,7 @@ inputs:
     sv_vcfs:
         type: File[]
     blocklist_bedpe:
-        type: string
+        type: File?
 outputs:
     bcftools_merged_sv_vcf:
         type: File

--- a/definitions/subworkflows/single_sample_sv_callers.cwl
+++ b/definitions/subworkflows/single_sample_sv_callers.cwl
@@ -57,7 +57,6 @@ inputs:
         type: boolean
     merge_min_sv_size:
         type: int
-
     smoove_exclude_regions:
         type: File?
     snps_vcf:
@@ -76,7 +75,8 @@ inputs:
         type: double?
     cnv_filter_min_size:
         type: int?
-
+    blocklist_bedpe:
+        type: string
 outputs:
     cn_diagram:
         type: File?
@@ -187,7 +187,6 @@ steps:
         in:
             deletion_depth: cnv_deletion_depth
             duplication_depth: cnv_duplication_depth
-            reference: reference
             min_sv_size: cnv_filter_min_size
             output_vcf_name:
                 default: "filtered_cnvkit.vcf"
@@ -222,7 +221,6 @@ steps:
         in:
             deletion_depth: cnv_deletion_depth
             duplication_depth: cnv_duplication_depth
-            reference: reference
             min_sv_size: cnv_filter_min_size
             output_vcf_name:
                 default: "filtered_cnvnator.vcf"
@@ -298,6 +296,7 @@ steps:
             same_strand: merge_same_strand
             same_type: merge_same_type
             snps_vcf: snps_vcf
+            blocklist_bedpe: blocklist_bedpe
             sv_vcfs:
                 source: [run_cnvkit_filter/filtered_vcf, run_cnvnator_filter/filtered_vcf, run_manta_filter/filtered_vcf, run_smoove_filter/filtered_vcf]
                 linkMerge: merge_flattened

--- a/definitions/subworkflows/single_sample_sv_callers.cwl
+++ b/definitions/subworkflows/single_sample_sv_callers.cwl
@@ -76,7 +76,7 @@ inputs:
     cnv_filter_min_size:
         type: int?
     blocklist_bedpe:
-        type: string
+        type: File?
 outputs:
     cn_diagram:
         type: File?

--- a/definitions/tools/filter_sv_vcf_blocklist_bedpe.cwl
+++ b/definitions/tools/filter_sv_vcf_blocklist_bedpe.cwl
@@ -17,19 +17,12 @@ requirements:
           set -eou pipefail
           set -o errexit
           
-          INPUT_VCF="$1"
-          BL_BEDPE="$2"
-          SLOPE="$3"
-          OUT_BASE="$4"
-          
-          #BASE=`basename $1`
-          #NAMEROOT=`echo $BASE | perl -pe 's/.vcf(.gz)?$//g'`
-          
-          if [[ "$BL_BEDPE" == 'NONE' ]]; then
-              /usr/local/bin/bedtools sort -header -i "$INPUT_VCF" > $OUT_BASE.vcf 
-              /opt/htslib/bin/bgzip $OUT_BASE.vcf
-              /usr/bin/tabix -p vcf $OUT_BASE.vcf.gz
-          else
+          if [[ "$#" == 4 ]];then # blocklist_bedpe is passed.
+              INPUT_VCF="$1"
+              BL_BEDPE="$2"
+              SLOPE="$3"
+              OUT_BASE="$4"
+
               #CNVkit outputs invalid format like CIPOS=.,894;CIEND=.,894, which can cause svtools vcftobedpe fail
               if [[ "$INPUT_VCF" =~ \.vcf\.gz$ ]]; then
                   /bin/zcat "$INPUT_VCF" | /bin/sed -E 's/CIPOS=\.,[0-9]+;CIEND=\.,[0-9]+/CIPOS=0,0;CIEND=0,0/g' > fixed_input.vcf
@@ -43,6 +36,14 @@ requirements:
           
               /opt/htslib/bin/bgzip $OUT_BASE.vcf
               /usr/bin/tabix -p vcf $OUT_BASE.vcf.gz
+          else # blocklist_bedpe is not passed.
+              INPUT_VCF="$1"
+              SLOPE="$2"
+              OUT_BASE="$3"
+
+              /usr/local/bin/bedtools sort -header -i "$INPUT_VCF" > $OUT_BASE.vcf
+              /opt/htslib/bin/bgzip $OUT_BASE.vcf
+              /usr/bin/tabix -p vcf $OUT_BASE.vcf.gz
           fi
 
 inputs:
@@ -52,7 +53,7 @@ inputs:
             position: 1
         doc: "vcf file to filter"
     blocklist_bedpe:
-        type: string
+        type: File?
         inputBinding:
             position: 2
         doc: "blocklist bedpe file"

--- a/definitions/tools/filter_sv_vcf_blocklist_bedpe.cwl
+++ b/definitions/tools/filter_sv_vcf_blocklist_bedpe.cwl
@@ -1,0 +1,76 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+
+baseCommand: ["/bin/bash", "filter_sv_vcf_blocklist_bedpe.sh"]
+requirements:
+    - class: ResourceRequirement
+      ramMin: 8000
+    - class: DockerRequirement
+      dockerPull: "mgibio/basespace_chromoseq:v12"
+    - class: InitialWorkDirRequirement
+      listing:
+      - entryname: "filter_sv_vcf_blocklist_bedpe.sh"
+        entry: |
+          #!/bin/bash
+          set -eou pipefail
+          set -o errexit
+          
+          INPUT_VCF="$1"
+          BL_BEDPE="$2"
+          SLOPE="$3"
+          OUT_BASE="$4"
+          
+          #BASE=`basename $1`
+          #NAMEROOT=`echo $BASE | perl -pe 's/.vcf(.gz)?$//g'`
+          
+          if [[ "$BL_BEDPE" == 'NONE' ]]; then
+              /usr/local/bin/bedtools sort -header -i "$INPUT_VCF" > $OUT_BASE.vcf 
+              /opt/htslib/bin/bgzip $OUT_BASE.vcf
+              /usr/bin/tabix -p vcf $OUT_BASE.vcf.gz
+          else
+              #CNVkit outputs invalid format like CIPOS=.,894;CIEND=.,894, which can cause svtools vcftobedpe fail
+              if [[ "$INPUT_VCF" =~ \.vcf\.gz$ ]]; then
+                  /bin/zcat "$INPUT_VCF" | /bin/sed -E 's/CIPOS=\.,[0-9]+;CIEND=\.,[0-9]+/CIPOS=0,0;CIEND=0,0/g' > fixed_input.vcf
+              else
+                  /bin/sed -E 's/CIPOS=\.,[0-9]+;CIEND=\.,[0-9]+/CIPOS=0,0;CIEND=0,0/g' "$INPUT_VCF" > fixed_input.vcf
+              fi
+              #svtools vcftobedpe can take either .vcf or .vcf.gz
+              /opt/conda/envs/python2/bin/svtools vcftobedpe -i fixed_input.vcf -o tmp.bedpe
+              /bin/grep '^#' tmp.bedpe > tmp.header
+              /usr/local/bin/bedtools pairtopair -is -slop "$SLOPE" -type notboth -a tmp.bedpe -b "$BL_BEDPE" | /bin/cat tmp.header /dev/stdin | /opt/conda/envs/python2/bin/svtools bedpetovcf -i /dev/stdin | /opt/conda/envs/python2/bin/svtools vcfsort /dev/stdin > "$OUT_BASE.vcf"
+          
+              /opt/htslib/bin/bgzip $OUT_BASE.vcf
+              /usr/bin/tabix -p vcf $OUT_BASE.vcf.gz
+          fi
+
+inputs:
+    input_vcf:
+        type: File
+        inputBinding:
+            position: 1
+        doc: "vcf file to filter"
+    blocklist_bedpe:
+        type: string
+        inputBinding:
+            position: 2
+        doc: "blocklist bedpe file"
+    slope:
+        type: int?
+        default: 100
+        inputBinding:
+            position: 3
+        doc: "slope(bp) used in bedtools pairtopair"
+    output_vcf_basename:
+        type: string?
+        default: "blocklist_filtered"
+        inputBinding:
+            position: 4
+        doc: "output vcf basename"
+outputs:
+    filtered_sv_vcf:
+        type: File
+        secondaryFiles: [.tbi]
+        outputBinding:
+            glob: $(inputs.output_vcf_basename).vcf.gz


### PR DESCRIPTION
An extra step to filter SVs listed in blocklist bedpe is needed for germline_wgs.cwl.  Refer to https://jira.ris.wustl.edu/browse/CI-487 and https://github.com/genome/analysis-workflows/issues/943