### PR TITLE
handle unparseable GT entries by skipping those lines

### DIFF
--- a/definitions/tools/add_strelka_gt.cwl
+++ b/definitions/tools/add_strelka_gt.cwl
@@ -55,11 +55,9 @@ requirements:
                             $id++;
                         }
 
-                        # parse GT, handling unparseable case with stderr
-                        my $parsed_n_gt = parse_gt($n_gt_str, \%ids);
                         if ($n_gt_info eq "ref") {
                             $n_gt = "0/0";
-                        } elsif (defined($parsed_n_gt)) {
+                        } elsif (defined(my $parsed_n_gt = parse_gt($n_gt_str, \%ids))) {
                             $n_gt = $parsed_n_gt;
                         } else {
                             my $id_keys = join(" ", sort keys(%ids));
@@ -67,8 +65,7 @@ requirements:
                             next;
                         }
 
-                        my $parsed_t_gt = parse_gt($t_gt_str, \%ids);
-                        if (defined($parsed_t_gt)) {
+                        if (defined(my $parsed_t_gt = parse_gt($t_gt_str, \%ids))) {
                             $t_gt = $parsed_t_gt;
                         } else {
                             my $id_keys = join(" ", sort keys(%ids));

--- a/definitions/tools/add_strelka_gt.cwl
+++ b/definitions/tools/add_strelka_gt.cwl
@@ -106,8 +106,7 @@ requirements:
             sub parse_gt {
                 my ($gt_str, $ids) = @_;
                 my @gt_ids = map{$ids->{$_}}(split //, $gt_str);
-                my $i;
-                foreach $i (@gt_ids) {
+                foreach my $i (@gt_ids) {
                     unless (defined $i) {
                         return undef;
                     }

--- a/definitions/tools/add_strelka_gt.cwl
+++ b/definitions/tools/add_strelka_gt.cwl
@@ -55,6 +55,27 @@ requirements:
                             $id++;
                         }
 
+                        # parse GT, handling unparseable case with stderr
+                        my $parsed_n_gt = parse_gt($n_gt_str, \%ids);
+                        if ($n_gt_info eq "ref") {
+                            $n_gt = "0/0";
+                        } elsif (defined($parsed_n_gt)) {
+                            $n_gt = $parsed_n_gt;
+                        } else {
+                            my $id_keys = join(" ", sort keys(%ids));
+                            print STDERR "parse_gt for n_gt=\"$n_gt_str\" and ids=\"$id_keys\" resulted in undefined\n";
+                            next;
+                        }
+
+                        my $parsed_t_gt = parse_gt($t_gt_str, \%ids);
+                        if (defined($parsed_t_gt)) {
+                            $t_gt = $parsed_t_gt;
+                        } else {
+                            my $id_keys = join(" ", sort keys(%ids));
+                            print STDERR "parse_gt for t_gt=\"$t_gt_str\" and ids=\"$id_keys\" resulted in undefined\n";
+                            next;
+                        }
+
                         $n_gt = $n_gt_info eq 'ref' ? '0/0' : parse_gt($n_gt_str, \%ids);
                         $t_gt = parse_gt($t_gt_str, \%ids);
                     }
@@ -88,6 +109,12 @@ requirements:
             sub parse_gt {
                 my ($gt_str, $ids) = @_;
                 my @gt_ids = map{$ids->{$_}}(split //, $gt_str);
+                my $i;
+                foreach $i (@gt_ids) {
+                    if (!defined($i)) {
+                        return undef;
+                    }
+                }
                 return join '/', sort @gt_ids;
             }
 

--- a/definitions/tools/add_strelka_gt.cwl
+++ b/definitions/tools/add_strelka_gt.cwl
@@ -63,7 +63,7 @@ requirements:
                             $n_gt = $parsed_n_gt;
                         } else {
                             my $id_keys = join(" ", sort keys(%ids));
-                            print STDERR "parse_gt for n_gt=\"$n_gt_str\" and ids=\"$id_keys\" resulted in undefined\n";
+                            say STDERR "parse_gt for n_gt=\"$n_gt_str\" and ids=\"$id_keys\" resulted in undefined";
                             next;
                         }
 
@@ -72,12 +72,9 @@ requirements:
                             $t_gt = $parsed_t_gt;
                         } else {
                             my $id_keys = join(" ", sort keys(%ids));
-                            print STDERR "parse_gt for t_gt=\"$t_gt_str\" and ids=\"$id_keys\" resulted in undefined\n";
+                            say STDERR "parse_gt for t_gt=\"$t_gt_str\" and ids=\"$id_keys\" resulted in undefined";
                             next;
                         }
-
-                        $n_gt = $n_gt_info eq 'ref' ? '0/0' : parse_gt($n_gt_str, \%ids);
-                        $t_gt = parse_gt($t_gt_str, \%ids);
                     }
                     else {#INDEL
                         my ($n_gt_info, $t_gt_info) = $info =~ /;NT=(\S+?);.*SGT.*\->(\S+?);/;
@@ -111,7 +108,7 @@ requirements:
                 my @gt_ids = map{$ids->{$_}}(split //, $gt_str);
                 my $i;
                 foreach $i (@gt_ids) {
-                    if (!defined($i)) {
+                    unless (defined $i) {
                         return undef;
                     }
                 }


### PR DESCRIPTION
Sometimes we'll encounter entries which have a $gt_str which has
characters not contained in the $ids map. This results in malformed gt
entries, like `/0` or `1/` or `/`. When these entries occur,
downstream calls like merge_vcf (in the case of immuno workflow) will
print an error and _silently continue on their merry way_. I have no
idea why they do this, but it's something we noticed when testing
conversion over to WDL with HCC1395 sample.

We address this issue by checking the results of @gt_ids, and if any
are undefined we eject early, returning undefined. At the call site we
handle this case separate by printing to STDERR, dropping that line,
and moving on to the remainder.

An alternative approach of a more strict failure is an option, but
discussion with Chris Miller and Malachi Griffith landed on decision
that we just drop and move on.