### PR TITLE
Upgrade fgbio to 1.3.0

### DIFF
--- a/definitions/tools/call_duplex_consensus.cwl
+++ b/definitions/tools/call_duplex_consensus.cwl
@@ -3,7 +3,7 @@
 cwlVersion: v1.0
 class: CommandLineTool
 label: 'call duplex consensus'
-baseCommand: ["/usr/bin/java", "-Xmx4g", "-jar", "/opt/fgbio-0.5.0.jar", "CallDuplexConsensusReads"]
+baseCommand: ["/usr/local/bin/fgbio", "CallDuplexConsensusReads"]
 arguments:
     ["--error-rate-pre-umi", "45", "--error-rate-post-umi", "30", "--min-input-base-quality", "30",
     "--output", { valueFrom: "$(runtime.outdir)/consensus_unaligned.bam"} ]
@@ -12,7 +12,7 @@ requirements:
       ramMin: 6000
       tmpdirMin: 25000
     - class: DockerRequirement
-      dockerPull: mgibio/dna-alignment:1.0.0
+      dockerPull: quay.io/biocontainers/fgbio:1.3.0--0
 inputs:
     bam:
         type: File

--- a/definitions/tools/call_molecular_consensus.cwl
+++ b/definitions/tools/call_molecular_consensus.cwl
@@ -3,7 +3,7 @@
 cwlVersion: v1.0
 class: CommandLineTool
 label: 'call molecular consensus'
-baseCommand: ["/usr/bin/java", "-Xmx4g", "-jar", "/opt/fgbio-0.5.0.jar", "CallMolecularConsensusReads"]
+baseCommand: ["/usr/local/bin/fgbio", "CallMolecularConsensusReads"]
 arguments:
     ["--error-rate-pre-umi", "45", "--error-rate-post-umi", "30", "--min-input-base-quality", "30", "--min-reads", "1",
     "--output", { valueFrom: "$(runtime.outdir)/consensus_unaligned.bam"} ]
@@ -12,7 +12,7 @@ requirements:
       ramMin: 6000
       tmpdirMin: 25000
     - class: DockerRequirement
-      dockerPull: mgibio/dna-alignment:1.0.0
+      dockerPull: quay.io/biocontainers/fgbio:1.3.0--0
 inputs:
     bam:
         type: File

--- a/definitions/tools/clip_overlap.cwl
+++ b/definitions/tools/clip_overlap.cwl
@@ -3,16 +3,16 @@
 cwlVersion: v1.0
 class: CommandLineTool
 label: 'clip overlapping reads'
-baseCommand: ["/usr/bin/java", "-Xmx4g", "-jar", "/opt/fgbio-0.5.0.jar", "ClipBam"]
+baseCommand: ["/usr/local/bin/fgbio", "ClipBam"]
 arguments:
-    ["--soft-clip", "false", "--clip-overlapping-reads", "true",
+    ["--clipping-mode", "Hard", "--clip-overlapping-reads", "true",
     "--output", { valueFrom: "$(runtime.outdir)/clipped.bam"} ]
 requirements:
     - class: ResourceRequirement
       ramMin: 6000
       tmpdirMin: 25000
     - class: DockerRequirement
-      dockerPull: mgibio/dna-alignment:1.0.0
+      dockerPull: quay.io/biocontainers/fgbio:1.3.0--0
 inputs:
     bam:
         type: File

--- a/definitions/tools/duplex_seq_metrics.cwl
+++ b/definitions/tools/duplex_seq_metrics.cwl
@@ -3,7 +3,7 @@
 cwlVersion: v1.0
 class: CommandLineTool
 label: 'collect duplex seq metrics'
-baseCommand: ["/usr/bin/java", "-Xmx4g", "-jar", "/opt/fgbio-0.5.0.jar", "CollectDuplexSeqMetrics"]
+baseCommand: ["/usr/local/bin/fgbio", "CollectDuplexSeqMetrics"]
 arguments:
     ["--output", { valueFrom: "$(runtime.outdir)/duplex_seq.metrics"} ]
 requirements:
@@ -11,7 +11,7 @@ requirements:
       ramMin: 6000
       tmpdirMin: 1000
     - class: DockerRequirement
-      dockerPull: mgibio/dna-alignment:1.0.0
+      dockerPull: quay.io/biocontainers/fgbio:1.3.0--0
 inputs:
     bam:
         type: File

--- a/definitions/tools/extract_umis.cwl
+++ b/definitions/tools/extract_umis.cwl
@@ -3,7 +3,7 @@
 cwlVersion: v1.0
 class: CommandLineTool
 label: 'extract umis from bam'
-baseCommand: ["/usr/bin/java", "-Xmx4g", "-jar", "/opt/fgbio-0.5.0.jar", "ExtractUmisFromBam"]
+baseCommand: ["/usr/local/bin/fgbio", "ExtractUmisFromBam"]
 arguments:
     ["--molecular-index-tags", "ZA", "ZB", "--single-tag", "RX",
     "--output", { valueFrom: "$(runtime.outdir)/umi_extracted.bam"} ]
@@ -12,7 +12,7 @@ requirements:
       ramMin: 6000
       tmpdirMin: 25000
     - class: DockerRequirement
-      dockerPull: mgibio/dna-alignment:1.0.0
+      dockerPull: quay.io/biocontainers/fgbio:1.3.0--0
 inputs:
     bam:
         type: File

--- a/definitions/tools/filter_consensus.cwl
+++ b/definitions/tools/filter_consensus.cwl
@@ -3,7 +3,7 @@
 cwlVersion: v1.0
 class: CommandLineTool
 label: 'filter consensus reads'
-baseCommand: ["/usr/bin/java", "-Xmx4g", "-jar", "/opt/fgbio-0.5.0.jar", "FilterConsensusReads"]
+baseCommand: ["/usr/local/bin/fgbio", "FilterConsensusReads"]
 arguments:
     [ "--output", { valueFrom: "$(runtime.outdir)/consensus_filtered.bam"} ]
 requirements:
@@ -11,7 +11,7 @@ requirements:
       ramMin: 6000
       tmpdirMin: 25000
     - class: DockerRequirement
-      dockerPull: mgibio/dna-alignment:1.0.0
+      dockerPull: quay.io/biocontainers/fgbio:1.3.0--0
 inputs:
     bam:
         type: File

--- a/definitions/tools/group_reads.cwl
+++ b/definitions/tools/group_reads.cwl
@@ -3,7 +3,7 @@
 cwlVersion: v1.0
 class: CommandLineTool
 label: 'group reads by umi'
-baseCommand: ["/usr/bin/java", "-Xmx4g", "-jar", "/opt/fgbio-0.5.0.jar", "GroupReadsByUmi"]
+baseCommand: ["/usr/local/bin/fgbio", "GroupReadsByUmi"]
 arguments:
     ["--strategy", "paired", "--assign-tag", "MI", "--raw-tag", "RX", "--min-map-q", "10", "--edits", "1",
     "--output", { valueFrom: "$(runtime.outdir)/umi_grouped.bam"} ]
@@ -12,7 +12,7 @@ requirements:
       ramMin: 6000
       tmpdirMin: 25000
     - class: DockerRequirement
-      dockerPull: mgibio/dna-alignment:1.0.0
+      dockerPull: quay.io/biocontainers/fgbio:1.3.0--0
 inputs:
     bam:
         type: File


### PR DESCRIPTION
This switches away from our fat DNA alignment image to an fgbio image on biocontainers as well.

This is part of #948.