### PR TITLE
update mutect regex to better handle sample name extraction

### DIFF
--- a/definitions/tools/mutect.cwl
+++ b/definitions/tools/mutect.cwl
@@ -22,8 +22,8 @@ requirements:
             export tumor_bam="$3"
             export normal_bam="$4"
 
-            TUMOR=`perl -e 'my $header_str = qx(samtools view -H $ENV{tumor_bam}); my ($sample_name) = $header_str =~ /@RG.+SM:([^\s]+)/; print $sample_name'` #Extracting the sample name from the TUMOR bam.
-            NORMAL=`perl -e 'my $header_str = qx(samtools view -H $ENV{normal_bam}); my ($sample_name) = $header_str =~ /@RG.+SM:([^\s]+)/; print $sample_name'` #Extracting the sample name from the NORMAL bam.
+            TUMOR=`perl -e 'my $header_str = qx(samtools view -H $ENV{tumor_bam}); my ($sample_name) = $header_str =~ /^@RG.+\tSM:([ -~]+)/; print $sample_name'` #Extracting the sample name from the TUMOR bam.
+            NORMAL=`perl -e 'my $header_str = qx(samtools view -H $ENV{normal_bam}); my ($sample_name) = $header_str =~ /^@RG.+\tSM:([ -~]+)/; print $sample_name'` #Extracting the sample name from the NORMAL bam.
             /gatk/gatk Mutect2 --java-options "-Xmx20g" -O $1 -R $2 -I $3 -tumor "$TUMOR" -I $4 -normal "$NORMAL" -L $5 #Running Mutect2.
             /gatk/gatk FilterMutectCalls -R $2 -V mutect.vcf.gz -O mutect.filtered.vcf.gz #Running FilterMutectCalls on the output vcf.
 

--- a/definitions/tools/mutect.cwl
+++ b/definitions/tools/mutect.cwl
@@ -22,8 +22,8 @@ requirements:
             export tumor_bam="$3"
             export normal_bam="$4"
 
-            TUMOR=`perl -e 'my $header_str = qx(samtools view -H $ENV{tumor_bam}); my ($sample_name) = $header_str =~ /SM:([ -~]+)/; print $sample_name'` #Extracting the sample name from the TUMOR bam.
-            NORMAL=`perl -e 'my $header_str = qx(samtools view -H $ENV{normal_bam}); my ($sample_name) = $header_str =~ /SM:([ -~]+)/; print $sample_name'` #Extracting the sample name from the NORMAL bam.
+            TUMOR=`perl -e 'my $header_str = qx(samtools view -H $ENV{tumor_bam}); my ($sample_name) = $header_str =~ /@RG.+SM:([^\s]+)/; print $sample_name'` #Extracting the sample name from the TUMOR bam.
+            NORMAL=`perl -e 'my $header_str = qx(samtools view -H $ENV{normal_bam}); my ($sample_name) = $header_str =~ /@RG.+SM:([^\s]+)/; print $sample_name'` #Extracting the sample name from the NORMAL bam.
             /gatk/gatk Mutect2 --java-options "-Xmx20g" -O $1 -R $2 -I $3 -tumor "$TUMOR" -I $4 -normal "$NORMAL" -L $5 #Running Mutect2.
             /gatk/gatk FilterMutectCalls -R $2 -V mutect.vcf.gz -O mutect.filtered.vcf.gz #Running FilterMutectCalls on the output vcf.
 


### PR DESCRIPTION
The previous regex fails when there are lines in the bam header like this, which contain the SM tag as well as trailing information, all of which gets captured. 

`@PG     ID:bwa.2        PN:bwa  VN:0.7.12-r1039 CL:bwa mem -t 8 -T 0 -R @RG\tCN:BI\tDT:2010-03-12T00\tID:61D5N.8\tLB:Solexa-21878\tPL:illumina\tPU:61D5NAAXX100312.8\tSM:TCGA-AB-2821-03B-01W-0728-08 /alignment/reference/GRCh38.d1.vd1.fa /alignment/scratch1yVgmO/fastq/rmdup/61D5N.8_1.fq.gz /alignment/scratch1yVgmO/fastq/rmdup/61D5N.8_2.fq.gz`

This change restricts to looking at `@RG` lines and only captures the sample name. 

It will fail on sample names with spaces in them, but [a space in a filename is a space in one's soul](https://twitter.com/aaronquinlan/status/711593127551733761). (and I'm fairly confident that there are other places in these pipelines that would break with spaces as well)