### PR TITLE
Limit pvacseq input to passing cle and pipeline variants

### DIFF
--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -129,10 +129,10 @@ inputs:
     vep_custom_annotations:
         type: ../types/vep_custom_annotation.yml#vep_custom_annotation[]
         doc: "custom type, check types directory for input format"
-    cle_variants:
+    validated_variants:
         type: File?
         secondaryFiles: [.tbi]
-        doc: "Previously discovered variants to be flagged in this pipelines's output vcf"
+        doc: "An optional VCF with variants that will be flagged as 'VALIDATED' if found in this pipeline's main output VCF"
 outputs:
     mutect_unfiltered_vcf:
         type: File
@@ -386,7 +386,7 @@ steps:
                     }
                     return('gnomAD_AF');
                 }
-            cle_variants: cle_variants
+            validated_variants: validated_variants
         out: 
             [filtered_vcf]
     annotated_filter_bgzip:

--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -129,7 +129,7 @@ inputs:
     vep_custom_annotations:
         type: ../types/vep_custom_annotation.yml#vep_custom_annotation[]
         doc: "custom type, check types directory for input format"
-    known_variants:
+    cle_variants:
         type: File?
         secondaryFiles: [.tbi]
         doc: "Previously discovered variants to be flagged in this pipelines's output vcf"
@@ -386,7 +386,7 @@ steps:
                     }
                     return('gnomAD_AF');
                 }
-            known_variants: known_variants
+            cle_variants: cle_variants
         out: 
             [filtered_vcf]
     annotated_filter_bgzip:

--- a/definitions/pipelines/detect_variants_wgs.cwl
+++ b/definitions/pipelines/detect_variants_wgs.cwl
@@ -121,10 +121,10 @@ inputs:
     vep_custom_annotations:
         type: ../types/vep_custom_annotation.yml#vep_custom_annotation[]
         doc: "custom type, check types directory for input format"
-    cle_variants:
+    validated_variants:
         type: File?
         secondaryFiles: [.tbi]
-        doc: "Previously discovered variants to be flagged in this pipelines's output vcf"
+        doc: "An optional VCF with variants that will be flagged as 'VALIDATED' if found in this pipeline's main output VCF"
 outputs:
     mutect_unfiltered_vcf:
         type: File
@@ -360,7 +360,7 @@ steps:
                     }
                     return('gnomAD_AF');
                 }
-            cle_variants: cle_variants
+            validated_variants: validated_variants
         out: 
             [filtered_vcf]
     annotated_filter_bgzip:

--- a/definitions/pipelines/detect_variants_wgs.cwl
+++ b/definitions/pipelines/detect_variants_wgs.cwl
@@ -121,7 +121,7 @@ inputs:
     vep_custom_annotations:
         type: ../types/vep_custom_annotation.yml#vep_custom_annotation[]
         doc: "custom type, check types directory for input format"
-    known_variants:
+    cle_variants:
         type: File?
         secondaryFiles: [.tbi]
         doc: "Previously discovered variants to be flagged in this pipelines's output vcf"
@@ -360,7 +360,7 @@ steps:
                     }
                     return('gnomAD_AF');
                 }
-            known_variants: known_variants
+            cle_variants: cle_variants
         out: 
             [filtered_vcf]
     annotated_filter_bgzip:

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -243,7 +243,7 @@ inputs:
         type: boolean?
     somalier_vcf:
         type: File
-    known_variants:
+    cle_variants:
         type: File?
         secondaryFiles: [.tbi]
         doc: "Previously discovered variants to be flagged in this pipelines's output vcf"
@@ -860,7 +860,7 @@ steps:
             somalier_vcf: somalier_vcf
             tumor_sample_name: tumor_sample_name
             normal_sample_name: normal_sample_name
-            known_variants: known_variants
+            cle_variants: cle_variants
         out:
             [tumor_cram,tumor_mark_duplicates_metrics,tumor_insert_size_metrics,tumor_alignment_summary_metrics,tumor_hs_metrics,tumor_per_target_coverage_metrics,tumor_per_target_hs_metrics,tumor_per_base_coverage_metrics,tumor_per_base_hs_metrics,tumor_summary_hs_metrics,tumor_flagstats,tumor_verify_bam_id_metrics,tumor_verify_bam_id_depth,normal_cram,normal_mark_duplicates_metrics,normal_insert_size_metrics,normal_alignment_summary_metrics,normal_hs_metrics,normal_per_target_coverage_metrics,normal_per_target_hs_metrics,normal_per_base_coverage_metrics,normal_per_base_hs_metrics,normal_summary_hs_metrics,normal_flagstats,normal_verify_bam_id_metrics,normal_verify_bam_id_depth,mutect_unfiltered_vcf,mutect_filtered_vcf,strelka_unfiltered_vcf,strelka_filtered_vcf,varscan_unfiltered_vcf,varscan_filtered_vcf,pindel_unfiltered_vcf,pindel_filtered_vcf,docm_filtered_vcf,final_vcf,final_filtered_vcf,final_tsv,vep_summary,tumor_snv_bam_readcount_tsv,tumor_indel_bam_readcount_tsv,normal_snv_bam_readcount_tsv,normal_indel_bam_readcount_tsv,intervals_antitarget,intervals_target,normal_antitarget_coverage,normal_target_coverage,reference_coverage,cn_diagram,cn_scatter_plot,tumor_antitarget_coverage,tumor_target_coverage,tumor_bin_level_ratios,tumor_segmented_ratios,diploid_variants,somatic_variants,all_candidates,small_candidates,tumor_only_variants,somalier_concordance_metrics,somalier_concordance_statistics]
     germline:
@@ -920,10 +920,17 @@ steps:
             clinical_mhc_classII_alleles: clinical_mhc_classII_alleles
         out:
             [consensus_alleles, hla_call_files]
+    intersect_passing_variants:
+        run: ../tools/intersect_known_variants.cwl
+        in:
+            vcf: somatic/final_filtered_vcf
+            cle_variants: cle_variants
+        out:
+            [cle_and_pipeline_vcf]
     pvacseq:
         run: ../subworkflows/pvacseq.cwl
         in:
-            detect_variants_vcf: somatic/final_filtered_vcf
+            detect_variants_vcf: intersect_passing_variants/cle_and_pipeline_vcf
             sample_name: tumor_sample_name
             normal_sample_name: normal_sample_name
             rnaseq_bam: rnaseq/final_bam

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -243,10 +243,10 @@ inputs:
         type: boolean?
     somalier_vcf:
         type: File
-    cle_variants:
+    validated_variants:
         type: File?
         secondaryFiles: [.tbi]
-        doc: "Previously discovered variants to be flagged in this pipelines's output vcf"
+        doc: "An optional VCF with variants that will be flagged as 'VALIDATED' if found in this pipeline's main output VCF"
 
     #germline inputs
     emit_reference_confidence:
@@ -924,13 +924,13 @@ steps:
         run: ../tools/intersect_known_variants.cwl
         in:
             vcf: somatic/final_filtered_vcf
-            cle_variants: cle_variants
+            validated_variants: validated_variants
         out:
-            [cle_and_pipeline_vcf]
+            [validated_and_pipeline_vcf]
     pvacseq:
         run: ../subworkflows/pvacseq.cwl
         in:
-            detect_variants_vcf: intersect_passing_variants/cle_and_pipeline_vcf
+            detect_variants_vcf: intersect_passing_variants/validated_and_pipeline_vcf
             sample_name: tumor_sample_name
             normal_sample_name: normal_sample_name
             rnaseq_bam: rnaseq/final_bam

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -860,7 +860,7 @@ steps:
             somalier_vcf: somalier_vcf
             tumor_sample_name: tumor_sample_name
             normal_sample_name: normal_sample_name
-            cle_variants: cle_variants
+            validated_variants: validated_variants
         out:
             [tumor_cram,tumor_mark_duplicates_metrics,tumor_insert_size_metrics,tumor_alignment_summary_metrics,tumor_hs_metrics,tumor_per_target_coverage_metrics,tumor_per_target_hs_metrics,tumor_per_base_coverage_metrics,tumor_per_base_hs_metrics,tumor_summary_hs_metrics,tumor_flagstats,tumor_verify_bam_id_metrics,tumor_verify_bam_id_depth,normal_cram,normal_mark_duplicates_metrics,normal_insert_size_metrics,normal_alignment_summary_metrics,normal_hs_metrics,normal_per_target_coverage_metrics,normal_per_target_hs_metrics,normal_per_base_coverage_metrics,normal_per_base_hs_metrics,normal_summary_hs_metrics,normal_flagstats,normal_verify_bam_id_metrics,normal_verify_bam_id_depth,mutect_unfiltered_vcf,mutect_filtered_vcf,strelka_unfiltered_vcf,strelka_filtered_vcf,varscan_unfiltered_vcf,varscan_filtered_vcf,pindel_unfiltered_vcf,pindel_filtered_vcf,docm_filtered_vcf,final_vcf,final_filtered_vcf,final_tsv,vep_summary,tumor_snv_bam_readcount_tsv,tumor_indel_bam_readcount_tsv,normal_snv_bam_readcount_tsv,normal_indel_bam_readcount_tsv,intervals_antitarget,intervals_target,normal_antitarget_coverage,normal_target_coverage,reference_coverage,cn_diagram,cn_scatter_plot,tumor_antitarget_coverage,tumor_target_coverage,tumor_bin_level_ratios,tumor_segmented_ratios,diploid_variants,somatic_variants,all_candidates,small_candidates,tumor_only_variants,somalier_concordance_metrics,somalier_concordance_statistics]
     germline:

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -245,10 +245,10 @@ inputs:
         type: string
     normal_sample_name:
         type: string
-    cle_variants:
+    validated_variants:
         type: File?
         secondaryFiles: [.tbi]
-        doc: "Previously discovered variants to be flagged in this pipelines's output vcf"
+        doc: "An optional VCF with variants that will be flagged as 'VALIDATED' if found in this pipeline's main output VCF"
 outputs:
     tumor_cram:
         type: File
@@ -546,7 +546,7 @@ steps:
             tumor_sample_name: tumor_sample_name
             normal_sample_name: normal_sample_name
             vep_custom_annotations: vep_custom_annotations
-            cle_variants: cle_variants            
+            validated_variants: validated_variants            
         out:
             [mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv]
     cnvkit:

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -245,7 +245,7 @@ inputs:
         type: string
     normal_sample_name:
         type: string
-    known_variants:
+    cle_variants:
         type: File?
         secondaryFiles: [.tbi]
         doc: "Previously discovered variants to be flagged in this pipelines's output vcf"
@@ -546,7 +546,7 @@ steps:
             tumor_sample_name: tumor_sample_name
             normal_sample_name: normal_sample_name
             vep_custom_annotations: vep_custom_annotations
-            known_variants: known_variants            
+            cle_variants: cle_variants            
         out:
             [mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv]
     cnvkit:

--- a/definitions/pipelines/somatic_exome_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_gathered.cwl
@@ -163,7 +163,7 @@ inputs:
         type: string
     normal_sample_name:
         type: string
-    known_variants:
+    cle_variants:
         type: File?
         secondaryFiles: [.tbi]
         doc: "Previously discovered variants to be flagged in this pipelines's output vcf"
@@ -223,7 +223,7 @@ steps:
             somalier_vcf: somalier_vcf
             tumor_sample_name: tumor_sample_name
             normal_sample_name: normal_sample_name
-            known_variants: known_variants
+            cle_variants: cle_variants
         out:
             [tumor_cram, tumor_mark_duplicates_metrics, tumor_insert_size_metrics, tumor_alignment_summary_metrics, tumor_hs_metrics, tumor_per_target_coverage_metrics, tumor_per_base_coverage_metrics, tumor_per_base_hs_metrics, tumor_summary_hs_metrics, tumor_flagstats, tumor_verify_bam_id_metrics, tumor_verify_bam_id_depth, normal_cram, normal_mark_duplicates_metrics, normal_insert_size_metrics, normal_alignment_summary_metrics, normal_hs_metrics, normal_per_target_coverage_metrics, normal_per_target_hs_metrics, normal_per_base_coverage_metrics, normal_per_base_hs_metrics, normal_summary_hs_metrics, normal_flagstats, normal_verify_bam_id_metrics, normal_verify_bam_id_depth, mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv, somalier_concordance_metrics, somalier_concordance_statistics]
     gatherer:

--- a/definitions/pipelines/somatic_exome_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_gathered.cwl
@@ -163,10 +163,10 @@ inputs:
         type: string
     normal_sample_name:
         type: string
-    cle_variants:
+    validated_variants:
         type: File?
         secondaryFiles: [.tbi]
-        doc: "Previously discovered variants to be flagged in this pipelines's output vcf"
+        doc: "An optional VCF with variants that will be flagged as 'VALIDATED' if found in this pipeline's main output VCF"
 outputs:
     final_outputs:
         type: string[]
@@ -223,7 +223,7 @@ steps:
             somalier_vcf: somalier_vcf
             tumor_sample_name: tumor_sample_name
             normal_sample_name: normal_sample_name
-            cle_variants: cle_variants
+            validated_variants: validated_variants
         out:
             [tumor_cram, tumor_mark_duplicates_metrics, tumor_insert_size_metrics, tumor_alignment_summary_metrics, tumor_hs_metrics, tumor_per_target_coverage_metrics, tumor_per_base_coverage_metrics, tumor_per_base_hs_metrics, tumor_summary_hs_metrics, tumor_flagstats, tumor_verify_bam_id_metrics, tumor_verify_bam_id_depth, normal_cram, normal_mark_duplicates_metrics, normal_insert_size_metrics, normal_alignment_summary_metrics, normal_hs_metrics, normal_per_target_coverage_metrics, normal_per_target_hs_metrics, normal_per_base_coverage_metrics, normal_per_base_hs_metrics, normal_summary_hs_metrics, normal_flagstats, normal_verify_bam_id_metrics, normal_verify_bam_id_depth, mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, pindel_unfiltered_vcf, pindel_filtered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv, somalier_concordance_metrics, somalier_concordance_statistics]
     gatherer:

--- a/definitions/pipelines/somatic_wgs.cwl
+++ b/definitions/pipelines/somatic_wgs.cwl
@@ -154,7 +154,7 @@ inputs:
         type: string
     normal_sample_name:
         type: string
-    known_variants:
+    cle_variants:
         type: File?
         secondaryFiles: [.tbi]
         doc: "Previously discovered variants to be flagged in this pipelines's output vcf"
@@ -432,7 +432,7 @@ steps:
             tumor_sample_name: tumor_sample_name
             normal_sample_name: normal_sample_name
             vep_custom_annotations: vep_custom_annotations
-            known_variants: known_variants
+            cle_variants: cle_variants
         out:
             [mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv]
     manta: 

--- a/definitions/pipelines/somatic_wgs.cwl
+++ b/definitions/pipelines/somatic_wgs.cwl
@@ -432,7 +432,7 @@ steps:
             tumor_sample_name: tumor_sample_name
             normal_sample_name: normal_sample_name
             vep_custom_annotations: vep_custom_annotations
-            cle_variants: cle_variants
+            validated_variants: validated_variants
         out:
             [mutect_unfiltered_vcf, mutect_filtered_vcf, strelka_unfiltered_vcf, strelka_filtered_vcf, varscan_unfiltered_vcf, varscan_filtered_vcf, docm_filtered_vcf, final_vcf, final_filtered_vcf, final_tsv, vep_summary, tumor_snv_bam_readcount_tsv, tumor_indel_bam_readcount_tsv, normal_snv_bam_readcount_tsv, normal_indel_bam_readcount_tsv]
     manta: 

--- a/definitions/pipelines/somatic_wgs.cwl
+++ b/definitions/pipelines/somatic_wgs.cwl
@@ -154,10 +154,10 @@ inputs:
         type: string
     normal_sample_name:
         type: string
-    cle_variants:
+    validated_variants:
         type: File?
         secondaryFiles: [.tbi]
-        doc: "Previously discovered variants to be flagged in this pipelines's output vcf"
+        doc: "An optional VCF with variants that will be flagged as 'VALIDATED' if found in this pipeline's main output VCF"
 outputs:
 ##tumor alignment and QC
     tumor_cram:

--- a/definitions/subworkflows/filter_vcf.cwl
+++ b/definitions/subworkflows/filter_vcf.cwl
@@ -39,7 +39,7 @@ inputs:
         type: string
     normal_sample_name:
         type: string
-    known_variants:
+    cle_variants:
         type: File?
         secondaryFiles: [.tbi]
         doc: "Previously discovered variants to be flagged in this workflow's output vcf"
@@ -51,14 +51,14 @@ steps:
     filter_known_variants:
         run: ../tools/filter_known_variants.cwl
         in:
-            known_variants: known_variants
             vcf: vcf
+            cle_variants: cle_variants
         out:
-            [known_filtered]
+            [cle_annotated_vcf]
     filter_vcf_gnomADe_allele_freq:
         run: ../tools/filter_vcf_custom_allele_freq.cwl
         in:
-            vcf: filter_known_variants/known_filtered
+            vcf: filter_known_variants/cle_annotated_vcf
             maximum_population_allele_frequency: filter_gnomADe_maximum_population_allele_frequency
             field_name: gnomad_field_name
         out:

--- a/definitions/subworkflows/filter_vcf.cwl
+++ b/definitions/subworkflows/filter_vcf.cwl
@@ -39,10 +39,10 @@ inputs:
         type: string
     normal_sample_name:
         type: string
-    cle_variants:
+    validated_variants:
         type: File?
         secondaryFiles: [.tbi]
-        doc: "Previously discovered variants to be flagged in this workflow's output vcf"
+        doc: "An optional VCF with variants that will be flagged as 'VALIDATED' if found in this pipeline's main output VCF"
 outputs:
     filtered_vcf:
         type: File
@@ -52,13 +52,13 @@ steps:
         run: ../tools/filter_known_variants.cwl
         in:
             vcf: vcf
-            cle_variants: cle_variants
+            validated_variants: validated_variants
         out:
-            [cle_annotated_vcf]
+            [validated_annotated_vcf]
     filter_vcf_gnomADe_allele_freq:
         run: ../tools/filter_vcf_custom_allele_freq.cwl
         in:
-            vcf: filter_known_variants/cle_annotated_vcf
+            vcf: filter_known_variants/validated_annotated_vcf
             maximum_population_allele_frequency: filter_gnomADe_maximum_population_allele_frequency
             field_name: gnomad_field_name
         out:

--- a/definitions/tools/filter_known_variants.cwl
+++ b/definitions/tools/filter_known_variants.cwl
@@ -2,7 +2,7 @@
  
 cwlVersion: v1.0
 class: CommandLineTool
-label: "Adds an INFO tag (CLE_VALIDATED) flagging variants in the pipeline vcf present in a cle vcf file"
+label: "Adds an INFO tag (VALIDATED) flagging variants in the pipeline vcf present in a previously validated vcf file"
 
 requirements:
     - class: DockerRequirement
@@ -18,14 +18,14 @@ requirements:
             PIPELINE_VCF="$1"
 
             if [ "$#" -eq 2 ]; then
-                CLE_VCF="$2"
-                /opt/bcftools/bin/bcftools view -f PASS -Oz -o pass_filtered_cle_variants.vcf.gz $CLE_VCF
-                /opt/bcftools/bin/bcftools index -t pass_filtered_cle_variants.vcf.gz
-                /opt/bcftools/bin/bcftools annotate -Oz -o cle_annotated_pipeline_variants.vcf.gz -a pass_filtered_cle_variants.vcf.gz -m 'CLE_VALIDATED' $PIPELINE_VCF
-                /opt/bcftools/bin/bcftools index -t cle_annotated_pipeline_variants.vcf.gz
+                VALIDATED_VCF="$2"
+                /opt/bcftools/bin/bcftools view -f PASS -Oz -o pass_filtered_validated_variants.vcf.gz $VALIDATED_VCF
+                /opt/bcftools/bin/bcftools index -t pass_filtered_validated_variants.vcf.gz
+                /opt/bcftools/bin/bcftools annotate -Oz -o validated_annotated_pipeline_variants.vcf.gz -a pass_filtered_validated_variants.vcf.gz -m 'VALIDATED' $PIPELINE_VCF
+                /opt/bcftools/bin/bcftools index -t validated_annotated_pipeline_variants.vcf.gz
             elif [ "$#" -eq 1 ]; then
-                cp $PIPELINE_VCF cle_annotated_pipeline_variants.vcf.gz
-                cp $PIPELINE_VCF.tbi cle_annotated_pipeline_variants.vcf.gz.tbi
+                cp $PIPELINE_VCF validated_annotated_pipeline_variants.vcf.gz
+                cp $PIPELINE_VCF.tbi validated_annotated_pipeline_variants.vcf.gz.tbi
             else
                 exit 1
             fi
@@ -38,8 +38,8 @@ inputs:
         secondaryFiles: [.tbi]
         inputBinding:
             position: 1
-        doc: "Each variant in this file that is also in the cle vcf file (if supplied) will be marked with a CLE_VALIDATED flag in its INFO field"
-    cle_variants:
+        doc: "Each variant in this file that is also in the validated vcf file (if supplied) will be marked with a VALIDATED flag in its INFO field"
+    validated_variants:
         type: File?
         secondaryFiles: [.tbi]
         inputBinding:
@@ -47,8 +47,8 @@ inputs:
         doc: "A vcf of previously discovered variants to be marked in the pipeline vcf; if not provided, this tool does nothing but rename the input vcf"
 
 outputs:
-    cle_annotated_vcf:
+    validated_annotated_vcf:
         type: File
         outputBinding:
-            glob: "cle_annotated_pipeline_variants.vcf.gz"
+            glob: "validated_annotated_pipeline_variants.vcf.gz"
         secondaryFiles: [.tbi]


### PR DESCRIPTION
This PR is a fix for #979. 
First, it updates the annotation step of the workflow: previously, any variant present in the cle vcf (if provided) matching a variant in the pipeline vcf was annotated in the pipeline vcf; now, only passing variants in the cle vcf are considered. The annotation label was updated from `PREVIOUSLY_DISCOVERED` to `CLE_VALIDATED` to more clearly indicate the source of the annotation, and the name of the input file variable within the workflows was updated accordingly. The behavior in the event that no cle vcf is provided remains unchanged: the input vcf is simply copied to be passed along to the next step unchanged.
Next, it adds an intersection step just before pvacseq is run. If a cle vcf is provided, this step takes the intersection of passing cle variants and the pipeline vcf. If no cle vcf is provided, as with the above step, the input pipeline vcf is copied. No filtering is necessary because pvacseq is run with the `--pass-only` flag, so only passing variants in the input vcf are considered. This step was not included in the above annotation step because that step is nested several layers into the workflow and would affect other pipelines if modified, and the resulting vcf is currently only intended for use in the immuno pipeline.