### PR TITLE
changes to get non_human somatic exome to work

### DIFF
--- a/definitions/subworkflows/sequence_to_bqsr_nonhuman.cwl
+++ b/definitions/subworkflows/sequence_to_bqsr_nonhuman.cwl
@@ -47,7 +47,7 @@ steps:
         out:
             [aligned_bam]
     merge:
-        run: ../tools/merge_bams_samtools.cwl
+        run: ../tools/merge_bams.cwl
         in:
             bams: align/aligned_bam
             name: final_name
@@ -63,6 +63,9 @@ steps:
         run: ../tools/mark_duplicates_and_sort.cwl
         in:
             bam: name_sort/name_sorted_bam
+            output_name:
+		source: final_name
+                valueFrom: $(self)
         out:
             [sorted_bam, metrics_file]
     index_bam:

--- a/definitions/subworkflows/sequence_to_bqsr_nonhuman.cwl
+++ b/definitions/subworkflows/sequence_to_bqsr_nonhuman.cwl
@@ -63,9 +63,7 @@ steps:
         run: ../tools/mark_duplicates_and_sort.cwl
         in:
             bam: name_sort/name_sorted_bam
-            output_name:
-		source: final_name
-                valueFrom: $(self)
+            output_name: final_name
         out:
             [sorted_bam, metrics_file]
     index_bam:


### PR DESCRIPTION
This PR resolves two issues for the non human somatic exome

1. resolves improper merging with multiple instrument data, see #998 
2. There was an issue where QC metric output files were named the same for tumor and normal resulting from the input bams having the same name (MarkedSorted.bam). This caused the GMS builds to fail as the GMS would try and copy the same named output for 2 different results. 

Workflow has been tested and is known to work, see buildID: 2feba7f0981e4b8cbb45951d72173291