### PR TITLE
Smoove to v0.2.6

### DIFF
--- a/definitions/tools/smoove.cwl
+++ b/definitions/tools/smoove.cwl
@@ -9,7 +9,7 @@ arguments: ["call", "--processes", $(runtime.cores), "-F"]
 
 requirements:
     - class: DockerRequirement
-      dockerPull: "brentp/smoove:v0.2.6"
+      dockerPull: "quay.io/biocontainers/smoove:0.2.6--0"
     - class: ResourceRequirement
       ramMin: 20000
       coresMin: 4

--- a/definitions/tools/smoove.cwl
+++ b/definitions/tools/smoove.cwl
@@ -4,12 +4,12 @@ cwlVersion: v1.0
 class: CommandLineTool
 label: "Run Smoove v0.1.6"
 
-baseCommand: "/usr/local/bin/smoove"
-arguments: ["call", "--processes", "4", "-F"]
+baseCommand: "/usr/bin/smoove"
+arguments: ["call", "--processes", $(runtime.cores), "-F"]
 
 requirements:
     - class: DockerRequirement
-      dockerPull: "brentp/smoove@sha256:9d5098d3882df1443aae36922d36b5188af1cb9b8f83dab4a9ed041a6a8019cc"
+      dockerPull: "brentp/smoove:v0.2.6"
     - class: ResourceRequirement
       ramMin: 20000
       coresMin: 4


### PR DESCRIPTION
This PR upgrades smoove to version `0.2.6`. The previous version was `0.1.6`. I decided to not use the sha256 for better readability on what version is being used in the CWL. 

There are a lot of improvements in calling variants, speeding up analysis, and bug fixes.

The location of where smoove is installed has changed. The inputs/outputs are the same.
part of #948 