### PR TITLE
Update deeptools_bamcoverage.cwl

### DIFF
--- a/definitions/tools/deeptools_bamcoverage.cwl
+++ b/definitions/tools/deeptools_bamcoverage.cwl
@@ -44,7 +44,7 @@ inputs:
         type: string?
         inputBinding:
             prefix: '-r'
-    blacklist_file:
+    blocklist_file:
         type: File?
         inputBinding:
             prefix: '-bl'


### PR DESCRIPTION
This PR is a fix for issue# 944

“blacklist_file” was modified to “blocklist_file” on line 47 of analysis-workflows/definitions/tools/deeptools_bamcoverage.cwl