### PR TITLE
Set user name and email for documentation update commit.

### DIFF
--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -29,6 +29,8 @@ jobs:
         run: |
           git clone "https://${WIKI_ACCESS_TOKEN}@github.com/genome/analysis-workflows.wiki.git"
           cd analysis-workflows.wiki/
+          git config user.email "apipe-tester@genome.wustl.edu"
+          git config user.name "APipe Tester"
           python scripts/create_cwl_documentation.py
           git add .
           git diff-index --quiet HEAD || git commit -m "Automated Documentation Update\n\nWorkflow run ${GITHUB_RUN_ID} on ${GITHUB_SHA}."


### PR DESCRIPTION
On Travis the default info was enough to generate a commit, but github doesn't fill in enough info in its actions, so let's set up a name and email for ourselves!