### PR TITLE
Handling picard memory in the merge step

### DIFF
--- a/definitions/tools/merge_bams.cwl
+++ b/definitions/tools/merge_bams.cwl
@@ -43,7 +43,7 @@ requirements:
                 cp "$BAMS" "$OUTFILENAME";
             else
                 if [[ $SORTED == "true" ]];then
-                    /usr/bin/sambamba merge -t "$NTHREADS" "$OUTFILENAME" "$BAMS"
+                    /usr/bin/sambamba merge -t "$NTHREADS" "$OUTFILENAME" "${BAMS[@]}"
                 else #unsorted bams, use picard
                     args=(OUTPUT="$OUTFILENAME" ASSUME_SORTED=true USE_THREADING=true SORT_ORDER=unsorted VALIDATION_STRINGENCY=LENIENT)
                     for i in "${BAMS[@]}";do

--- a/definitions/tools/merge_bams.cwl
+++ b/definitions/tools/merge_bams.cwl
@@ -21,13 +21,10 @@ requirements:
 
             SORTED=false
 
-            while getopts "t:m:n:s:" opt; do
+            while getopts "t:n:s:" opt; do
                 case "$opt" in
                     t)
                         NTHREADS="$OPTARG"
-                        ;;
-                    m)
-                        MEM="$OPTARG"
                         ;;
                     n)
                         OUTFILENAME="$OPTARG"
@@ -46,13 +43,13 @@ requirements:
                 cp "$BAMS" "$OUTFILENAME";
             else
                 if [[ $SORTED == "true" ]];then
-                    /usr/bin/sambamba merge -t "$NTHREADS" "$OUTFILENAME" "${BAMS[@]}"
+                    /usr/bin/sambamba merge -t "$NTHREADS" "$OUTFILENAME" "$BAMS"
                 else #unsorted bams, use picard
                     args=(OUTPUT="$OUTFILENAME" ASSUME_SORTED=true USE_THREADING=true SORT_ORDER=unsorted VALIDATION_STRINGENCY=LENIENT)
                     for i in "${BAMS[@]}";do
                       args+=("INPUT=$i")
                     done
-                    java -jar /opt/picard/picard.jar MergeSamFiles "${args[@]}"
+                    java -jar -Xmx6g /opt/picard/picard.jar MergeSamFiles "${args[@]}"
                 fi
             fi
             if [[ $SORTED == "true" ]];then
@@ -61,7 +58,6 @@ requirements:
 
 arguments: [
     "-t", "$(runtime.cores)",
-    "-m", "$(runtime.ram)",
 ]
 inputs:
     bams:


### PR DESCRIPTION
I don't love that this requires specifying it twice (in the cwl and the call to picard, but any other way gets janky kind of fast