### PR TITLE
upgrade cellranger to version 4.0.0

### DIFF
--- a/definitions/tools/cellranger_count.cwl
+++ b/definitions/tools/cellranger_count.cwl
@@ -4,12 +4,12 @@ cwlVersion: v1.0
 class: CommandLineTool
 label: "Run Cell Ranger Count"
 
-baseCommand: ["/apps/cellranger-3.1.0/cellranger", "count"]
+baseCommand: ["/apps/cellranger-4.0.0/cellranger", "count"]
 arguments: ["--id=$(inputs.sample_name)", "--localcores=$(runtime.cores)", "--localmem=$(runtime.ram/1000)"]
 
 requirements:
     - class: DockerRequirement
-      dockerPull: "registry.gsc.wustl.edu/alex.paul/cellranger:3.1.0"
+      dockerPull: "registry.gsc.wustl.edu/alex.paul/cellranger:4.0.0"
     - class: ResourceRequirement
       ramMin: 56000
       coresMin: 8

--- a/definitions/tools/cellranger_feature_barcoding.cwl
+++ b/definitions/tools/cellranger_feature_barcoding.cwl
@@ -5,12 +5,12 @@ class: CommandLineTool
 label: "Run Cell Ranger Count with feature barcoding"
 
 baseCommand: ["/bin/bash", "create_library_file.sh"]
-arguments: [{ shellQuote: false, valueFrom: "&&" }, "/apps/cellranger-3.1.0/cellranger", "count", "--libraries=libraries.csv", "--id=$(inputs.run_name)", "--localcores=$(runtime.cores)", "--localmem=$(runtime.ram/1000)"]
+arguments: [{ shellQuote: false, valueFrom: "&&" }, "/apps/cellranger-4.0.0/cellranger", "count", "--libraries=libraries.csv", "--id=$(inputs.run_name)", "--localcores=$(runtime.cores)", "--localmem=$(runtime.ram/1000)"]
 
 requirements:
     - class: ShellCommandRequirement
     - class: DockerRequirement
-      dockerPull: "registry.gsc.wustl.edu/alex.paul/cellranger:3.1.0"
+      dockerPull: "registry.gsc.wustl.edu/alex.paul/cellranger:4.0.0"
     - class: ResourceRequirement
       ramMin: 56000
       coresMin: 8

--- a/definitions/tools/cellranger_mkfastq.cwl
+++ b/definitions/tools/cellranger_mkfastq.cwl
@@ -4,12 +4,12 @@ cwlVersion: v1.0
 class: CommandLineTool
 label: "Run Cell Ranger mkfastq"
 
-baseCommand: ["/apps/cellranger-3.1.0/cellranger", "mkfastq", "--id=cellranger_output"]
+baseCommand: ["/apps/cellranger-4.0.0/cellranger", "mkfastq", "--id=cellranger_output"]
 arguments: ["--localcores=$(runtime.cores)", "--localmem=$(runtime.ram/1000)"]
 
 requirements:
     - class: DockerRequirement
-      dockerPull: "registry.gsc.wustl.edu/alex.paul/cellranger:3.1.0"
+      dockerPull: "registry.gsc.wustl.edu/alex.paul/cellranger:4.0.0"
     - class: ResourceRequirement
       ramMin: 64000
       coresMin: 8

--- a/definitions/tools/cellranger_vdj.cwl
+++ b/definitions/tools/cellranger_vdj.cwl
@@ -4,12 +4,12 @@ cwlVersion: v1.0
 class: CommandLineTool
 label: "Run Cell Ranger V(D)J"
 
-baseCommand: ["/apps/cellranger-3.1.0/cellranger", "vdj"]
+baseCommand: ["/apps/cellranger-4.0.0/cellranger", "vdj"]
 arguments: ["--id=$(inputs.sample_name)", "--localcores=$(runtime.cores)", "--localmem=$(runtime.ram/1000)"]
 
 requirements:
     - class: DockerRequirement
-      dockerPull: "registry.gsc.wustl.edu/alex.paul/cellranger:3.1.0"
+      dockerPull: "registry.gsc.wustl.edu/alex.paul/cellranger:4.0.0"
     - class: ResourceRequirement
       ramMin: 64000
       coresMin: 8


### PR DESCRIPTION
I was able to run a small test dataset through the mkfastq and count steps. 
I downloaded the example bcl data from  
https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/using/mkfastq#example_data


```
bcl_directory:
  class: Directory
  path: /data/cellranger-tiny-bcl-1.2.0
simple_sample_csv:
  class: File
  path: /data/cellranger-tiny-bcl-simple-1.2.0.csv
sample_name: test_sample
reference:
  class: Directory
  path: /gscmnt/gc2560/core/reference_sequences/refdata-cellranger-GRCh38-3.0.0
chemistry: SC3Pv2
```
