### PR TITLE
Documentation updates (mostly to "sequence" input fields)

### DIFF
--- a/definitions/pipelines/alignment_exome.cwl
+++ b/definitions/pipelines/alignment_exome.cwl
@@ -18,6 +18,10 @@ inputs:
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+        label: "sequence: sequencing data and readgroup information"
+        doc: |
+          sequence represents the sequencing data as either FASTQs or BAMs with accompanying
+          readgroup information. Note that in the @RG field ID and SM are required.
     trimming:
         type:
             - ../types/trimming_options.yml#trimming_options

--- a/definitions/pipelines/alignment_exome_nonhuman.cwl
+++ b/definitions/pipelines/alignment_exome_nonhuman.cwl
@@ -18,6 +18,10 @@ inputs:
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+        label: "sequence: sequencing data and readgroup information"
+        doc: |
+          sequence represents the sequencing data as either FASTQs or BAMs with accompanying
+          readgroup information. Note that in the @RG field ID and SM are required.
     trimming:
         type:
             - ../types/trimming_options.yml#trimming_options

--- a/definitions/pipelines/alignment_umi_duplex.cwl
+++ b/definitions/pipelines/alignment_umi_duplex.cwl
@@ -12,6 +12,11 @@ requirements:
 inputs:
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+        label: "sequence: sequencing data and readgroup information"
+        doc: |
+          sequence represents the sequencing data as either FASTQs or BAMs with accompanying
+          readgroup information. Note that in the @RG field ID and SM are required for FASTQs.
+          For BAMs, this pipeline assumes that the RG information is already in the header.
     sample_name:
         type: string
     read_structure:

--- a/definitions/pipelines/alignment_umi_molecular.cwl
+++ b/definitions/pipelines/alignment_umi_molecular.cwl
@@ -12,6 +12,11 @@ requirements:
 inputs:
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+        label: "sequence: sequencing data and readgroup information"
+        doc: |
+          sequence represents the sequencing data as either FASTQs or BAMs with accompanying
+          readgroup information. Note that in the @RG field ID and SM are required for FASTQs.
+          For BAMs, this pipeline assumes that the RG information is already in the header.
     sample_name:
         type: string
     read_structure:

--- a/definitions/pipelines/alignment_wgs.cwl
+++ b/definitions/pipelines/alignment_wgs.cwl
@@ -18,6 +18,10 @@ inputs:
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+        label: "sequence: sequencing data and readgroup information"
+        doc: |
+          sequence represents the sequencing data as either FASTQs or BAMs with accompanying
+          readgroup information. Note that in the @RG field ID and SM are required.
     trimming:
         type:
             - ../types/trimming_options.yml#trimming_options

--- a/definitions/pipelines/alignment_wgs_nonhuman.cwl
+++ b/definitions/pipelines/alignment_wgs_nonhuman.cwl
@@ -19,6 +19,10 @@ inputs:
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+        label: "sequence: sequencing data and readgroup information"
+        doc: |
+          sequence represents the sequencing data as either FASTQs or BAMs with accompanying
+          readgroup information. Note that in the @RG field ID and SM are required.
     trimming:
         type:
             - ../types/trimming_options.yml#trimming_options

--- a/definitions/pipelines/aml_trio_cle.cwl
+++ b/definitions/pipelines/aml_trio_cle.cwl
@@ -15,11 +15,19 @@ inputs:
     reference: string
     tumor_sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+        label: "tumor_sequence: MT sequencing data and readgroup information"
+        doc: |
+          tumor_sequence represents the sequencing data for the MT sample as either FASTQs or BAMs with
+          accompanying readgroup information. Note that in the @RG field ID and SM are required.
     tumor_name:
         type: string?
         default: 'tumor'
     normal_sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+        label: "normal_sequence: WT sequencing data and readgroup information"
+        doc: |
+          normal_sequence represents the sequencing data for the WT sample as either FASTQs or BAMs with
+          accompanying readgroup information. Note that in the @RG field ID and SM are required.
     normal_name:
         type: string?
         default: 'normal'

--- a/definitions/pipelines/aml_trio_cle_gathered.cwl
+++ b/definitions/pipelines/aml_trio_cle_gathered.cwl
@@ -15,11 +15,19 @@ inputs:
     reference: string
     tumor_sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+        label: "tumor_sequence: MT sequencing data and readgroup information"
+        doc: |
+          tumor_sequence represents the sequencing data for the MT sample as either FASTQs or BAMs with
+          accompanying readgroup information. Note that in the @RG field ID and SM are required.
     tumor_name:
         type: string?
         default: 'tumor'
     normal_sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+        label: "normal_sequence: WT sequencing data and readgroup information"
+        doc: |
+          normal_sequence represents the sequencing data for the WT sample as either FASTQs or BAMs with
+          accompanying readgroup information. Note that in the @RG field ID and SM are required.
     normal_name:
         type: string?
         default: 'normal'

--- a/definitions/pipelines/chipseq.cwl
+++ b/definitions/pipelines/chipseq.cwl
@@ -20,6 +20,10 @@ inputs:
         type: string?
     chipseq_sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+        label: "chipseq_sequence: sequencing data and readgroup information"
+        doc: |
+          chipseq_sequence represents the sequencing data as either FASTQs or BAMs with accompanying
+          readgroup information. Note that in the @RG field ID and SM are required.
     omni_vcf:
         type: File
         secondaryFiles: [.tbi]

--- a/definitions/pipelines/chipseq_alignment_nonhuman.cwl
+++ b/definitions/pipelines/chipseq_alignment_nonhuman.cwl
@@ -21,6 +21,10 @@ inputs:
         type: string?
     chipseq_sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+        label: "chipseq_sequence: sequencing data and readgroup information"
+        doc: |
+          chipseq_sequence represents the sequencing data as either FASTQs or BAMs with accompanying
+          readgroup information. Note that in the @RG field ID and SM are required.
     trimming:
         type:
             - ../types/trimming_options.yml#trimming_options

--- a/definitions/pipelines/germline_exome.cwl
+++ b/definitions/pipelines/germline_exome.cwl
@@ -19,6 +19,10 @@ inputs:
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+        label: "sequence: sequencing data and readgroup information"
+        doc: |
+          sequence represents the sequencing data as either FASTQs or BAMs with accompanying
+          readgroup information. Note that in the @RG field ID and SM are required.
     trimming:
         type:
             - ../types/trimming_options.yml#trimming_options

--- a/definitions/pipelines/germline_exome_gvcf.cwl
+++ b/definitions/pipelines/germline_exome_gvcf.cwl
@@ -18,6 +18,10 @@ inputs:
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+        label: "sequence: sequencing data and readgroup information"
+        doc: |
+          sequence represents the sequencing data as either FASTQs or BAMs with accompanying
+          readgroup information. Note that in the @RG field ID and SM are required.
     trimming:
         type:
             - ../types/trimming_options.yml#trimming_options

--- a/definitions/pipelines/germline_exome_hla_typing.cwl
+++ b/definitions/pipelines/germline_exome_hla_typing.cwl
@@ -18,6 +18,10 @@ inputs:
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+        label: "sequence: sequencing data and readgroup information"
+        doc: |
+          sequence represents the sequencing data as either FASTQs or BAMs with accompanying
+          readgroup information. Note that in the @RG field ID and SM are required.
     bqsr_known_sites:
         type: File[]
         secondaryFiles: [.tbi]

--- a/definitions/pipelines/germline_wgs.cwl
+++ b/definitions/pipelines/germline_wgs.cwl
@@ -20,6 +20,10 @@ inputs:
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+        label: "sequence: sequencing data and readgroup information"
+        doc: |
+          sequence represents the sequencing data as either FASTQs or BAMs with accompanying
+          readgroup information. Note that in the @RG field ID and SM are required.
     trimming:
         type:
             - ../types/trimming_options.yml#trimming_options

--- a/definitions/pipelines/germline_wgs_gvcf.cwl
+++ b/definitions/pipelines/germline_wgs_gvcf.cwl
@@ -19,6 +19,10 @@ inputs:
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+        label: "sequence: sequencing data and readgroup information"
+        doc: |
+          sequence represents the sequencing data as either FASTQs or BAMs with accompanying
+          readgroup information. Note that in the @RG field ID and SM are required.
     trimming:
         type:
             - ../types/trimming_options.yml#trimming_options

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -109,7 +109,7 @@ inputs:
         doc: |
           bqsr_intervals provides an array of genomic intervals for which to apply
           GATK base quality score recalibrations. Typically intervals are given
-          for the entire chromosome (i.e. chr1, chr2, etc.), these names should match
+          for the entire chromosome (chr1, chr2, etc.), these names should match
           the format in the reference file.
     bait_intervals:
         type: File

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -70,13 +70,10 @@ inputs:
 
     tumor_sequence:
         type: ../types/sequence_data.yml#sequence_data[]
-        label: "tumor_sequence: file specifying the location of MT sequencing data"
+        label: "tumor_sequence: MT sequencing data and readgroup information"
         doc: |
-          tumor_sequence is a data structure described in sequence_data.yml used to pass information regarding
-          sequencing data for single sample (i.e. fastq files). If more than one fastq file exist
-          for a sample, as in the case for multiple instrument data, the sequence tag is simply
-          repeated with the additional data (see example input file). Note that in the @RG field
-          ID and SM are required.
+          tumor_sequence represents the sequencing data for the MT sample as either FASTQs or BAMs with
+          accompanying readgroup information. Note that in the @RG field ID and SM are required.
     tumor_name:
         type: string?
         default: 'tumor'
@@ -86,13 +83,10 @@ inputs:
           outputs, for exmaple the VCF files.
     normal_sequence:
         type: ../types/sequence_data.yml#sequence_data[]
-        label: "normal_sequence: file specifying the location of WT sequencing data"
+        label: "normal_sequence: WT sequencing data and readgroup information"
         doc: |
-          normal_sequence is a data structure described in sequence_data.yml used to pass information regarding
-          sequencing data for single sample (i.e. fastq files). If more than one fastq file exist
-          for a sample, as in the case for multiple instrument data, the sequence tag is simply
-          repeated with the additional data (see example input file). Note that in the @RG field
-          ID and SM are required.
+          normal_sequence represents the sequencing data for the WT sample as either FASTQs or BAMs with
+          accompanying readgroup information. Note that in the @RG field ID and SM are required.
     normal_name:
         type: string?
         default: 'normal'

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -80,7 +80,7 @@ inputs:
         label: "tumor_name: String specifying the name of the MT sample"
         doc: |
           tumor_name provides a string for what the MT sample will be referred to in the various
-          outputs, for exmaple the VCF files.
+          outputs, for example the VCF files.
     normal_sequence:
         type: ../types/sequence_data.yml#sequence_data[]
         label: "normal_sequence: WT sequencing data and readgroup information"
@@ -93,7 +93,7 @@ inputs:
         label: "normal_name: String specifying the name of the WT sample"
         doc: |
           normal_name provides a string for what the WT sample will be referred to in the various
-          outputs, for exmaple the VCF files.
+          outputs, for example the VCF files.
     bqsr_known_sites:
         type: File[]
         secondaryFiles: [.tbi]

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -48,7 +48,7 @@ inputs:
         label: "tumor_name: String specifying the name of the MT sample"
         doc: |
           tumor_name provides a string for what the MT sample will be referred to in the various
-          outputs, for exmaple the VCF files.
+          outputs, for example the VCF files.
     normal_sequence:
         type: ../types/sequence_data.yml#sequence_data[]
         label: "normal_sequence: WT sequencing data and readgroup information"
@@ -61,7 +61,7 @@ inputs:
         label: "normal_name: String specifying the name of the WT sample"
         doc: |
           normal_name provides a string for what the WT sample will be referred to in the various
-          outputs, for exmaple the VCF files.
+          outputs, for example the VCF files.
     trimming:
         type:
             - ../types/trimming_options.yml#trimming_options

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -38,13 +38,10 @@ inputs:
           samtools index, bwa index, and picard CreateSequenceDictionary.
     tumor_sequence:
         type: ../types/sequence_data.yml#sequence_data[]
-        label: "tumor_sequence: yml file specifying the location of MT sequencing data"
+        label: "tumor_sequence: MT sequencing data and readgroup information"
         doc: |
-          tumor_sequence is a yml file for which to pass information regarding
-          sequencing data for single sample (i.e. fastq files). If more than one fastq file exist
-          for a sample, as in the case for multiple instrument data, the sequence tag is simply
-          repeated with the additional data (see example input file). Note that in the @RG field
-          ID and SM are required.
+          tumor_sequence represents the sequencing data for the MT sample as either FASTQs or BAMs with
+          accompanying readgroup information. Note that in the @RG field ID and SM are required.
     tumor_name:
         type: string?
         default: 'tumor'
@@ -54,13 +51,10 @@ inputs:
           outputs, for exmaple the VCF files.
     normal_sequence:
         type: ../types/sequence_data.yml#sequence_data[]
-        label: "normal_sequence: yml file specifying the location of WT sequencing data"
+        label: "normal_sequence: WT sequencing data and readgroup information"
         doc: |
-          normal_sequence is a yml file for which to pass information regarding
-          sequencing data for single sample (i.e. fastq files). If more than one fastq file exist
-          for a sample, as in the case for multiple instrument data, the sequence tag is simply
-          repeated with the additional data (see example input file). Note that in the @RG field
-          ID and SM are required.
+          normal_sequence represents the sequencing data for the WT sample as either FASTQs or BAMs with
+          accompanying readgroup information. Note that in the @RG field ID and SM are required.
     normal_name:
         type: string?
         default: 'normal'

--- a/definitions/pipelines/somatic_exome.cwl
+++ b/definitions/pipelines/somatic_exome.cwl
@@ -81,7 +81,7 @@ inputs:
         doc: |
           bqsr_intervals provides an array of genomic intervals for which to apply
           GATK base quality score recalibrations. Typically intervals are given
-          for the entire chromosome (i.e. chr1, chr2, etc.), these names should match
+          for the entire chromosome (chr1, chr2, etc.), these names should match
           the format in the reference file.
     bait_intervals:
         type: File

--- a/definitions/pipelines/somatic_exome_cle.cwl
+++ b/definitions/pipelines/somatic_exome_cle.cwl
@@ -15,11 +15,19 @@ inputs:
     reference: string
     tumor_sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+        label: "tumor_sequence: MT sequencing data and readgroup information"
+        doc: |
+          tumor_sequence represents the sequencing data for the MT sample as either FASTQs or BAMs with
+          accompanying readgroup information. Note that in the @RG field ID and SM are required.
     tumor_name:
         type: string?
         default: 'tumor'
     normal_sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+        label: "normal_sequence: WT sequencing data and readgroup information"
+        doc: |
+          normal_sequence represents the sequencing data for the WT sample as either FASTQs or BAMs with
+          accompanying readgroup information. Note that in the @RG field ID and SM are required.
     normal_name:
         type: string?
         default: 'normal'

--- a/definitions/pipelines/somatic_exome_cle_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_cle_gathered.cwl
@@ -15,11 +15,19 @@ inputs:
     reference: string
     tumor_sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+        label: "tumor_sequence: MT sequencing data and readgroup information"
+        doc: |
+          tumor_sequence represents the sequencing data for the MT sample as either FASTQs or BAMs with
+          accompanying readgroup information. Note that in the @RG field ID and SM are required.
     tumor_name:
         type: string?
         default: 'tumor.cram'
     normal_sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+        label: "normal_sequence: WT sequencing data and readgroup information"
+        doc: |
+          normal_sequence represents the sequencing data for the WT sample as either FASTQs or BAMs with
+          accompanying readgroup information. Note that in the @RG field ID and SM are required.
     normal_name:
         type: string?
         default: 'normal.cram'

--- a/definitions/pipelines/somatic_exome_gathered.cwl
+++ b/definitions/pipelines/somatic_exome_gathered.cwl
@@ -19,11 +19,19 @@ inputs:
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     tumor_sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+        label: "tumor_sequence: MT sequencing data and readgroup information"
+        doc: |
+          tumor_sequence represents the sequencing data for the MT sample as either FASTQs or BAMs with
+          accompanying readgroup information. Note that in the @RG field ID and SM are required.
     tumor_cram_name:
         type: string?
         default: 'tumor.cram'
     normal_sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+        label: "normal_sequence: WT sequencing data and readgroup information"
+        doc: |
+          normal_sequence represents the sequencing data for the WT sample as either FASTQs or BAMs with
+          accompanying readgroup information. Note that in the @RG field ID and SM are required.
     normal_cram_name:
         type: string?
         default: 'normal.cram'

--- a/definitions/pipelines/somatic_exome_nonhuman.cwl
+++ b/definitions/pipelines/somatic_exome_nonhuman.cwl
@@ -20,13 +20,10 @@ inputs:
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     tumor_sequence:
         type: ../types/sequence_data.yml#sequence_data[]
-        label: "tumor_sequence: yml file specifying the location of MT sequencing data"
+        label: "tumor_sequence: MT sequencing data and readgroup information"
         doc: |
-          tumor_sequence is a yml file for which to pass information regarding
-          sequencing data for single sample (i.e. fastq files). If more than one fastq file exist
-          for a sample, as in the case for multiple instrument data, the sequence tag is simply
-          repeated with the additional data (see example input file). Note that in the @RG field
-          ID and SM are required.
+          tumor_sequence represents the sequencing data for the MT sample as either FASTQs or BAMs with
+          accompanying readgroup information. Note that in the @RG field ID and SM are required.
     tumor_name:
         type: string?
         default: 'tumor'
@@ -36,13 +33,10 @@ inputs:
           outputs, for exmaple the VCF files.
     normal_sequence:
         type: ../types/sequence_data.yml#sequence_data[]
-        label: "normal_sequence: yml file specifying the location of WT sequencing data"
+        label: "normal_sequence: WT sequencing data and readgroup information"
         doc: |
-          normal_sequence is a yml file for which to pass information regarding
-          sequencing data for single sample (i.e. fastq files). If more than one fastq file exist
-          for a sample, as in the case for multiple instrument data, the sequence tag is simply
-          repeated with the additional data (see example input file). Note that in the @RG field
-          ID and SM are required.
+          normal_sequence represents the sequencing data for the WT sample as either FASTQs or BAMs with
+          accompanying readgroup information. Note that in the @RG field ID and SM are required.
     normal_name:
         type: string?
         default: 'normal'

--- a/definitions/pipelines/somatic_exome_nonhuman.cwl
+++ b/definitions/pipelines/somatic_exome_nonhuman.cwl
@@ -30,7 +30,7 @@ inputs:
         label: "tumor_name: String specifying the name of the MT sample"
         doc: |
           tumor_name provides a string for what the MT sample will be referred to in the various
-          outputs, for exmaple the VCF files.
+          outputs, for example the VCF files.
     normal_sequence:
         type: ../types/sequence_data.yml#sequence_data[]
         label: "normal_sequence: WT sequencing data and readgroup information"
@@ -43,7 +43,7 @@ inputs:
         label: "normal_name: String specifying the name of the WT sample"
         doc: |
           normal_name provides a string for what the WT sample will be referred to in the various
-          outputs, for exmaple the VCF files.
+          outputs, for example the VCF files.
     trimming:
         type:
             - ../types/trimming_options.yml#trimming_options

--- a/definitions/pipelines/somatic_wgs.cwl
+++ b/definitions/pipelines/somatic_wgs.cwl
@@ -16,11 +16,19 @@ inputs:
     reference: string
     tumor_sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+        label: "tumor_sequence: MT sequencing data and readgroup information"
+        doc: |
+          tumor_sequence represents the sequencing data for the MT sample as either FASTQs or BAMs with
+          accompanying readgroup information. Note that in the @RG field ID and SM are required.
     tumor_name:
         type: string?
         default: 'tumor'
     normal_sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+        label: "normal_sequence: WT sequencing data and readgroup information"
+        doc: |
+          normal_sequence represents the sequencing data for the WT sample as either FASTQs or BAMs with
+          accompanying readgroup information. Note that in the @RG field ID and SM are required.
     normal_name:
         type: string?
         default: 'normal'

--- a/definitions/pipelines/tumor_only_exome.cwl
+++ b/definitions/pipelines/tumor_only_exome.cwl
@@ -19,6 +19,10 @@ inputs:
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+        label: "sequence: sequencing data and readgroup information"
+        doc: |
+          sequence represents the sequencing data as either FASTQs or BAMs with accompanying
+          readgroup information. Note that in the @RG field ID and SM are required.
     trimming:
         type:
             - ../types/trimming_options.yml#trimming_options

--- a/definitions/pipelines/tumor_only_wgs.cwl
+++ b/definitions/pipelines/tumor_only_wgs.cwl
@@ -19,6 +19,10 @@ inputs:
         secondaryFiles: [.fai, ^.dict, .amb, .ann, .bwt, .pac, .sa]
     sequence:
         type: ../types/sequence_data.yml#sequence_data[]
+        label: "sequence: sequencing data and readgroup information"
+        doc: |
+          sequence represents the sequencing data as either FASTQs or BAMs with accompanying
+          readgroup information. Note that in the @RG field ID and SM are required.
     trimming:
         type:
             - ../types/trimming_options.yml#trimming_options

--- a/definitions/pipelines/tumor_only_wgs.cwl
+++ b/definitions/pipelines/tumor_only_wgs.cwl
@@ -40,7 +40,7 @@ inputs:
         doc: |
           bqsr_intervals provides an array of genomic intervals for which to apply
           GATK base quality score recalibrations. Typically intervals are given
-          for the entire chromosome (i.e. chr1, chr2, etc.), these names should match
+          for the entire chromosome (chr1, chr2, etc.), these names should match
           the format in the reference file.
     target_intervals:
         type: File


### PR DESCRIPTION
This cleans up the documentation for "sequence" inputs (#987) and then propagates the updated documentation to other pipeline CWLs that have sequence inputs.  Also fixes a few typos and redundancies in other somatic documentation.