### PR TITLE
Fix the problem of indexing an unsorted merged BAM in rnaseq.cwl

### DIFF
--- a/definitions/pipelines/rnaseq.cwl
+++ b/definitions/pipelines/rnaseq.cwl
@@ -131,16 +131,22 @@ steps:
             bams: bam_to_trimmed_fastq_and_hisat_alignments/aligned_bam
         out:
             [merged_bam]
+    position_sort:
+        run: ../tools/position_sort.cwl
+        in:
+            bam: merge/merged_bam
+        out:
+            [position_sorted_bam]
     index_bam:
         run: ../tools/index_bam.cwl
         in:
-            bam: merge/merged_bam
+            bam: position_sort/position_sorted_bam
         out:
             [indexed_bam]
     mark_dup:
         run: ../tools/mark_duplicates_and_sort.cwl
         in:
-            bam: merge/merged_bam
+            bam: index_bam/indexed_bam
             input_sort_order: 
                 default: "coordinate"
         out:


### PR DESCRIPTION
**Background**:
There is a broken step in `definitions/pipelines/rnaseq.cwl` because it tries to index an unsorted BAM. For fixing this problem, a new step was added in order to sort a merged BAMs between the `merge` and `index_bam` step in rnaseq.cwl.

**Changes**:
There is a built-in cwl tool `definitions/tools/position_sort.cwl` for this purpose. I added it in rnaseq.cwl, and I changed inputs in the `index_bam` and `mark_up` step accordingly.