### PR TITLE
update smoove path for quay image

### DIFF
--- a/definitions/tools/smoove.cwl
+++ b/definitions/tools/smoove.cwl
@@ -4,7 +4,7 @@ cwlVersion: v1.0
 class: CommandLineTool
 label: "Run Smoove v0.1.6"
 
-baseCommand: "/usr/bin/smoove"
+baseCommand: "/usr/local/bin/smoove"
 arguments: ["call", "--processes", $(runtime.cores), "-F"]
 
 requirements:


### PR DESCRIPTION
The quay image has smoove installed at `/usr/local/bin/smoove` brentp's image had it installed at `/usr/bin/smoove`. This PR updates the cwl command to match the docker image.