### PR TITLE
Update merge_bams.cwl to work with both cwltool and cromwell.

### DIFF
--- a/definitions/tools/merge_bams.cwl
+++ b/definitions/tools/merge_bams.cwl
@@ -66,7 +66,7 @@ inputs:
             position: 3
     sorted:
         type: boolean?
-        default: "false"
+        default: false
         inputBinding:
             prefix: "-s"
             position: 2

--- a/definitions/tools/merge_bams.cwl
+++ b/definitions/tools/merge_bams.cwl
@@ -3,7 +3,7 @@
 cwlVersion: v1.0
 class: CommandLineTool
 label: "Sambamba: merge"
-baseCommand: ["/bin/bash", "merge.sh"]
+baseCommand: ["/usr/bin/perl", "merge.pl"]
 requirements:
     - class: ResourceRequirement
       ramMin: 8000
@@ -12,49 +12,49 @@ requirements:
       dockerPull: "mgibio/bam-merge:0.1"
     - class: InitialWorkDirRequirement
       listing:
-      - entryname: 'merge.sh'
+      - entryname: 'merge.pl'
         entry: |
-            #!/bin/bash
-            set -o pipefail
-            set -o errexit
-            set -o nounset
+            #!/usr/bin/perl
 
-            SORTED=false
+            use strict;
+            use warnings;
 
-            while getopts "t:n:s:" opt; do
-                case "$opt" in
-                    t)
-                        NTHREADS="$OPTARG"
-                        ;;
-                    n)
-                        OUTFILENAME="$OPTARG"
-                        ;;
-                    s)
-                        SORTED=true
-                        ;;
-                esac
-            done
+            use Getopt::Std;
+            use File::Copy;
 
-            BAMS=("${@:$OPTIND}")
-            NUM_BAMS=${#BAMS[@]}
+            my %opts;
+            getopts('t:n:s', \%opts);
+            my $nthreads = $opts{t} // die 'missing thread count';
+            my $outfilename = $opts{n} // die 'missing output filename';
+            my $sorted = $opts{s};
+
+            my @bams = @ARGV;
+            die 'missing input bams' unless scalar(@bams);
 
             #if there is only one bam, just copy it and index it
-            if [[ $NUM_BAMS -eq 1 ]]; then
-                cp "$BAMS" "$OUTFILENAME";
-            else
-                if [[ $SORTED == "true" ]];then
-                    /usr/bin/sambamba merge -t "$NTHREADS" "$OUTFILENAME" "${BAMS[@]}"
-                else #unsorted bams, use picard
-                    args=(OUTPUT="$OUTFILENAME" ASSUME_SORTED=true USE_THREADING=true SORT_ORDER=unsorted VALIDATION_STRINGENCY=LENIENT)
-                    for i in "${BAMS[@]}";do
-                      args+=("INPUT=$i")
-                    done
-                    java -jar -Xmx6g /opt/picard/picard.jar MergeSamFiles "${args[@]}"
-                fi
-            fi
-            if [[ $SORTED == "true" ]];then
-              /usr/bin/sambamba index "$OUTFILENAME"
-            fi
+            if (scalar(@bams) == 1) {
+                copy($bams[0], $outfilename) or die 'failed to copy file:' . $!;
+            } else {
+                if ($sorted) {
+                    my $rv = system((qw(/usr/bin/sambamba merge -t)), $nthreads, $outfilename, @bams);
+                    $rv == 0 or die 'failed to merge with sambamba';
+                } else { #unsorted bams, use picard
+                    my @args = (
+                        'OUTPUT=' . $outfilename,
+                        'ASSUME_SORTED=true',
+                        'USE_THREADING=true',
+                        'SORT_ORDER=unsorted',
+                        'VALIDATION_STRINGENCY=LENIENT',
+                        map { 'INPUT=' . $_ } @bams
+                    );
+                    my $rv = system((qw(java -jar -Xmx6g /opt/picard/picard.jar MergeSamFiles)), @args);
+                    $rv == 0 or die 'failed to merge with picard';
+                }
+            }
+            if ($sorted) {
+                my $rv = system((qw(/usr/bin/sambamba index)), $outfilename);
+                $rv == 0 or die 'failed to index';
+            }
 
 arguments: [
     "-t", "$(runtime.cores)",


### PR DESCRIPTION
The `${...}` syntax is problematic, since cromwell doesn't respect the escaping described in the CWL specification.  Thus if you properly escape for `cwltool` the script is wrong in cromwell and if you don't escape it then `cwltool` complains about JavaScript issues.  This replaces the bash script with a perl script (`perl` 5.22 is already installed in this docker image.) to avoid needing the `${...}` syntax altogether.

(Also, for some reason the boolean default value was quoted here even though it wasn't other places. `cwltool` complains about that, too, so this PR removes the quotes.)