### PR TITLE
Updated stringtie version to 2.1.4

### DIFF
--- a/definitions/pipelines/rnaseq_star_fusion.cwl
+++ b/definitions/pipelines/rnaseq_star_fusion.cwl
@@ -18,7 +18,7 @@ inputs:
         type: Directory
     cdna_fasta:
         type: File
-    reference_fasta:
+    reference:
         type: File
         secondaryFiles: [.fai, ^.dict]
     gtf_file:
@@ -183,7 +183,7 @@ steps:
     stringtie:
         run: ../tools/stringtie.cwl
         in:
-            bam: index_bam/indexed_bam
+            bam: mark_dup/sorted_bam
             reference_annotation: gtf_file
             sample_name: sample_name
             strand: strand
@@ -195,13 +195,13 @@ steps:
             refFlat: refFlat
             ribosomal_intervals: ribosomal_intervals
             strand: strand
-            bam: index_bam/indexed_bam
+            bam: mark_dup/sorted_bam
         out:
             [metrics, chart]
     bam_to_cram:
         run: ../tools/bam_to_cram.cwl
         in:
-          reference: reference_fasta
+          reference: reference
           bam: index_bam/indexed_bam
         out:
             [cram]
@@ -214,7 +214,7 @@ steps:
     cgpbigwig_bamcoverage:
         run: ../tools/bam_to_bigwig.cwl
         in:
-            bam: index_bam/indexed_bam
-            reference: reference_fasta
+            bam: mark_dup/sorted_bam
+            reference: reference
         out:
             [outfile]

--- a/definitions/tools/stringtie.cwl
+++ b/definitions/tools/stringtie.cwl
@@ -3,13 +3,13 @@
 cwlVersion: v1.0
 class: CommandLineTool
 label: "StringTie"
-baseCommand: ["/usr/bin/stringtie"]
+baseCommand: ["/usr/local/bin/stringtie"]
 requirements:
     - class: ResourceRequirement
       ramMin: 16000
       coresMin: 12
     - class: DockerRequirement
-      dockerPull: "mgibio/rnaseq:1.0.0"
+      dockerPull: "quay.io/biocontainers/stringtie:2.1.4--h7e0af3c_0"
     - class: StepInputExpressionRequirement
 
 arguments: [
@@ -54,7 +54,6 @@ inputs:
         type: File
         inputBinding:
             position: 4
-        secondaryFiles: [.bai,^.bai]
 outputs:
     transcript_gtf:
         type: File

--- a/example_data/rnaseq/workflow_star_fusion.yaml
+++ b/example_data/rnaseq/workflow_star_fusion.yaml
@@ -41,6 +41,6 @@ refFlat:
 cdna_fasta:
     class: File
     path: /gscmnt/gc2560/core/GRC-human-build38_human_95_38_U2AF1_fix/rna_seq_annotation/Homo_sapiens.GRCh38.cdna.all.fa.gz
-reference_fasta:
-    class: gtf_file
+reference:
+    class: File
     path: /gscmnt/gc2560/core/GRC-human-build38_human_95_38_U2AF1_fix/rna_seq_annotation/star_2.7.0f_index/all_sequences.fa


### PR DESCRIPTION
Updated version of stringtie from version 1.3.3 to 2.1.4.

Coverage,FPKM and TPM values do change in the stringtie_gene_expression.tsv output file for version 2.1.4 compared to version 1.3.3 but the workflow finishes successfully!