### PR TITLE
update bcftools version 1.12

### DIFF
--- a/definitions/tools/bcftools_merge.cwl
+++ b/definitions/tools/bcftools_merge.cwl
@@ -9,7 +9,7 @@ requirements:
     - class: ResourceRequirement
       ramMin: 4000
     - class: DockerRequirement
-      dockerPull: "mgibio/bcftools-cwl:1.9"
+      dockerPull: "mgibio/bcftools-cwl:1.12"
 
 inputs:
     force_merge:

--- a/definitions/tools/filter_known_variants.cwl
+++ b/definitions/tools/filter_known_variants.cwl
@@ -6,7 +6,7 @@ label: "Adds an INFO tag (VALIDATED) flagging variants in the pipeline vcf prese
 
 requirements:
     - class: DockerRequirement
-      dockerPull: "mgibio/bcftools-cwl:1.9"
+      dockerPull: "mgibio/bcftools-cwl:1.12"
     - class: ResourceRequirement
       ramMin: 8000
     - class: InitialWorkDirRequirement

--- a/definitions/tools/filter_sv_vcf_depth.cwl
+++ b/definitions/tools/filter_sv_vcf_depth.cwl
@@ -8,7 +8,7 @@ requirements:
     - class: ResourceRequirement
       ramMin: 4000
     - class: DockerRequirement
-      dockerPull: "mgibio/bcftools-cwl:1.9"
+      dockerPull: "mgibio/bcftools-cwl:1.12"
     - class: InitialWorkDirRequirement
       listing:
       - entryname: "filter_sv_vcf_depth.sh"

--- a/definitions/tools/filter_sv_vcf_read_support.cwl
+++ b/definitions/tools/filter_sv_vcf_read_support.cwl
@@ -8,7 +8,7 @@ requirements:
     - class: ResourceRequirement
       ramMin: 4000
     - class: DockerRequirement
-      dockerPull: "mgibio/bcftools-cwl:1.9"
+      dockerPull: "mgibio/bcftools-cwl:1.12"
     - class: InitialWorkDirRequirement
       listing:
       - entryname: "filter_sv_vcf_read_support.sh"

--- a/definitions/tools/filter_sv_vcf_size.cwl
+++ b/definitions/tools/filter_sv_vcf_size.cwl
@@ -8,7 +8,7 @@ requirements:
     - class: ResourceRequirement
       ramMin: 4000
     - class: DockerRequirement
-      dockerPull: "mgibio/bcftools-cwl:1.9"
+      dockerPull: "mgibio/bcftools-cwl:1.12"
     - class: InitialWorkDirRequirement
       listing:
       - entryname: "filter_sv_vcf_size.sh"

--- a/definitions/tools/intersect_known_variants.cwl
+++ b/definitions/tools/intersect_known_variants.cwl
@@ -6,7 +6,7 @@ label: "Intersect passing validated variants and passing pipeline variants for u
 
 requirements:
     - class: DockerRequirement
-      dockerPull: "mgibio/bcftools-cwl:1.9"
+      dockerPull: "mgibio/bcftools-cwl:1.12"
     - class: ResourceRequirement
       ramMin: 8000
     - class: InitialWorkDirRequirement

--- a/definitions/tools/merge_vcf.cwl
+++ b/definitions/tools/merge_vcf.cwl
@@ -6,7 +6,7 @@ label: "vcf merge"
 baseCommand: ["/opt/bcftools/bin/bcftools", "concat"]
 requirements:
     - class: DockerRequirement
-      dockerPull: mgibio/bcftools-cwl:1.3.1
+      dockerPull: mgibio/bcftools-cwl:1.12
     - class: ResourceRequirement
       ramMin: 4000
 arguments:

--- a/definitions/tools/remove_end_tags.cwl
+++ b/definitions/tools/remove_end_tags.cwl
@@ -13,7 +13,7 @@ requirements:
     - class: ResourceRequirement
       ramMin: 4000
     - class: DockerRequirement
-      dockerPull: "mgibio/bcftools-cwl:1.3.1"
+      dockerPull: "mgibio/bcftools-cwl:1.12"
 inputs:
     vcf:
         type: File

--- a/definitions/tools/replace_vcf_sample_name.cwl
+++ b/definitions/tools/replace_vcf_sample_name.cwl
@@ -9,7 +9,7 @@ requirements:
     - class: ResourceRequirement
       ramMin: 8000
     - class: DockerRequirement
-      dockerPull: "mgibio/bcftools-cwl:1.9"
+      dockerPull: "mgibio/bcftools-cwl:1.12"
     - class: InitialWorkDirRequirement
       listing:
       - entryname: "rename_sample.sh"


### PR DESCRIPTION
updating bcftools version for #948
version 1.9 to 1.12, release notes can be found [here](https://github.com/samtools/bcftools/releases)
One new feature is that the output type no longer needs to be specified. bcftools is able to determine the output type based on the suffix of the output file name. 

