### PR TITLE
Fix cgpbigwig_bamcoverage step and update workflow example of rnaseq.cwl

### DIFF
--- a/definitions/tools/bam_to_bigwig.cwl
+++ b/definitions/tools/bam_to_bigwig.cwl
@@ -3,7 +3,7 @@
 cwlVersion: v1.0
 class: CommandLineTool
 label: 'cgpBigWig Converting BAM to BigWig'
-baseCommand: ["bam2bw", "-a -F", "1024"]
+baseCommand: ["bam2bw", "-a", "-F", "1024"]
 arguments: ["-o", { valueFrom: $(inputs.bam.nameroot).bw}]
 requirements:
     - class: DockerRequirement
@@ -16,7 +16,7 @@ inputs:
         inputBinding:
             position: 1
             prefix: '-i'
-        secondaryFiles: [^.bai, .bai]
+        secondaryFiles: [.bai]
     reference:
         type:
             - string

--- a/example_data/rnaseq/workflow.yaml
+++ b/example_data/rnaseq/workflow.yaml
@@ -3,24 +3,33 @@ instrument_data_bams:
       path: gerald_H3MYFBBXX_4_GCCAAT_1k.bam
     - class: File
       path: gerald_H3MYFBBXX_5_GCCAAT_1k.bam
+reference: /gscmnt/gc2560/core/model_data/2887491634/build21f22873ebe0486c8e6f69c15435aa96/all_sequences.fa
 reference_index:
-    class: File
-    path: /gscmnt/gc2560/core/GRC-human-build38_human_90_38/rna_seq_annotation/hisat2.1.0_index/GRCh38DH
+  class: File
+  path: /gscmnt/gc2560/core/GRC-human-build38_human_95_38_U2AF1_fix/rna_seq_annotation/hisat2.1.0_index/GRCh38DH
 reference_annotation:
-    class: File
-    path: /gscmnt/gc2560/core/GRC-human-build38_human_90_38/rna_seq_annotation/Homo_sapiens.GRCh38DH.90.gtf
+  class: File
+  path: /gscmnt/gc2560/core/GRC-human-build38_human_95_38_U2AF1_fix/rna_seq_annotation/Homo_sapiens.GRCh38.95.gtf
 kallisto_index:
   class: File
-  path: /gscmnt/gc2560/core/GRC-human-build38_human_90_38/rna_seq_annotation/Homo_sapiens.GRCh38.cdna.all.fa.kallisto.idx
+  path: /gscmnt/gc2560/core/GRC-human-build38_human_95_38_U2AF1_fix/rna_seq_annotation/Homo_sapiens.GRCh38.cdna.all.fa.kallisto.idx
 gene_transcript_lookup_table:
   class: File
-  path: /gscmnt/gc2560/core/GRC-human-build38_human_90_38/rna_seq_annotation/ensembl90.transcriptToGene.tsv
+  path: /gscmnt/gc2560/core/GRC-human-build38_human_95_38_U2AF1_fix/rna_seq_annotation/ensembl95.transcriptToGene.tsv
 read_group_id:
     - '2895626107'
     - '2895626112'
 read_group_fields:
-    - ['PU:H3MYFBBXX5.4.GCCAAT', 'SM:H_NJ-HCC1395-HCC1395_RNA', 'LB:Pooled_RNA_2891007020-cD1-lib1', 'PL:Illumina', 'CN:WUGSC']
-    - ['PU:H3MYFBBXX5.5.GCCAAT', 'SM:H_NJ-HCC1395-HCC1395_RNA', 'LB:Pooled_RNA_2891007020-cD1-lib1', 'PL:Illumina', 'CN:WUGSC']
+- - PU:H3MYFBBXX.4
+  - SM:H_NJ-HCC1395-HCC1395_RNA
+  - LB:Pooled_RNA_2891007020-cD1-lib1
+  - PL:Illumina
+  - CN:WUGSC
+- - PU:H3MYFBBXX.5
+  - SM:H_NJ-HCC1395-HCC1395_RNA
+  - LB:Pooled_RNA_2891007020-cD1-lib1
+  - PL:Illumina
+  - CN:WUGSC
 trimming_adapters:
     class: File
     path: illumina_multiplex.fa
@@ -29,11 +38,12 @@ trimming_adapter_min_overlap: 7
 trimming_max_uncalled: 300
 trimming_min_readlength: 25
 sample_name: H_NJ-HCC1395-HCC1395_RNA
-firststrand: TRUE
+strand: first
 refFlat:
-    class: File
-    path: /gscmnt/gc2560/core/GRC-human-build38_human_90_38_U2AF1_fix/rna_seq_annotation/Homo_sapiens.GRCh38.90.refFlat.txt
+  class: File
+  path: /gscmnt/gc2560/core/GRC-human-build38_human_95_38_U2AF1_fix/rna_seq_annotation/Homo_sapiens.GRCh38.95.refFlat.txt
 ribosomal_intervals:
-    class: File
-    path: /gscmnt/gc2560/core/GRC-human-build38_human_90_38_U2AF1_fix/rna_seq_annotation/Homo_sapiens.GRCh38.90.rRNA.interval_list
-strand: "second"
+  class: File
+  path: /gscmnt/gc2560/core/GRC-human-build38_human_95_38_U2AF1_fix/rna_seq_annotation/Homo_sapiens.GRCh38.95.ribo_intervals
+species: homo_sapiens
+assembly: GRCh38


### PR DESCRIPTION
This PR has two updates. I finally confirmed that the current rnaseq.cwl is now working with these updates.

(1) Fix `definitions/tools/bam_to_bigwig.cwl` as a subsequent update of #1007

The current rnaseq.cwl was broken in the `cgpbigwig_bamcoverage` step, because of invalid `MarkedSorted.bai` requirement. This PR fixes this broken step.

(2) Update rnaseq.cwl workflow example for the issue #958 

The previous workflow example was outdated. I updated the inputs YAML file, and I confirmed that this workflow example for `rnaseq.cwl` is perfectly working now.
