### PR TITLE
Correct parsing issues with sample name regex in mutect and filter_vcf_docm

### DIFF
--- a/definitions/tools/filter_vcf_docm.cwl
+++ b/definitions/tools/filter_vcf_docm.cwl
@@ -28,8 +28,8 @@ requirements:
             my $normal_header_str = `$samtools view -H $normal_cram`;
             my $tumor_header_str  = `$samtools view -H $tumor_cram`;
 
-            my ($normal_name) = $normal_header_str =~ /^@RG\tSM:([ -~]+)/;
-            my ($tumor_name)  = $tumor_header_str =~ /^@RG\tSM:([ -~]+)/;
+            my ($normal_name) = $normal_header_str =~ /\@RG.+\tSM:([ -~]+)/;
+            my ($tumor_name)  = $tumor_header_str =~ /\@RG.+\tSM:([ -~]+)/;
 
             unless ($normal_name and $tumor_name) {
                 die "Failed to get normal_name: $normal_name from $normal_cram AND tumor_name: $tumor_name from $tumor_cram";

--- a/definitions/tools/filter_vcf_docm.cwl
+++ b/definitions/tools/filter_vcf_docm.cwl
@@ -25,8 +25,8 @@ requirements:
             my ($docm_vcf, $normal_cram, $tumor_cram, $output_vcf_file, $set_filter_flag) = @ARGV;
 
             my $samtools = '/opt/samtools/bin/samtools';
-            my $normal_header_str = `$samtools view -H $normal_cram`;
-            my $tumor_header_str  = `$samtools view -H $tumor_cram`;
+            my $normal_header_str = `$samtools view -H $normal_cram | grep "^\@RG" | head -n 1`;
+            my $tumor_header_str  = `$samtools view -H $tumor_cram | grep "^\@RG" | head -n 1`;
 
             my ($normal_name) = $normal_header_str =~ /\@RG.+\tSM:([ -~]+)/;
             my ($tumor_name)  = $tumor_header_str =~ /\@RG.+\tSM:([ -~]+)/;

--- a/definitions/tools/mutect.cwl
+++ b/definitions/tools/mutect.cwl
@@ -22,8 +22,8 @@ requirements:
             export tumor_bam="$3"
             export normal_bam="$4"
 
-            TUMOR=`perl -e 'my $header_str = qx(samtools view -H $ENV{tumor_bam}); my ($sample_name) = $header_str =~ /^@RG.+\tSM:([ -~]+)/; print $sample_name'` #Extracting the sample name from the TUMOR bam.
-            NORMAL=`perl -e 'my $header_str = qx(samtools view -H $ENV{normal_bam}); my ($sample_name) = $header_str =~ /^@RG.+\tSM:([ -~]+)/; print $sample_name'` #Extracting the sample name from the NORMAL bam.
+            TUMOR=`perl -e 'my $header_str = qx(samtools view -H $ENV{tumor_bam}); my ($sample_name) = $header_str =~ /@RG.+\tSM:([ -~]+)/; print $sample_name'` #Extracting the sample name from the TUMOR bam.
+            NORMAL=`perl -e 'my $header_str = qx(samtools view -H $ENV{normal_bam}); my ($sample_name) = $header_str =~ /@RG.+\tSM:([ -~]+)/; print $sample_name'` #Extracting the sample name from the NORMAL bam.
             /gatk/gatk Mutect2 --java-options "-Xmx20g" -O $1 -R $2 -I $3 -tumor "$TUMOR" -I $4 -normal "$NORMAL" -L $5 #Running Mutect2.
             /gatk/gatk FilterMutectCalls -R $2 -V mutect.vcf.gz -O mutect.filtered.vcf.gz #Running FilterMutectCalls on the output vcf.
 

--- a/definitions/tools/mutect.cwl
+++ b/definitions/tools/mutect.cwl
@@ -22,8 +22,8 @@ requirements:
             export tumor_bam="$3"
             export normal_bam="$4"
 
-            NORMAL=`samtools view -H $normal_bam | perl -ne 'print $1 . "\n" if $_ =~ /^@RG.+\tSM:([ -~]+)/' | head -n 1`
-            TUMOR=`samtools view -H $tumor_bam | perl -ne 'print $1 . "\n" if $_ =~ /^@RG.+\tSM:([ -~]+)/' | head -n 1`
+            NORMAL=`samtools view -H $normal_bam | perl -nE 'say $1 if /^\@RG.+\tSM:([ -~]+)/' | head -n 1`
+            TUMOR=`samtools view -H $tumor_bam | perl -nE 'say $1 if /^\@RG.+\tSM:([ -~]+)/' | head -n 1`
 
             /gatk/gatk Mutect2 --java-options "-Xmx20g" -O $1 -R $2 -I $3 -tumor "$TUMOR" -I $4 -normal "$NORMAL" -L $5 #Running Mutect2.
             /gatk/gatk FilterMutectCalls -R $2 -V mutect.vcf.gz -O mutect.filtered.vcf.gz #Running FilterMutectCalls on the output vcf.

--- a/definitions/tools/mutect.cwl
+++ b/definitions/tools/mutect.cwl
@@ -22,8 +22,9 @@ requirements:
             export tumor_bam="$3"
             export normal_bam="$4"
 
-            TUMOR=`perl -e 'my $header_str = qx(samtools view -H $ENV{tumor_bam}); my ($sample_name) = $header_str =~ /@RG.+\tSM:([ -~]+)/; print $sample_name'` #Extracting the sample name from the TUMOR bam.
-            NORMAL=`perl -e 'my $header_str = qx(samtools view -H $ENV{normal_bam}); my ($sample_name) = $header_str =~ /@RG.+\tSM:([ -~]+)/; print $sample_name'` #Extracting the sample name from the NORMAL bam.
+            NORMAL=`samtools view -H $normal_bam | perl -ne 'print $1 . "\n" if $_ =~ /^@RG.+\tSM:([ -~]+)/' | head -n 1`
+            TUMOR=`samtools view -H $tumor_bam | perl -ne 'print $1 . "\n" if $_ =~ /^@RG.+\tSM:([ -~]+)/' | head -n 1`
+
             /gatk/gatk Mutect2 --java-options "-Xmx20g" -O $1 -R $2 -I $3 -tumor "$TUMOR" -I $4 -normal "$NORMAL" -L $5 #Running Mutect2.
             /gatk/gatk FilterMutectCalls -R $2 -V mutect.vcf.gz -O mutect.filtered.vcf.gz #Running FilterMutectCalls on the output vcf.
 


### PR DESCRIPTION
somatic_exome workflow was breaking with an error indicating that the sample name wasn't being extracted from the bam properly. Replicated in a local docker, and there are three issues that were happening with these regexes.

1. Perl seems to be reading the samtools results as a single string, not a collection of strings. The leading ^ to pin to start of string no longer works, because they're several lines down.
2. Somehow filter_vcf_dom.cwl was missing the .+ to span the line
3. filter_vcf_dom needs to escape the @. Unsure why mutect doesn't?

Error from the unmatched regex:
```
Use of uninitialized value $normal_name in concatenation (.) or string at docm_filter.pl line 19.
Use of uninitialized value $tumor_name in concatenation (.) or string at docm_filter.pl line 19.
```
Error from the unescaped @:
```
Possible unintended interpolation of @RG in string at /app/docm/docm_filter.pl line 16.
Global symbol "@RG" requires explicit package name (did you forget to declare "my @RG"?) at /app/docm/docm_filter.pl line 16.
```