### PR TITLE
Switch to docker image hosted in our mgibio namespace.

### DIFF
--- a/definitions/tools/strandedness_check.cwl
+++ b/definitions/tools/strandedness_check.cwl
@@ -25,7 +25,7 @@ requirements:
       tmpdirMin: 5000
       coresMin: 1
     - class: DockerRequirement
-      dockerPull: "smk5g5/checkstranded:version1.0"
+      dockerPull: "mgibio/checkstrandedness:v1"
 inputs:
     gtf_file:
         type: File


### PR DESCRIPTION
Closes #1011.