### PR TITLE
changing bam variable to sam for clarity

### DIFF
--- a/definitions/tools/homer_tag_directory.cwl
+++ b/definitions/tools/homer_tag_directory.cwl
@@ -27,10 +27,10 @@ requirements:
                 set -o errexit
 
                 name="homer_tag_directory"
-                bam=$1
+                sam=$1
                 mkdir -p $name
                 echo "creating tagDir"
-                /opt/homer/bin/makeTagDirectory $name $bam
+                /opt/homer/bin/makeTagDirectory $name $sam
 
 inputs:
     sam:


### PR DESCRIPTION
Homer only accepts sam files as input, which is a little painful and disk intensive. Renaming variable to reflect that.