### PR TITLE
Update pvactools CWLs to version 2.0.0

### DIFF
--- a/definitions/pipelines/detect_variants.cwl
+++ b/definitions/pipelines/detect_variants.cwl
@@ -88,7 +88,7 @@ inputs:
               symbols: ["pick", "flag_pick", "pick_allele", "per_gene", "pick_allele_gene", "flag_pick_allele", "flag_pick_allele_gene"]
     vep_plugins:
         type: string[]
-        default: [Downstream, Wildtype]
+        default: [Frameshift, Wildtype]
     filter_gnomADe_maximum_population_allele_frequency:
         type: float
         default: 0.001

--- a/definitions/pipelines/detect_variants_nonhuman.cwl
+++ b/definitions/pipelines/detect_variants_nonhuman.cwl
@@ -74,7 +74,7 @@ inputs:
               symbols: ["pick", "flag_pick", "pick_allele", "per_gene", "pick_allele_gene", "flag_pick_allele", "flag_pick_allele_gene"]
     vep_plugins:
         type: string[]
-        default: [Downstream, Wildtype]
+        default: [Frameshift, Wildtype]
     filter_mapq0_threshold:
         type: float
         default: 0.15

--- a/definitions/pipelines/detect_variants_wgs.cwl
+++ b/definitions/pipelines/detect_variants_wgs.cwl
@@ -80,7 +80,7 @@ inputs:
               symbols: ["pick", "flag_pick", "pick_allele", "per_gene", "pick_allele_gene", "flag_pick_allele", "flag_pick_allele_gene"]
     vep_plugins:
         type: string[]?
-        default: [Downstream, Wildtype]
+        default: [Frameshift, Wildtype]
     filter_gnomADe_maximum_population_allele_frequency:
         type: float?
         default: 0.001

--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -280,16 +280,18 @@ inputs:
         type: int?
     prediction_algorithms:
         type: string[]
-    epitope_lengths:
+    epitope_lengths_class_i:
+        type: int[]?
+    epitope_lengths_class_ii:
         type: int[]?
     binding_threshold:
+        type: int?
+    percentile_threshold:
         type: int?
     allele_specific_binding_thresholds:
         type: boolean?
     minimum_fold_change:
         type: float?
-    peptide_sequence_length:
-        type: int?
     top_score_metric:
         type:
             - "null"
@@ -348,6 +350,11 @@ inputs:
         label: "netmhc_stab: sets an option whether to run  NetMHCStabPan or not"
         doc: |
           netmhc_stab sets an option that decides whether it will run NetMHCStabPan after all filtering and add stability predictions to predicted epitopes.
+    run_reference_proteome_similarity:
+        type: boolean?
+        label: "run_reference_proteome_similarity: sets an option whether to run reference proteome similarity or not"
+        doc: |
+          run_reference_proteome_similarity sets an option that decides whether it will run reference proteome similarity after all filtering and BLAST peptide sequences against the reference proteome to see if they appear elsewhere in the proteome.
     pvacseq_threads:
         type: int?
         label: "pvacseq_threads: Number of threads to use for parallelizing pvacseq prediction"
@@ -935,11 +942,12 @@ steps:
             transcript_expression_file: rnaseq/transcript_abundance_tsv
             alleles: hla_consensus/consensus_alleles
             prediction_algorithms: prediction_algorithms
-            epitope_lengths: epitope_lengths
+            epitope_lengths_class_i: epitope_lengths_class_i
+            epitope_lengths_class_ii: epitope_lengths_class_ii
             binding_threshold: binding_threshold
+            percentile_threshold: percentile_threshold
             allele_specific_binding_thresholds: allele_specific_binding_thresholds
             minimum_fold_change: minimum_fold_change
-            peptide_sequence_length: peptide_sequence_length
             top_score_metric: top_score_metric
             additional_report_columns: additional_report_columns
             fasta_size: fasta_size
@@ -957,6 +965,7 @@ steps:
             net_chop_method: net_chop_method
             net_chop_threshold: net_chop_threshold
             netmhc_stab: netmhc_stab
+            run_reference_proteome_similarity: run_reference_proteome_similarity
             n_threads: pvacseq_threads
             variants_to_table_fields: variants_to_table_fields
             variants_to_table_genotype_fields: variants_to_table_genotype_fields

--- a/definitions/pipelines/tumor_only_detect_variants.cwl
+++ b/definitions/pipelines/tumor_only_detect_variants.cwl
@@ -75,7 +75,7 @@ inputs:
         default: [Consequence,SYMBOL,Feature_type,Feature,HGVSc,HGVSp,cDNA_position,CDS_position,Protein_position,Amino_acids,Codons,HGNC_ID,Existing_variation,gnomADe_AF,CLIN_SIG,SOMATIC,PHENO]
     vep_plugins:
         type: string[]
-        default: [Downstream, Wildtype]
+        default: [Frameshift, Wildtype]
     sample_name:
         type: string
     docm_vcf:

--- a/definitions/subworkflows/germline_detect_variants.cwl
+++ b/definitions/subworkflows/germline_detect_variants.cwl
@@ -50,7 +50,7 @@ inputs:
         doc: "ensembl species - Must be present in the cache directory. Examples: homo_sapiens or mus_musculus"
     vep_plugins:
         type: string[]
-        default: [Downstream, Wildtype]
+        default: [Frameshift, Wildtype]
     synonyms_file:
         type: File?
     annotate_coding_only:

--- a/definitions/subworkflows/joint_genotype.cwl
+++ b/definitions/subworkflows/joint_genotype.cwl
@@ -43,7 +43,7 @@ inputs:
         doc: "ensembl species - Must be present in the cache directory. Examples: homo_sapiens or mus_musculus"
     vep_plugins:
         type: string[]
-        default: [Downstream, Wildtype]
+        default: [Frameshift, Wildtype]
     synonyms_file:
         type: File?
     annotate_coding_only:

--- a/definitions/subworkflows/pvacseq.cwl
+++ b/definitions/subworkflows/pvacseq.cwl
@@ -38,9 +38,13 @@ inputs:
         type: string[]
     prediction_algorithms:
         type: string[]
-    epitope_lengths:
+    epitope_lengths_class_i:
+        type: int[]?
+    epitope_lengths_class_ii:
         type: int[]?
     binding_threshold:
+        type: int?
+    percentile_threshold:
         type: int?
     allele_specific_binding_thresholds:
         type: boolean?
@@ -94,6 +98,8 @@ inputs:
     net_chop_threshold:
         type: float?
     netmhc_stab:
+        type: boolean?
+    run_reference_proteome_similarity:
         type: boolean?
     n_threads:
         type: int?
@@ -174,10 +180,12 @@ steps:
             sample_name: sample_name
             alleles: alleles
             prediction_algorithms: prediction_algorithms
-            epitope_lengths: epitope_lengths
+            epitope_lengths_class_i: epitope_lengths_class_i
+            epitope_lengths_class_ii: epitope_lengths_class_ii
+            binding_threshold: binding_threshold
+            percentile_threshold: percentile_threshold
             normal_sample_name: normal_sample_name
             minimum_fold_change: minimum_fold_change
-            peptide_sequence_length: peptide_sequence_length
             top_score_metric: top_score_metric
             additional_report_columns: additional_report_columns
             fasta_size: fasta_size
@@ -195,6 +203,7 @@ steps:
             net_chop_method: net_chop_method
             net_chop_threshold: net_chop_threshold
             netmhc_stab: netmhc_stab
+            run_reference_proteome_similarity: run_reference_proteome_similarity
             n_threads: n_threads
         out:
             [pvacseq_predictions]

--- a/definitions/tools/pvacbind.cwl
+++ b/definitions/tools/pvacbind.cwl
@@ -13,14 +13,14 @@ arguments: [
     { valueFrom: " && ", shellQuote: false },
     "export", "TMPDIR=/tmp/pvacbind",
     { valueFrom: " && ", shellQuote: false },
-    "/opt/conda/bin/pvacbind", "run",
+    "/usr/local/bin/pvacbind", "run",
     "--iedb-install-directory", "/opt/iedb",
     { position: 5, valueFrom: $(runtime.outdir) },
 ]
 requirements:
     - class: ShellCommandRequirement
     - class: DockerRequirement
-      dockerPull: "griffithlab/pvactools:1.5.13"
+      dockerPull: "griffithlab/pvactools:2.0.0"
     - class: ResourceRequirement
       ramMin: 16000
       coresMin: $(inputs.n_threads)
@@ -44,16 +44,26 @@ inputs:
         type: string[]
         inputBinding:
             position: 4
-    epitope_lengths:
+    epitope_lengths_class_i:
         type: int[]?
         inputBinding:
-            prefix: "-e"
+            prefix: "-e1"
+            itemSeparator: ','
+            separate: false
+    epitope_lengths_class_ii:
+        type: int[]?
+        inputBinding:
+            prefix: "-e2"
             itemSeparator: ','
             separate: false
     binding_threshold:
         type: int?
         inputBinding:
             prefix: "-b"
+    percentile_threshold:
+        type: int?
+        inputBinding:
+            prefix: "--percentile-threshold"
     allele_specific_binding_thresholds:
         type: boolean?
         inputBinding:
@@ -88,6 +98,10 @@ inputs:
         type: float?
         inputBinding:
             prefix: "--net-chop-threshold"
+    run_reference_proteome_similarity:
+        type: boolean?
+        inputBinding:
+            prefix: "--run-reference-proteome-similarity"
     additional_report_columns:
         type:
             - "null"
@@ -113,6 +127,10 @@ outputs:
         type: File?
         outputBinding:
             glob: "MHC_Class_I/$(inputs.sample_name).all_epitopes.tsv"
+    mhc_i_aggregated_report:
+        type: File?
+        outputBinding:
+            glob: "MHC_Class_I/$(inputs.sample_name).all_epitopes.aggregated.tsv"
     mhc_i_filtered_epitopes:
         type: File?
         outputBinding:
@@ -121,6 +139,10 @@ outputs:
         type: File?
         outputBinding:
             glob: "MHC_Class_II/$(inputs.sample_name).all_epitopes.tsv"
+    mhc_ii_aggregated_report:
+        type: File?
+        outputBinding:
+            glob: "MHC_Class_II/$(inputs.sample_name).all_epitopes.aggregated.tsv"
     mhc_ii_filtered_epitopes:
         type: File?
         outputBinding:
@@ -129,6 +151,10 @@ outputs:
         type: File?
         outputBinding:
             glob: "combined/$(inputs.sample_name).all_epitopes.tsv"
+    combined_aggregated_report:
+        type: File?
+        outputBinding:
+            glob: "combined/$(inputs.sample_name).all_epitopes.aggregated.tsv"
     combined_filtered_epitopes:
         type: File?
         outputBinding:

--- a/definitions/tools/pvacbind.cwl
+++ b/definitions/tools/pvacbind.cwl
@@ -49,13 +49,11 @@ inputs:
         inputBinding:
             prefix: "-e1"
             itemSeparator: ','
-            separate: false
     epitope_lengths_class_ii:
         type: int[]?
         inputBinding:
             prefix: "-e2"
             itemSeparator: ','
-            separate: false
     binding_threshold:
         type: int?
         inputBinding:

--- a/definitions/tools/pvacbind.cwl
+++ b/definitions/tools/pvacbind.cwl
@@ -20,7 +20,7 @@ arguments: [
 requirements:
     - class: ShellCommandRequirement
     - class: DockerRequirement
-      dockerPull: "griffithlab/pvactools:2.0.0"
+      dockerPull: "griffithlab/pvactools:2.0.1"
     - class: ResourceRequirement
       ramMin: 16000
       coresMin: $(inputs.n_threads)

--- a/definitions/tools/pvacfuse.cwl
+++ b/definitions/tools/pvacfuse.cwl
@@ -52,13 +52,11 @@ inputs:
         inputBinding:
             prefix: "-e1"
             itemSeparator: ','
-            separate: false
     epitope_lengths_class_ii:
         type: int[]?
         inputBinding:
             prefix: "-e1"
             itemSeparator: ','
-            separate: false
     binding_threshold:
         type: int?
         inputBinding:

--- a/definitions/tools/pvacfuse.cwl
+++ b/definitions/tools/pvacfuse.cwl
@@ -55,7 +55,7 @@ inputs:
     epitope_lengths_class_ii:
         type: int[]?
         inputBinding:
-            prefix: "-e1"
+            prefix: "-e2"
             itemSeparator: ','
     binding_threshold:
         type: int?

--- a/definitions/tools/pvacfuse.cwl
+++ b/definitions/tools/pvacfuse.cwl
@@ -21,7 +21,7 @@ arguments: [
 requirements:
     - class: ShellCommandRequirement
     - class: DockerRequirement
-      dockerPull: "griffithlab/pvactools:2.0.0"
+      dockerPull: "griffithlab/pvactools:2.0.1"
     - class: ResourceRequirement
       ramMin: 16000
       coresMin: $(inputs.n_threads)

--- a/definitions/tools/pvacfuse.cwl
+++ b/definitions/tools/pvacfuse.cwl
@@ -13,7 +13,7 @@ arguments: [
     { valueFrom: " && ", shellQuote: false },
     "export", "TMPDIR=/tmp/pvacseq",
     { valueFrom: " && ", shellQuote: false },
-    "/opt/conda/bin/pvacfuse",
+    "/usr/local/bin/pvacfuse",
     "run",
     "--iedb-install-directory", "/opt/iedb",
     { position: 5, valueFrom: $(runtime.outdir) },
@@ -21,7 +21,7 @@ arguments: [
 requirements:
     - class: ShellCommandRequirement
     - class: DockerRequirement
-      dockerPull: "griffithlab/pvactools:1.5.13"
+      dockerPull: "griffithlab/pvactools:2.0.0"
     - class: ResourceRequirement
       ramMin: 16000
       coresMin: $(inputs.n_threads)
@@ -47,16 +47,26 @@ inputs:
         type: string[]
         inputBinding:
             position: 4
-    epitope_lengths:
+    epitope_lengths_class_i:
         type: int[]?
         inputBinding:
-            prefix: "-e"
+            prefix: "-e1"
+            itemSeparator: ','
+            separate: false
+    epitope_lengths_class_ii:
+        type: int[]?
+        inputBinding:
+            prefix: "-e1"
             itemSeparator: ','
             separate: false
     binding_threshold:
         type: int?
         inputBinding:
             prefix: "-b"
+    percentile_threshold:
+        type: int?
+        inputBinding:
+            prefix: "--percentile-threshold"
     iedb_retries:
         type: int?
         inputBinding:
@@ -65,11 +75,6 @@ inputs:
         type: boolean?
         inputBinding:
             prefix: "-k"
-    peptide_sequence_length:
-        type: int?
-        inputBinding:
-            prefix: "-l"
-        default: 21
     net_chop_method:
         type:
             - "null"
@@ -92,6 +97,10 @@ inputs:
         type: float?
         inputBinding:
             prefix: "--net-chop-threshold"
+    run_reference_proteome_similarity:
+        type: boolean?
+        inputBinding:
+            prefix: "--run-reference-proteome-similarity"
     additional_report_columns:
         type:
             - "null"
@@ -121,35 +130,35 @@ outputs:
         type: File?
         outputBinding:
             glob: "MHC_Class_I/$(inputs.sample_name).all_epitopes.tsv"
+    mhc_i_aggregated_report:
+        type: File?
+        outputBinding:
+            glob: "MHC_Class_I/$(inputs.sample_name).all_epitopes.aggregated.tsv"
     mhc_i_filtered_epitopes:
         type: File?
         outputBinding:
             glob: "MHC_Class_I/$(inputs.sample_name).filtered.tsv"
-    mhc_i_ranked_epitopes:
-        type: File?
-        outputBinding:
-            glob: "MHC_Class_I/$(inputs.sample_name).filtered.condensed.ranked.tsv"
     mhc_ii_all_epitopes:
         type: File?
         outputBinding:
             glob: "MHC_Class_II/$(inputs.sample_name).all_epitopes.tsv"
+    mhc_ii_aggregated_report:
+        type: File?
+        outputBinding:
+            glob: "MHC_Class_II/$(inputs.sample_name).all_epitopes.aggregated.tsv"
     mhc_ii_filtered_epitopes:
         type: File?
         outputBinding:
             glob: "MHC_Class_II/$(inputs.sample_name).filtered.tsv"
-    mhc_ii_ranked_epitopes:
-        type: File?
-        outputBinding:
-            glob: "MHC_Class_II/$(inputs.sample_name).filtered.condensed.ranked.tsv"
     combined_all_epitopes:
         type: File?
         outputBinding:
             glob: "combined/$(inputs.sample_name).all_epitopes.tsv"
+    combined_aggregated_report:
+        type: File?
+        outputBinding:
+            glob: "combined/$(inputs.sample_name).all_epitopes.aggregated.tsv"
     combined_filtered_epitopes:
         type: File?
         outputBinding:
             glob: "combined/$(inputs.sample_name).filtered.tsv"
-    combined_ranked_epitopes:
-        type: File?
-        outputBinding:
-            glob: "combined/$(inputs.sample_name).filtered.condensed.ranked.tsv"

--- a/definitions/tools/pvacseq.cwl
+++ b/definitions/tools/pvacseq.cwl
@@ -13,7 +13,7 @@ arguments: [
     { valueFrom: " && ", shellQuote: false },
     "export", "TMPDIR=/tmp/pvacseq",
     { valueFrom: " && ", shellQuote: false },
-    "/opt/conda/bin/pvacseq", "run",
+    "/usr/local/bin/pvacseq", "run",
     "--iedb-install-directory", "/opt/iedb",
     "--pass-only",
     { position: 5, valueFrom: "pvacseq_predictions" },
@@ -21,7 +21,7 @@ arguments: [
 requirements:
     - class: ShellCommandRequirement
     - class: DockerRequirement
-      dockerPull: "griffithlab/pvactools:1.5.13"
+      dockerPull: "griffithlab/pvactools:2.0.0"
     - class: ResourceRequirement
       ramMin: 16000
       coresMin: $(inputs.n_threads)
@@ -46,16 +46,26 @@ inputs:
         type: string[]
         inputBinding:
             position: 4
-    epitope_lengths:
+    epitope_lengths_class_i:
         type: int[]?
         inputBinding:
-            prefix: "-e"
+            prefix: "-e1"
+            itemSeparator: ','
+            separate: false
+    epitope_lengths_class_ii:
+        type: int[]?
+        inputBinding:
+            prefix: "-e2"
             itemSeparator: ','
             separate: false
     binding_threshold:
         type: int?
         inputBinding:
             prefix: "-b"
+    percentile_threshold:
+        type: int?
+        inputBinding:
+            prefix: "--percentile-threshold"
     allele_specific_binding_thresholds:
         type: boolean?
         inputBinding:
@@ -68,10 +78,6 @@ inputs:
         type: boolean?
         inputBinding:
             prefix: "-k"
-    peptide_sequence_length:
-        type: int?
-        inputBinding:
-            prefix: "-l"
     normal_sample_name:
         type: string?
         inputBinding:
@@ -87,6 +93,10 @@ inputs:
         type: boolean?
         inputBinding:
             prefix: "--netmhc-stab"
+    run_reference_proteome_similarity:
+        type: boolean?
+        inputBinding:
+            prefix: "--run-reference-proteome-similarity"
     top_score_metric:
         type:
             - "null"
@@ -171,38 +181,38 @@ outputs:
         type: File?
         outputBinding:
             glob: "pvacseq_predictions/MHC_Class_I/$(inputs.sample_name).all_epitopes.tsv"
+    mhc_i_aggregated_report:
+        type: File?
+        outputBinding:
+            glob: "pvacseq_predictions/MHC_Class_I/$(inputs.sample_name).all_epitopes.aggregated.tsv"
     mhc_i_filtered_epitopes:
         type: File?
         outputBinding:
             glob: "pvacseq_predictions/MHC_Class_I/$(inputs.sample_name).filtered.tsv"
-    mhc_i_ranked_epitopes:
-        type: File?
-        outputBinding:
-            glob: "pvacseq_predictions/MHC_Class_I/$(inputs.sample_name).filtered.condensed.ranked.tsv"
     mhc_ii_all_epitopes:
         type: File?
         outputBinding:
             glob: "pvacseq_predictions/MHC_Class_II/$(inputs.sample_name).all_epitopes.tsv"
+    mhc_ii_aggregated_report:
+        type: File?
+        outputBinding:
+            glob: "pvacseq_predictions/MHC_Class_II/$(inputs.sample_name).all_epitopes.aggregated.tsv"
     mhc_ii_filtered_epitopes:
         type: File?
         outputBinding:
             glob: "pvacseq_predictions/MHC_Class_II/$(inputs.sample_name).filtered.tsv"
-    mhc_ii_ranked_epitopes:
-        type: File?
-        outputBinding:
-            glob: "pvacseq_predictions/MHC_Class_II/$(inputs.sample_name).filtered.condensed.ranked.tsv"
     combined_all_epitopes:
         type: File?
         outputBinding:
             glob: "pvacseq_predictions/combined/$(inputs.sample_name).all_epitopes.tsv"
+    combined_aggregated_report:
+        type: File?
+        outputBinding:
+            glob: "pvacseq_predictions/combined/$(inputs.sample_name).all_epitopes.aggregated.tsv"
     combined_filtered_epitopes:
         type: File?
         outputBinding:
             glob: "pvacseq_predictions/combined/$(inputs.sample_name).filtered.tsv"
-    combined_ranked_epitopes:
-        type: File?
-        outputBinding:
-            glob: "pvacseq_predictions/combined/$(inputs.sample_name).filtered.condensed.ranked.tsv"
     pvacseq_predictions:
         type: Directory
         outputBinding:

--- a/definitions/tools/pvacseq.cwl
+++ b/definitions/tools/pvacseq.cwl
@@ -51,13 +51,11 @@ inputs:
         inputBinding:
             prefix: "-e1"
             itemSeparator: ','
-            separate: false
     epitope_lengths_class_ii:
         type: int[]?
         inputBinding:
             prefix: "-e2"
             itemSeparator: ','
-            separate: false
     binding_threshold:
         type: int?
         inputBinding:

--- a/definitions/tools/pvacseq.cwl
+++ b/definitions/tools/pvacseq.cwl
@@ -21,7 +21,7 @@ arguments: [
 requirements:
     - class: ShellCommandRequirement
     - class: DockerRequirement
-      dockerPull: "griffithlab/pvactools:2.0.0"
+      dockerPull: "griffithlab/pvactools:2.0.1"
     - class: ResourceRequirement
       ramMin: 16000
       coresMin: $(inputs.n_threads)

--- a/definitions/tools/pvacvector.cwl
+++ b/definitions/tools/pvacvector.cwl
@@ -13,7 +13,7 @@ arguments: [
     { valueFrom: " && ", shellQuote: false },
     "export", "TMPDIR=/tmp/pvacseq",
     { valueFrom: " && ", shellQuote: false },
-    "/opt/conda/bin/pvacvector",
+    "/usr/local/bin/pvacvector",
     "run",
     "--iedb-install-directory", "/opt/iedb",
     { position: 5, valueFrom: $(runtime.outdir) },
@@ -21,7 +21,7 @@ arguments: [
 requirements:
     - class: ShellCommandRequirement
     - class: DockerRequirement
-      dockerPull: "griffithlab/pvactools:1.5.13"
+      dockerPull: "griffithlab/pvactools:2.0.0"
     - class: ResourceRequirement
       ramMin: 16000
       coresMin: $(inputs.n_threads)
@@ -45,16 +45,26 @@ inputs:
         type: string[]
         inputBinding:
             position: 4
-    epitope_lengths:
+    epitope_lengths_class_i:
         type: int[]?
         inputBinding:
-            prefix: "-e"
+            prefix: "-e1"
+            itemSeparator: ','
+            separate: false
+    epitope_lengths_class_ii:
+        type: int[]?
+        inputBinding:
+            prefix: "-e2"
             itemSeparator: ','
             separate: false
     binding_threshold:
         type: int?
         inputBinding:
             prefix: "-b"
+    percentile_threshold:
+        type: int?
+        inputBinding:
+            prefix: "--percentile-threshold"
     top_score_metric:
         type:
             - "null"
@@ -99,6 +109,10 @@ outputs:
         type: File
         outputBinding:
             glob: "$(inputs.sample_name)_results.fa"
+    vector_dna_fasta:
+        type: File
+        outputBinding:
+            glob: "$(inputs.sample_name)_results.dna.fa"
     vector_jpg:
         type: File?
         outputBinding:

--- a/definitions/tools/pvacvector.cwl
+++ b/definitions/tools/pvacvector.cwl
@@ -21,7 +21,7 @@ arguments: [
 requirements:
     - class: ShellCommandRequirement
     - class: DockerRequirement
-      dockerPull: "griffithlab/pvactools:2.0.0"
+      dockerPull: "griffithlab/pvactools:2.0.1"
     - class: ResourceRequirement
       ramMin: 16000
       coresMin: $(inputs.n_threads)

--- a/definitions/tools/pvacvector.cwl
+++ b/definitions/tools/pvacvector.cwl
@@ -50,13 +50,11 @@ inputs:
         inputBinding:
             prefix: "-e1"
             itemSeparator: ','
-            separate: false
     epitope_lengths_class_ii:
         type: int[]?
         inputBinding:
             prefix: "-e2"
             itemSeparator: ','
-            separate: false
     binding_threshold:
         type: int?
         inputBinding:

--- a/definitions/tools/vep.cwl
+++ b/definitions/tools/vep.cwl
@@ -14,7 +14,7 @@ requirements:
       ramMin: 64000
       tmpdirMin: 25000
     - class: DockerRequirement
-      dockerPull: "mgibio/vep_helper-cwl:vep_101.0_v1"
+      dockerPull: "mgibio/vep_helper-cwl:vep_101.0_v2"
 arguments:
     ["--format", "vcf",
     "--vcf",


### PR DESCRIPTION
This involved quite a few changes to the inputs since those changed in the new version. The VEP version was also updated to one that has the new Frameshift plugin, which is required for running pVACseq 2.0.

@johnegarza if you could have a look at the immuno.cwl to make sure I didn't miss anything, that would be great.