### PR TITLE
Keep sample names in filenames

### DIFF
--- a/definitions/tools/sequence_to_fastq.cwl
+++ b/definitions/tools/sequence_to_fastq.cwl
@@ -49,36 +49,43 @@ requirements:
 
             if [[ "$MODE" == 'fastq' ]]; then #must be fastq input
 
+                unzip1=`basename "$FASTQ1" .gz`
+                unzip2=`basename "$FASTQ2" .gz`
+                nameroot1=`basename "$unzip1" .fastq`
+                nameroot2=`basename "$unzip2" .fastq`
+
                 if $UNZIP; then
                     if gzip -t $FASTQ1 2> /dev/null; then
-                        gunzip -c $FASTQ1 > $OUTDIR/read1.fastq
+                        gunzip -c $FASTQ1 > $OUTDIR/"$nameroot1".read1.fastq
                     else
-                        cp $FASTQ1 $OUTDIR/read1.fastq
+                        cp $FASTQ1 $OUTDIR/"$nameroot1".read1.fastq
                     fi
 
                     if gzip -t $FASTQ2 2> /dev/null; then
-                        gunzip -c $FASTQ2 > $OUTDIR/read2.fastq
+                        gunzip -c $FASTQ2 > $OUTDIR/"$nameroot2".read2.fastq
                     else
-                        cp $FASTQ2 $OUTDIR/read2.fastq
+                        cp $FASTQ2 $OUTDIR/"$nameroot2".read2.fastq
                     fi
                 else
                     if gzip -t $FASTQ1 2> /dev/null; then
-                        cp $FASTQ1 $OUTDIR/read1.fastq.gz
+                        cp $FASTQ1 $OUTDIR/"$nameroot1".read1.fastq.gz
                     else
-                        cp $FASTQ1 $OUTDIR/read1.fastq
+                        cp $FASTQ1 $OUTDIR/"$nameroot1".read1.fastq
                     fi
 
                     if gzip -t $FASTQ2 2> /dev/null; then
-                        cp $FASTQ2 $OUTDIR/read2.fastq.gz
+                        cp $FASTQ2 $OUTDIR/"$nameroot2".read2.fastq.gz
                     else
-                        cp $FASTQ2 $OUTDIR/read2.fastq
+                        cp $FASTQ2 $OUTDIR/"$nameroot2".read2.fastq
                     fi
                 fi
 
             else # then
                 ##run samtofastq here, dumping to the same filenames
                 ## input file is $BAM
-                /usr/bin/java -Xmx4g -jar /usr/picard/picard.jar SamToFastq I="$BAM" INCLUDE_NON_PF_READS=true F=$OUTDIR/read1.fastq F2=$OUTDIR/read2.fastq VALIDATION_STRINGENCY=SILENT
+
+                nameroot=`basename "$BAM" .bam`
+                /usr/bin/java -Xmx4g -jar /usr/picard/picard.jar SamToFastq I="$BAM" INCLUDE_NON_PF_READS=true F=$OUTDIR/"$nameroot".read1.fastq F2=$OUTDIR/"$nameroot".read2.fastq VALIDATION_STRINGENCY=SILENT
             fi
 arguments: [
     {valueFrom: $(runtime.outdir), position: -6, prefix: '-d'}
@@ -105,10 +112,10 @@ outputs:
     fastq1:
         type: File
         outputBinding:
-            glob: "read1.fastq*"
+            glob: "*read1.fastq*"
             outputEval: $(self[0])
     fastq2:
         type: File
         outputBinding:
-            glob: "read2.fastq*"
+            glob: "*read2.fastq*"
             outputEval: $(self[0])

--- a/definitions/tools/sequence_to_fastq.cwl
+++ b/definitions/tools/sequence_to_fastq.cwl
@@ -49,10 +49,14 @@ requirements:
 
             if [[ "$MODE" == 'fastq' ]]; then #must be fastq input
 
+                #basename is a no-op if suffix isn't found,
+                #so it's safe to use on optional file extensions
                 unzip1=`basename "$FASTQ1" .gz`
                 unzip2=`basename "$FASTQ2" .gz`
                 nameroot1=`basename "$unzip1" .fastq`
                 nameroot2=`basename "$unzip2" .fastq`
+                nameroot1=`basename "$nameroot1" .fq`
+                nameroot2=`basename "$nameroot2" .fq`
 
                 if $UNZIP; then
                     if gzip -t $FASTQ1 2> /dev/null; then

--- a/definitions/tools/trim_fastq.cwl
+++ b/definitions/tools/trim_fastq.cwl
@@ -5,7 +5,7 @@ class: CommandLineTool
 label: "Trim FASTQ (flexbar)"
 baseCommand: ['/opt/flexbar/flexbar']
 arguments: [
-    "--target", {valueFrom: "$(runtime.outdir)/trimmed_read"},
+    "--target", {valueFrom: "$(runtime.outdir)/$(inputs.reads1.nameroot).trimmed_read"},
     "--threads", {valueFrom: "$(runtime.cores)"}
 ]
 requirements:
@@ -55,12 +55,13 @@ outputs:
     fastq1:
         type: File
         outputBinding:
-            glob: "trimmed_read_1.fastq"
+            glob: "$(inputs.reads1.nameroot).trimmed_read_1.fastq"
     fastq2:
         type: File
         outputBinding:
-            glob: "trimmed_read_2.fastq"
+            glob: "$(inputs.reads1.nameroot).trimmed_read_2.fastq"
     fastqs:
         type: File[]
         outputBinding:
-            glob: "trimmed_read_*.fastq"
+            glob: "$(inputs.reads1.nameroot).trimmed_read_*.fastq"
+


### PR DESCRIPTION
A small change to produce unique filenames from the flexbar tool step, so that GMS output staging doesn't fail when running the immuno pipeline.