### PR TITLE
fixed bug regarding missing indexed bam in bigwig

### DIFF
--- a/definitions/pipelines/rnaseq.cwl
+++ b/definitions/pipelines/rnaseq.cwl
@@ -148,7 +148,7 @@ steps:
     stringtie:
         run: ../tools/stringtie.cwl
         in:
-            bam: mark_dup/sorted_bam
+            bam: index_bam/indexed_bam
             reference_annotation: reference_annotation
             sample_name: sample_name
             strand: strand

--- a/definitions/pipelines/rnaseq_star_fusion.cwl
+++ b/definitions/pipelines/rnaseq_star_fusion.cwl
@@ -195,7 +195,7 @@ steps:
             refFlat: refFlat
             ribosomal_intervals: ribosomal_intervals
             strand: strand
-            bam: mark_dup/sorted_bam
+            bam: index_bam/indexed_bam
         out:
             [metrics, chart]
     bam_to_cram:

--- a/definitions/pipelines/rnaseq_star_fusion.cwl
+++ b/definitions/pipelines/rnaseq_star_fusion.cwl
@@ -214,7 +214,7 @@ steps:
     cgpbigwig_bamcoverage:
         run: ../tools/bam_to_bigwig.cwl
         in:
-            bam: mark_dup/sorted_bam
+            bam: index_bam/indexed_bam
             reference: reference_fasta
         out:
             [outfile]

--- a/definitions/pipelines/rnaseq_star_fusion.cwl
+++ b/definitions/pipelines/rnaseq_star_fusion.cwl
@@ -183,7 +183,7 @@ steps:
     stringtie:
         run: ../tools/stringtie.cwl
         in:
-            bam: mark_dup/sorted_bam
+            bam: index_bam/indexed_bam
             reference_annotation: gtf_file
             sample_name: sample_name
             strand: strand

--- a/definitions/pipelines/rnaseq_star_fusion_with_xenosplit.cwl
+++ b/definitions/pipelines/rnaseq_star_fusion_with_xenosplit.cwl
@@ -237,7 +237,7 @@ steps:
     stringtie:
         run: ../tools/stringtie.cwl
         in:
-            bam: mark_dup/sorted_bam
+            bam: index_bam/indexed_bam
             reference_annotation: graft_gtf_file
             sample_name: sample_name
             strand: strand

--- a/definitions/pipelines/rnaseq_star_fusion_with_xenosplit.cwl
+++ b/definitions/pipelines/rnaseq_star_fusion_with_xenosplit.cwl
@@ -249,13 +249,13 @@ steps:
             refFlat: refFlat
             ribosomal_intervals: ribosomal_intervals
             strand: strand
-            bam: mark_dup/sorted_bam
+            bam: index_bam/indexed_bam
         out:
             [metrics, chart]
     cgpbigwig_bamcoverage:
         run: ../tools/bam_to_bigwig.cwl
         in:
-            bam: mark_dup/sorted_bam
+            bam: index_bam/indexed_bam
             reference: reference
         out:
             [outfile]

--- a/definitions/tools/stringtie.cwl
+++ b/definitions/tools/stringtie.cwl
@@ -54,6 +54,7 @@ inputs:
         type: File
         inputBinding:
             position: 4
+        secondaryFiles: [.bai,^.bai]
 outputs:
     transcript_gtf:
         type: File


### PR DESCRIPTION
I think there is a small bug in the new rnaseq_star_fusion workflow, the bigwig step is looking for an indexed bam file but no indexed file is getting passed. this results in cwl errors such as this:

{code}
Could not localize /storage1/fs1/obigriffith/Active/gmsroot/model_data/35693d91d68a42d292998a5dd3789c4a/build1aeba2dfb53e4ef592d91c13a231a78a/tmp/cromwell-executions/rnaseq_star_fusion.cwl/24d995d7-a045-4d96-9217-399c3e11ec86/call-mark_dup/execution/MarkedSorted.bai -> /storage1/fs1/obigriffi
th/Active/gmsroot/model_data/35693d91d68a42d292998a5dd3789c4a/build1aeba2dfb53e4ef592d91c13a231a78a/tmp/cromwell-executions/rnaseq_star_fusion.cwl/24d995d7-a045-4d96-9217-399c3e11ec86/call-cgpbigwig_bamcoverage/inputs/-1277726306/MarkedSorted.bai:
        /storage1/fs1/obigriffith/Active/gmsroot/model_data/35693d91d68a42d292998a5dd3789c4a/build1aeba2dfb53e4ef592d91c13a231a78a/tmp/cromwell-executions/rnaseq_star_fusion.cwl/24d995d7-a045-4d96-9217-399c3e11ec86/call-mark_dup/execution/MarkedSorted.bai doesn't exist
        File not found /storage1/fs1/obigriffith/Active/gmsroot/model_data/35693d91d68a42d292998a5dd3789c4a/build1aeba2dfb53e4ef592d91c13a231a78a/tmp/cromwell-executions/rnaseq_star_fusion.cwl/24d995d7-a045-4d96-9217-399c3e11ec86/call-cgpbigwig_bamcoverage/inputs/-1277726306/MarkedSorted.bai
-> /storage1/fs1/obigriffith/Active/gmsroot/model_data/35693d91d68a42d292998a5dd3789c4a/build1aeba2dfb53e4ef592d91c13a231a78a/tmp/cromwell-executions/rnaseq_star_fusion.cwl/24d995d7-a045-4d96-9217-399c3e11ec86/call-mark_dup/execution/MarkedSorted.bai
        File not found /storage1/fs1/obigriffith/Active/gmsroot/model_data/35693d91d68a42d292998a5dd3789c4a/build1aeba2dfb53e4ef592d91c13a231a78a/tmp/cromwell-executions/rnaseq_star_fusion.cwl/24d995d7-a045-4d96-9217-399c3e11ec86/call-mark_dup/execution/MarkedSorted.bai
        at common.validation.Validation$ValidationTry$.toTry$extension1(Validation.scala:89)
        at common.validation.Validation$ValidationTry$.toTry$extension0(Validation.scala:85)
        at cromwell.backend.standard.StandardAsyncExecutionActor.instantiatedCommand(StandardAsyncExecutionActor.scala:612)
        ... 32 common frames omitted
[2021-01-14 23:42:21,53] [error] DispatchedConfigAsyncJobExecutionActor [24d995d7cgpbigwig_bamcoverage:NA:1]: Error attempting to Execute
java.lang.Exception: Failed command instantiation
{code}