### PR TITLE
v4.1.8.1 weird behaviour, not seen in v4.2+

### DIFF
--- a/definitions/tools/mutect.cwl
+++ b/definitions/tools/mutect.cwl
@@ -11,7 +11,7 @@ requirements:
       ramMin: 32000
       tmpdirMin: 100000
     - class: DockerRequirement
-      dockerPull: "broadinstitute/gatk:4.1.8.1"
+      dockerPull: "broadinstitute/gatk:4.2.3.0"
     - class: InitialWorkDirRequirement
       listing:
       - entryname: 'Mutect2.sh'


### PR DESCRIPTION
For broadinstitute/gatk:4.1.8.1 mutect calls variants that do not appear in IGV or pileup. Behaviour not seen in broadinstitute/gatk:4.2+