### PR TITLE
Example YAML: bqsr_known_sites is an array of Files.

### DIFF
--- a/example_data/somatic_exome.yaml
+++ b/example_data/somatic_exome.yaml
@@ -47,10 +47,14 @@ omni_vcf:
   path: somatic_inputs/hla_and_brca_genes_omni.vcf.gz
 
 bqsr_known_sites:
-  - somatic_inputs/hla_and_brca_genes_omni.vcf.gz
-  - somatic_inputs/hla_and_brca_genes_dbsnp.vcf.gz
-  - somatic_inputs/hla_and_brca_genes_mills.vcf.gz
-  - somatic_inputs/hla_and_brca_genes_known_indels.vcf.gz
+  - path: somatic_inputs/hla_and_brca_genes_omni.vcf.gz
+    class: File
+  - path: somatic_inputs/hla_and_brca_genes_dbsnp.vcf.gz
+    class: File
+  - path: somatic_inputs/hla_and_brca_genes_mills.vcf.gz
+    class: File
+  - path: somatic_inputs/hla_and_brca_genes_known_indels.vcf.gz
+    class: File
 
 picard_metric_accumulation_level: LIBRARY
 


### PR DESCRIPTION
To match the type in pipelines/somatic_exome.cwl, this should be an array of `File` rather than of strings.

https://github.com/genome/analysis-workflows/blob/389f6edccab082d947bee9c032f59dbdf9f7c325/definitions/pipelines/somatic_exome.cwl#L69-L70