### PR TITLE
Immuno FDA metrics

### DIFF
--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -474,6 +474,48 @@ inputs:
     pvacfuse_keep_tmp_files:
         type: boolean?
 
+    #FDA metrics inputs
+    reference_genome_name:
+        type: string?
+    dna_sequencing_platform:
+        type: string?
+    dna_sequencing_instrument:
+        type: string?
+    dna_sequencing_kit:
+        type: string?
+    dna_sequencing_type:
+        type: string?
+    dna_single_or_paired_end:
+        type: string?
+    normal_dna_spike_in_error_rate:
+        type: string?
+    tumor_dna_spike_in_error_rate:
+        type: string?
+    normal_dna_total_DNA:
+        type: string?
+    tumor_dna_total_DNA:
+        type: string?
+    rna_sequencing_platform:
+        type: string?
+    rna_sequencing_instrument:
+        type: string?
+    rna_sequencing_kit:
+        type: string?
+    rna_sequencing_type:
+        type: string?
+    rna_single_or_paired_end:
+        type: string?
+    rna_spike_in_error_rate:
+        type: string?
+    rna_total_RNA:
+        type: string?
+    rna_RIN_score:
+        type: string?
+    rna_freq_normalization_method:
+        type: string?
+    rna_annotation_file:
+        type: string?
+
 outputs:
     final_bigwig:
         type: File
@@ -932,6 +974,9 @@ outputs:
     unaligned_normal_dna_md5sums:
         type: File
         outputSource: fda_metrics/unaligned_normal_dna_md5sums
+    unaligned_normal_dna_table1:
+        type: File
+        outputSource: fda_metrics/unaligned_normal_dna_table1
 
     unaligned_tumor_dna_fastqc_data:
         type: File[]
@@ -942,6 +987,9 @@ outputs:
     unaligned_tumor_dna_md5sums:
         type: File
         outputSource: fda_metrics/unaligned_tumor_dna_md5sums
+    unaligned_tumor_dna_table1:
+        type: File
+        outputSource: fda_metrics/unaligned_tumor_dna_table1
 
     unaligned_tumor_rna_fastqc_data:
         type: File[]
@@ -952,6 +1000,9 @@ outputs:
     unaligned_tumor_rna_md5sums:
         type: File
         outputSource: fda_metrics/unaligned_tumor_rna_md5sums
+    unaligned_tumor_rna_table1:
+        type: File
+        outputSource: fda_metrics/unaligned_tumor_rna_table1
 
     aligned_normal_dna_fastqc_data:
         type: File[]
@@ -962,6 +1013,9 @@ outputs:
     aligned_normal_dna_md5sums:
         type: File
         outputSource: fda_metrics/aligned_normal_dna_md5sums
+    aligned_normal_dna_table2:
+        type: File
+        outputSource: fda_metrics/aligned_normal_dna_table2
 
     aligned_tumor_dna_fastqc_data:
         type: File[]
@@ -972,6 +1026,9 @@ outputs:
     aligned_tumor_dna_md5sums:
         type: File
         outputSource: fda_metrics/aligned_tumor_dna_md5sums
+    aligned_tumor_dna_table2:
+        type: File
+        outputSource: fda_metrics/aligned_tumor_dna_table2
 
     aligned_tumor_rna_fastqc_data:
         type: File[]
@@ -982,6 +1039,9 @@ outputs:
     aligned_tumor_rna_md5sums:
         type: File
         outputSource: fda_metrics/aligned_tumor_rna_md5sums
+    aligned_tumor_rna_table3:
+        type: File
+        outputSource: fda_metrics/aligned_tumor_rna_table3
 
 steps:
     rnaseq:
@@ -1108,8 +1168,42 @@ steps:
             aligned_normal_dna: somatic/normal_cram
             aligned_tumor_dna: somatic/tumor_cram
             aligned_tumor_rna: rnaseq/final_bam
+            normal_alignment_summary_metrics: somatic/normal_alignment_summary_metrics
+            normal_duplication_metrics: somatic/normal_mark_duplicates_metrics
+            normal_insert_size_metrics: somatic/normal_insert_size_metrics
+            normal_hs_metrics: somatic/normal_hs_metrics
+            normal_flagstat: somatic/normal_flagstats
+            tumor_alignment_summary_metrics: somatic/tumor_alignment_summary_metrics
+            tumor_duplication_metrics: somatic/tumor_mark_duplicates_metrics
+            tumor_insert_size_metrics: somatic/tumor_insert_size_metrics
+            tumor_hs_metrics: somatic/tumor_hs_metrics
+            tumor_flagstat: somatic/tumor_flagstats
+            rna_metrics: rnaseq/metrics
+            reference_genome: reference_genome_name
+            dna_sequencing_platform: dna_sequencing_platform
+            dna_sequencing_instrument: dna_sequencing_instrument
+            dna_sequencing_kit: dna_sequencing_kit
+            dna_sequencing_type: dna_sequencing_type
+            dna_single_or_paired_end: dna_single_or_paired_end
+            normal_dna_spike_in_error_rate: normal_dna_spike_in_error_rate
+            tumor_dna_spike_in_error_rate: tumor_dna_spike_in_error_rate
+            normal_dna_total_DNA: normal_dna_total_DNA
+            tumor_dna_total_DNA: tumor_dna_total_DNA
+            normal_dna_sample_name: normal_sample_name
+            tumor_dna_sample_name: tumor_sample_name
+            rna_sequencing_platform: rna_sequencing_platform
+            rna_sequencing_instrument: rna_sequencing_instrument
+            rna_sequencing_kit: rna_sequencing_kit
+            rna_sequencing_type: rna_sequencing_type
+            rna_single_or_paired_end: rna_single_or_paired_end
+            rna_spike_in_error_rate: rna_spike_in_error_rate
+            rna_total_RNA: rna_total_RNA
+            rna_RIN_score: rna_RIN_score
+            rna_freq_normalization_method: rna_freq_normalization_method
+            rna_annotation_file: rna_annotation_file
+            rna_sample_name: rna_sample_name
         out:
-            [unaligned_normal_dna_fastqc_data,unaligned_normal_dna_table_metrics,unaligned_normal_dna_md5sums,unaligned_tumor_dna_fastqc_data,unaligned_tumor_dna_table_metrics,unaligned_tumor_dna_md5sums,unaligned_tumor_rna_fastqc_data,unaligned_tumor_rna_table_metrics,unaligned_tumor_rna_md5sums,aligned_normal_dna_fastqc_data,aligned_normal_dna_table_metrics,aligned_normal_dna_md5sums,aligned_tumor_dna_fastqc_data,aligned_tumor_dna_table_metrics,aligned_tumor_dna_md5sums,aligned_tumor_rna_fastqc_data,aligned_tumor_rna_table_metrics,aligned_tumor_rna_md5sums]
+            [unaligned_normal_dna_fastqc_data,unaligned_normal_dna_table_metrics,unaligned_normal_dna_md5sums,unaligned_normal_dna_table1,unaligned_tumor_dna_fastqc_data,unaligned_tumor_dna_table_metrics,unaligned_tumor_dna_md5sums,unaligned_tumor_dna_table1,unaligned_tumor_rna_fastqc_data,unaligned_tumor_rna_table_metrics,unaligned_tumor_rna_md5sums,unaligned_tumor_rna_table1,aligned_normal_dna_fastqc_data,aligned_normal_dna_table_metrics,aligned_normal_dna_md5sums,aligned_normal_dna_table2,aligned_tumor_dna_fastqc_data,aligned_tumor_dna_table_metrics,aligned_tumor_dna_md5sums,aligned_tumor_dna_table2,aligned_tumor_rna_fastqc_data,aligned_tumor_rna_table_metrics,aligned_tumor_rna_md5sums,aligned_tumor_rna_table3]
 
     phase_vcf:
         run: ../subworkflows/phase_vcf.cwl

--- a/definitions/subworkflows/generate_fda_metrics.cwl
+++ b/definitions/subworkflows/generate_fda_metrics.cwl
@@ -14,7 +14,9 @@ requirements:
 
 inputs:
     reference:
-        type: File
+        type:
+            - string
+            - File
     unaligned_normal_dna:
         type: ../types/sequence_data.yml#sequence_data[]
     unaligned_tumor_dna:

--- a/definitions/subworkflows/generate_fda_metrics.cwl
+++ b/definitions/subworkflows/generate_fda_metrics.cwl
@@ -1,0 +1,354 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+label: "Calculate FDA-requested metrics on all aligned and unaligned sequence files"
+requirements:
+    - class: MultipleInputFeatureRequirement
+    - class: SubworkflowFeatureRequirement
+    - class: InlineJavascriptRequirement
+    - class: StepInputExpressionRequirement
+    - class: SchemaDefRequirement
+      types:
+          - $import: ../types/sequence_data.yml
+
+inputs:
+    reference_fasta:
+        type: File
+    unaligned_normal_dna:
+        type: ../types/sequence_data.yml#sequence_data[]
+    unaligned_tumor_dna:
+        type: ../types/sequence_data.yml#sequence_data[]
+    unaligned_tumor_rna:
+        type: ../types/sequence_data.yml#sequence_data[]
+    aligned_normal_dna:
+        type: File
+    aligned_tumor_dna:
+        type: File
+    aligned_tumor_rna:
+        type: File
+
+outputs:
+    unaligned_normal_dna_fastqc_data:
+        type: File[]
+        outputSource: unaligned_normal_dna_fastqc/fastqc_all_data
+    unaligned_normal_dna_table_metrics:
+        type: File
+        outputSource: unaligned_normal_dna_metrics/unaligned_stats
+    unaligned_normal_dna_md5sums:
+        type: File
+        outputSource: unaligned_normal_dna_md5/md5sum
+
+    unaligned_tumor_dna_fastqc_data:
+        type: File[]
+        outputSource: unaligned_tumor_dna_fastqc/fastqc_all_data
+    unaligned_tumor_dna_table_metrics:
+        type: File
+        outputSource: unaligned_tumor_dna_metrics/unaligned_stats
+    unaligned_tumor_dna_md5sums:
+        type: File
+        outputSource: unaligned_tumor_dna_md5/md5sum
+
+    unaligned_tumor_rna_fastqc_data:
+        type: File[]
+        outputSource: unaligned_tumor_rna_fastqc/fastqc_all_data
+    unaligned_tumor_rna_table_metrics:
+        type: File
+        outputSource: unaligned_tumor_rna_metrics/unaligned_stats
+    unaligned_tumor_rna_md5sums:
+        type: File
+        outputSource: unaligned_tumor_rna_md5/md5sum
+
+    aligned_normal_dna_fastqc_data:
+        type: File[]
+        outputSource: aligned_normal_dna_fastqc/fastqc_all_data
+    aligned_normal_dna_table_metrics:
+        type: File
+        outputSource: aligned_normal_dna_metrics/aligned_stats
+    aligned_normal_dna_md5sums:
+        type: File
+        outputSource: aligned_normal_dna_md5/md5sum
+
+    aligned_tumor_dna_fastqc_data:
+        type: File[]
+        outputSource: aligned_tumor_dna_fastqc/fastqc_all_data
+    aligned_tumor_dna_table_metrics:
+        type: File
+        outputSource: aligned_tumor_dna_metrics/aligned_stats
+    aligned_tumor_dna_md5sums:
+        type: File
+        outputSource: aligned_tumor_dna_md5/md5sum
+
+    aligned_tumor_rna_fastqc_data:
+        type: File[]
+        outputSource: aligned_tumor_rna_fastqc/fastqc_all_data
+    aligned_tumor_rna_table_metrics:
+        type: File
+        outputSource: aligned_tumor_rna_metrics/aligned_stats
+    aligned_tumor_rna_md5sums:
+        type: File
+        outputSource: aligned_tumor_rna_md5/md5sum
+
+steps:
+    unaligned_normal_dna_fastqc:
+        run: ../tools/fastqc.cwl
+        in:
+            input_files:
+                source: unaligned_normal_dna
+                valueFrom: |
+                    ${
+                        var files = [];
+                        for (const seq of self) {
+                            if (seq.sequence.hasOwnProperty('bam')) files.push(seq.sequence.bam);
+                            if (seq.sequence.hasOwnProperty('fastq1')) files.push(seq.sequence.fastq1);
+                            if (seq.sequence.hasOwnProperty('fastq2')) files.push(seq.sequence.fastq2);
+                        }
+                        return files;
+                    }
+        out:
+            [fastqc_all_data]
+    unaligned_normal_dna_metrics:
+        run: ../tools/unaligned_seq_fda_stats.cwl
+        in:
+            input_files:
+                source: unaligned_normal_dna
+                valueFrom: |
+                    ${
+                        var files = [];
+                        for (const seq of self) {
+                            if (seq.sequence.hasOwnProperty('bam')) files.push(seq.sequence.bam);
+                            if (seq.sequence.hasOwnProperty('fastq1')) files.push(seq.sequence.fastq1);
+                            if (seq.sequence.hasOwnProperty('fastq2')) files.push(seq.sequence.fastq2);
+                        }
+                        return files;
+                    }
+            output_name:
+                default: "normal_dna"
+        out:
+            [unaligned_stats]
+    unaligned_normal_dna_md5:
+        run: ../tools/md5sum.cwl
+        in:
+            input_files:
+                source: unaligned_normal_dna
+                valueFrom: |
+                    ${
+                        var files = [];
+                        for (const seq of self) {
+                            if (seq.sequence.hasOwnProperty('bam')) files.push(seq.sequence.bam);
+                            if (seq.sequence.hasOwnProperty('fastq1')) files.push(seq.sequence.fastq1);
+                            if (seq.sequence.hasOwnProperty('fastq2')) files.push(seq.sequence.fastq2);
+                        }
+                        return files;
+                    }
+            output_name:
+                default: "normal_dna_unaligned"
+        out:
+            [md5sum]
+
+
+    unaligned_tumor_dna_fastqc:
+        run: ../tools/fastqc.cwl
+        in:
+            input_files:
+                source: unaligned_tumor_dna
+                valueFrom: |
+                    ${
+                        var files = [];
+                        for (const seq of self) {
+                            if (seq.sequence.hasOwnProperty('bam')) files.push(seq.sequence.bam);
+                            if (seq.sequence.hasOwnProperty('fastq1')) files.push(seq.sequence.fastq1);
+                            if (seq.sequence.hasOwnProperty('fastq2')) files.push(seq.sequence.fastq2);
+                        }
+                        return files;
+                    }
+        out:
+            [fastqc_all_data]
+    unaligned_tumor_dna_metrics:
+        run: ../tools/unaligned_seq_fda_stats.cwl
+        in:
+            input_files:
+                source: unaligned_tumor_dna
+                valueFrom: |
+                    ${
+                        var files = [];
+                        for (const seq of self) {
+                            if (seq.sequence.hasOwnProperty('bam')) files.push(seq.sequence.bam);
+                            if (seq.sequence.hasOwnProperty('fastq1')) files.push(seq.sequence.fastq1);
+                            if (seq.sequence.hasOwnProperty('fastq2')) files.push(seq.sequence.fastq2);
+                        }
+                        return files;
+                    }
+            output_name:
+                default: "tumor_dna"
+        out:
+            [unaligned_stats]
+    unaligned_tumor_dna_md5:
+        run: ../tools/md5sum.cwl
+        in:
+            input_files:
+                source: unaligned_tumor_dna
+                valueFrom: |
+                    ${
+                        var files = [];
+                        for (const seq of self) {
+                            if (seq.sequence.hasOwnProperty('bam')) files.push(seq.sequence.bam);
+                            if (seq.sequence.hasOwnProperty('fastq1')) files.push(seq.sequence.fastq1);
+                            if (seq.sequence.hasOwnProperty('fastq2')) files.push(seq.sequence.fastq2);
+                        }
+                        return files;
+                    }
+            output_name:
+                default: "tumor_dna_unaligned"
+        out:
+            [md5sum]
+
+
+    unaligned_tumor_rna_fastqc:
+        run: ../tools/fastqc.cwl
+        in: 
+            input_files:
+                source: unaligned_tumor_rna
+                valueFrom: |
+                    ${  
+                        var files = []; 
+                        for (const seq of self) {
+                            if (seq.sequence.hasOwnProperty('bam')) files.push(seq.sequence.bam);
+                            if (seq.sequence.hasOwnProperty('fastq1')) files.push(seq.sequence.fastq1);
+                            if (seq.sequence.hasOwnProperty('fastq2')) files.push(seq.sequence.fastq2);
+                        }   
+                        return files;
+                    }   
+        out:
+            [fastqc_all_data]
+    unaligned_tumor_rna_metrics:
+        run: ../tools/unaligned_seq_fda_stats.cwl
+        in: 
+            input_files:
+                source: unaligned_tumor_rna
+                valueFrom: |
+                    ${  
+                        var files = []; 
+                        for (const seq of self) {
+                            if (seq.sequence.hasOwnProperty('bam')) files.push(seq.sequence.bam);
+                            if (seq.sequence.hasOwnProperty('fastq1')) files.push(seq.sequence.fastq1);
+                            if (seq.sequence.hasOwnProperty('fastq2')) files.push(seq.sequence.fastq2);
+                        }   
+                        return files;
+                    }   
+            output_name:
+                default: "tumor_rna"
+        out:
+            [unaligned_stats]
+    unaligned_tumor_rna_md5:
+        run: ../tools/md5sum.cwl
+        in: 
+            input_files:
+                source: unaligned_tumor_rna
+                valueFrom: |
+                    ${  
+                        var files = []; 
+                        for (const seq of self) {
+                            if (seq.sequence.hasOwnProperty('bam')) files.push(seq.sequence.bam);
+                            if (seq.sequence.hasOwnProperty('fastq1')) files.push(seq.sequence.fastq1);
+                            if (seq.sequence.hasOwnProperty('fastq2')) files.push(seq.sequence.fastq2);
+                        }   
+                        return files;
+                    }   
+            output_name:
+                default: "tumor_rna_unaligned"
+        out:
+            [md5sum]
+
+
+    aligned_normal_dna_fastqc:
+        run: ../tools/fastqc.cwl
+        in:
+            input_files:
+                source: aligned_normal_dna
+                valueFrom: ${ return [self]; }
+        out:
+            [fastqc_all_data]
+    aligned_normal_dna_metrics:
+        run: ../tools/aligned_seq_fda_stats.cwl
+        in:
+            reference: reference
+            input_files:
+                source: aligned_normal_dna
+                valueFrom: ${ return [self]; }
+           output_name:
+                default: "normal_dna"
+        out:
+            [aligned_stats]
+    aligned_normal_dna_md5:
+        run: ../tools/md5sum.cwl
+        in:
+            input_files:
+                source: aligned_normal_dna
+                valueFrom: ${ return [self]; }
+           output_name:
+                default: "normal_dna_aligned"
+        out:
+            [md5sum]
+
+
+    aligned_tumor_dna_fastqc:
+        run: ../tools/fastqc.cwl
+        in:
+            input_files:
+                source: aligned_tumor_dna
+                valueFrom: ${ return [self]; }
+        out:
+            [fastqc_all_data]
+    aligned_tumor_dna_metrics:
+        run: ../tools/aligned_seq_fda_stats.cwl
+        in:
+            reference: reference
+            input_files:
+                source: aligned_tumor_dna
+                valueFrom: ${ return [self]; }
+           output_name:
+                default: "tumor_dna"
+        out:
+            [aligned_stats]
+    aligned_tumor_dna_md5:
+        run: ../tools/md5sum.cwl
+        in:
+            input_files:
+                source: aligned_tumor_dna
+                valueFrom: ${ return [self]; }
+           output_name:
+                default: "tumor_dna_aligned"
+        out:
+            [md5sum]
+
+
+    aligned_tumor_rna_fastqc:
+        run: ../tools/fastqc.cwl
+        in:
+            input_files:
+                source: aligned_tumor_rna
+                valueFrom: ${ return [self]; }
+        out:
+            [fastqc_all_data]
+    aligned_tumor_rna_metrics:
+        run: ../tools/aligned_seq_fda_stats.cwl
+        in:
+            reference: reference
+            input_files:
+                source: aligned_tumor_rna
+                valueFrom: ${ return [self]; }
+           output_name:
+                default: "tumor_rna"
+        out:
+            [aligned_stats]
+    aligned_tumor_rna_md5:
+        run: ../tools/md5sum.cwl
+        in:
+            input_files:
+                source: aligned_tumor_rna
+                valueFrom: ${ return [self]; }
+           output_name:
+                default: "tumor_rna_aligned"
+        out:
+            [md5sum]

--- a/definitions/subworkflows/generate_fda_metrics.cwl
+++ b/definitions/subworkflows/generate_fda_metrics.cwl
@@ -13,7 +13,7 @@ requirements:
           - $import: ../types/sequence_data.yml
 
 inputs:
-    reference_fasta:
+    reference:
         type: File
     unaligned_normal_dna:
         type: ../types/sequence_data.yml#sequence_data[]
@@ -276,7 +276,7 @@ steps:
             input_files:
                 source: aligned_normal_dna
                 valueFrom: ${ return [self]; }
-           output_name:
+            output_name:
                 default: "normal_dna"
         out:
             [aligned_stats]
@@ -286,7 +286,7 @@ steps:
             input_files:
                 source: aligned_normal_dna
                 valueFrom: ${ return [self]; }
-           output_name:
+            output_name:
                 default: "normal_dna_aligned"
         out:
             [md5sum]
@@ -307,7 +307,7 @@ steps:
             input_files:
                 source: aligned_tumor_dna
                 valueFrom: ${ return [self]; }
-           output_name:
+            output_name:
                 default: "tumor_dna"
         out:
             [aligned_stats]
@@ -317,7 +317,7 @@ steps:
             input_files:
                 source: aligned_tumor_dna
                 valueFrom: ${ return [self]; }
-           output_name:
+            output_name:
                 default: "tumor_dna_aligned"
         out:
             [md5sum]
@@ -338,7 +338,7 @@ steps:
             input_files:
                 source: aligned_tumor_rna
                 valueFrom: ${ return [self]; }
-           output_name:
+            output_name:
                 default: "tumor_rna"
         out:
             [aligned_stats]
@@ -348,7 +348,7 @@ steps:
             input_files:
                 source: aligned_tumor_rna
                 valueFrom: ${ return [self]; }
-           output_name:
+            output_name:
                 default: "tumor_rna_aligned"
         out:
             [md5sum]

--- a/definitions/subworkflows/generate_fda_metrics.cwl
+++ b/definitions/subworkflows/generate_fda_metrics.cwl
@@ -98,10 +98,11 @@ steps:
                 valueFrom: |
                     ${
                         var files = [];
-                        for (const seq of self) {
-                            if (seq.sequence.hasOwnProperty('bam')) files.push(seq.sequence.bam);
-                            if (seq.sequence.hasOwnProperty('fastq1')) files.push(seq.sequence.fastq1);
-                            if (seq.sequence.hasOwnProperty('fastq2')) files.push(seq.sequence.fastq2);
+                        var i;
+                        for (i = 0; i < self.length; i = i + 1) {
+                            if (self[i].sequence.hasOwnProperty('bam')) { files.push(self[i].sequence.bam); }
+                            if (self[i].sequence.hasOwnProperty('fastq1')) { files.push(self[i].sequence.fastq1); }
+                            if (self[i].sequence.hasOwnProperty('fastq2')) { files.push(self[i].sequence.fastq2); }
                         }
                         return files;
                     }
@@ -115,10 +116,11 @@ steps:
                 valueFrom: |
                     ${
                         var files = [];
-                        for (const seq of self) {
-                            if (seq.sequence.hasOwnProperty('bam')) files.push(seq.sequence.bam);
-                            if (seq.sequence.hasOwnProperty('fastq1')) files.push(seq.sequence.fastq1);
-                            if (seq.sequence.hasOwnProperty('fastq2')) files.push(seq.sequence.fastq2);
+                        var i;
+                        for (i = 0; i < self.length; i = i + 1) {
+                            if (self[i].sequence.hasOwnProperty('bam')) { files.push(self[i].sequence.bam); }
+                            if (self[i].sequence.hasOwnProperty('fastq1')) { files.push(self[i].sequence.fastq1); }
+                            if (self[i].sequence.hasOwnProperty('fastq2')) { files.push(self[i].sequence.fastq2); }
                         }
                         return files;
                     }
@@ -134,10 +136,11 @@ steps:
                 valueFrom: |
                     ${
                         var files = [];
-                        for (const seq of self) {
-                            if (seq.sequence.hasOwnProperty('bam')) files.push(seq.sequence.bam);
-                            if (seq.sequence.hasOwnProperty('fastq1')) files.push(seq.sequence.fastq1);
-                            if (seq.sequence.hasOwnProperty('fastq2')) files.push(seq.sequence.fastq2);
+                        var i;
+                        for (i = 0; i < self.length; i = i + 1) {
+                            if (self[i].sequence.hasOwnProperty('bam')) { files.push(self[i].sequence.bam); }
+                            if (self[i].sequence.hasOwnProperty('fastq1')) { files.push(self[i].sequence.fastq1); }
+                            if (self[i].sequence.hasOwnProperty('fastq2')) { files.push(self[i].sequence.fastq2); }
                         }
                         return files;
                     }
@@ -155,10 +158,11 @@ steps:
                 valueFrom: |
                     ${
                         var files = [];
-                        for (const seq of self) {
-                            if (seq.sequence.hasOwnProperty('bam')) files.push(seq.sequence.bam);
-                            if (seq.sequence.hasOwnProperty('fastq1')) files.push(seq.sequence.fastq1);
-                            if (seq.sequence.hasOwnProperty('fastq2')) files.push(seq.sequence.fastq2);
+                        var i;
+                        for (i = 0; i < self.length; i = i + 1) {
+                            if (self[i].sequence.hasOwnProperty('bam')) { files.push(self[i].sequence.bam); }
+                            if (self[i].sequence.hasOwnProperty('fastq1')) { files.push(self[i].sequence.fastq1); }
+                            if (self[i].sequence.hasOwnProperty('fastq2')) { files.push(self[i].sequence.fastq2); }
                         }
                         return files;
                     }
@@ -172,10 +176,11 @@ steps:
                 valueFrom: |
                     ${
                         var files = [];
-                        for (const seq of self) {
-                            if (seq.sequence.hasOwnProperty('bam')) files.push(seq.sequence.bam);
-                            if (seq.sequence.hasOwnProperty('fastq1')) files.push(seq.sequence.fastq1);
-                            if (seq.sequence.hasOwnProperty('fastq2')) files.push(seq.sequence.fastq2);
+                        var i;
+                        for (i = 0; i < self.length; i = i + 1) {
+                            if (self[i].sequence.hasOwnProperty('bam')) { files.push(self[i].sequence.bam); }
+                            if (self[i].sequence.hasOwnProperty('fastq1')) { files.push(self[i].sequence.fastq1); }
+                            if (self[i].sequence.hasOwnProperty('fastq2')) { files.push(self[i].sequence.fastq2); }
                         }
                         return files;
                     }
@@ -191,10 +196,11 @@ steps:
                 valueFrom: |
                     ${
                         var files = [];
-                        for (const seq of self) {
-                            if (seq.sequence.hasOwnProperty('bam')) files.push(seq.sequence.bam);
-                            if (seq.sequence.hasOwnProperty('fastq1')) files.push(seq.sequence.fastq1);
-                            if (seq.sequence.hasOwnProperty('fastq2')) files.push(seq.sequence.fastq2);
+                        var i;
+                        for (i = 0; i < self.length; i = i + 1) {
+                            if (self[i].sequence.hasOwnProperty('bam')) { files.push(self[i].sequence.bam); }
+                            if (self[i].sequence.hasOwnProperty('fastq1')) { files.push(self[i].sequence.fastq1); }
+                            if (self[i].sequence.hasOwnProperty('fastq2')) { files.push(self[i].sequence.fastq2); }
                         }
                         return files;
                     }
@@ -210,15 +216,16 @@ steps:
             input_files:
                 source: unaligned_tumor_rna
                 valueFrom: |
-                    ${  
-                        var files = []; 
-                        for (const seq of self) {
-                            if (seq.sequence.hasOwnProperty('bam')) files.push(seq.sequence.bam);
-                            if (seq.sequence.hasOwnProperty('fastq1')) files.push(seq.sequence.fastq1);
-                            if (seq.sequence.hasOwnProperty('fastq2')) files.push(seq.sequence.fastq2);
-                        }   
+                    ${
+                        var files = [];
+                        var i;
+                        for (i = 0; i < self.length; i = i + 1) {
+                            if (self[i].sequence.hasOwnProperty('bam')) { files.push(self[i].sequence.bam); }
+                            if (self[i].sequence.hasOwnProperty('fastq1')) { files.push(self[i].sequence.fastq1); }
+                            if (self[i].sequence.hasOwnProperty('fastq2')) { files.push(self[i].sequence.fastq2); }
+                        }
                         return files;
-                    }   
+                    }
         out:
             [fastqc_all_data]
     unaligned_tumor_rna_metrics:
@@ -227,15 +234,16 @@ steps:
             input_files:
                 source: unaligned_tumor_rna
                 valueFrom: |
-                    ${  
-                        var files = []; 
-                        for (const seq of self) {
-                            if (seq.sequence.hasOwnProperty('bam')) files.push(seq.sequence.bam);
-                            if (seq.sequence.hasOwnProperty('fastq1')) files.push(seq.sequence.fastq1);
-                            if (seq.sequence.hasOwnProperty('fastq2')) files.push(seq.sequence.fastq2);
-                        }   
+                    ${
+                        var files = [];
+                        var i;
+                        for (i = 0; i < self.length; i = i + 1) {
+                            if (self[i].sequence.hasOwnProperty('bam')) { files.push(self[i].sequence.bam); }
+                            if (self[i].sequence.hasOwnProperty('fastq1')) { files.push(self[i].sequence.fastq1); }
+                            if (self[i].sequence.hasOwnProperty('fastq2')) { files.push(self[i].sequence.fastq2); }
+                        }
                         return files;
-                    }   
+                    }
             output_name:
                 default: "tumor_rna"
         out:
@@ -246,15 +254,16 @@ steps:
             input_files:
                 source: unaligned_tumor_rna
                 valueFrom: |
-                    ${  
-                        var files = []; 
-                        for (const seq of self) {
-                            if (seq.sequence.hasOwnProperty('bam')) files.push(seq.sequence.bam);
-                            if (seq.sequence.hasOwnProperty('fastq1')) files.push(seq.sequence.fastq1);
-                            if (seq.sequence.hasOwnProperty('fastq2')) files.push(seq.sequence.fastq2);
-                        }   
+                    ${
+                        var files = [];
+                        var i;
+                        for (i = 0; i < self.length; i = i + 1) {
+                            if (self[i].sequence.hasOwnProperty('bam')) { files.push(self[i].sequence.bam); }
+                            if (self[i].sequence.hasOwnProperty('fastq1')) { files.push(self[i].sequence.fastq1); }
+                            if (self[i].sequence.hasOwnProperty('fastq2')) { files.push(self[i].sequence.fastq2); }
+                        }
                         return files;
-                    }   
+                    }
             output_name:
                 default: "tumor_rna_unaligned"
         out:

--- a/definitions/subworkflows/generate_fda_metrics.cwl
+++ b/definitions/subworkflows/generate_fda_metrics.cwl
@@ -30,6 +30,77 @@ inputs:
     aligned_tumor_rna:
         type: File
 
+    normal_alignment_summary_metrics:
+        type: File
+    normal_duplication_metrics:
+        type: File
+    normal_insert_size_metrics:
+        type: File
+    normal_hs_metrics:
+        type: File
+    normal_flagstat:
+        type: File
+    tumor_alignment_summary_metrics:
+        type: File
+    tumor_duplication_metrics:
+        type: File
+    tumor_insert_size_metrics:
+        type: File
+    tumor_hs_metrics:
+        type: File
+    tumor_flagstat:
+        type: File
+    rna_metrics:
+        type: File
+
+    reference_genome:
+        type: string?
+    dna_sequencing_platform:
+        type: string?
+    dna_sequencing_instrument:
+        type: string?
+    dna_sequencing_kit:
+        type: string?
+    dna_sequencing_type:
+        type: string?
+    dna_single_or_paired_end:
+        type: string?
+    normal_dna_spike_in_error_rate:
+        type: string?
+    tumor_dna_spike_in_error_rate:
+        type: string?
+    normal_dna_total_DNA:
+        type: string?
+    tumor_dna_total_DNA:
+        type: string?
+    normal_dna_sample_name:
+        type: string?
+    tumor_dna_sample_name:
+        type: string?
+    rna_sequencing_platform:
+        type: string?
+    rna_sequencing_instrument:
+        type: string?
+    rna_sequencing_kit:
+        type: string?
+    rna_sequencing_type:
+        type: string?
+    rna_single_or_paired_end:
+        type: string?
+    rna_spike_in_error_rate:
+        type: string?
+    rna_total_RNA:
+        type: string?
+    rna_RIN_score:
+        type: string?
+    rna_freq_normalization_method:
+        type: string?
+    rna_annotation_file:
+        type: string?
+    rna_sample_name:
+        type: string?
+
+
 outputs:
     unaligned_normal_dna_fastqc_data:
         type: File[]
@@ -40,6 +111,9 @@ outputs:
     unaligned_normal_dna_md5sums:
         type: File
         outputSource: unaligned_normal_dna_md5/md5sum
+    unaligned_normal_dna_table1:
+        type: File
+        outputSource: unaligned_normal_dna_table/table
 
     unaligned_tumor_dna_fastqc_data:
         type: File[]
@@ -50,6 +124,9 @@ outputs:
     unaligned_tumor_dna_md5sums:
         type: File
         outputSource: unaligned_tumor_dna_md5/md5sum
+    unaligned_tumor_dna_table1:
+        type: File
+        outputSource: unaligned_tumor_dna_table/table
 
     unaligned_tumor_rna_fastqc_data:
         type: File[]
@@ -60,6 +137,9 @@ outputs:
     unaligned_tumor_rna_md5sums:
         type: File
         outputSource: unaligned_tumor_rna_md5/md5sum
+    unaligned_tumor_rna_table1:
+        type: File
+        outputSource: unaligned_tumor_rna_table/table
 
     aligned_normal_dna_fastqc_data:
         type: File[]
@@ -70,6 +150,9 @@ outputs:
     aligned_normal_dna_md5sums:
         type: File
         outputSource: aligned_normal_dna_md5/md5sum
+    aligned_normal_dna_table2:
+        type: File
+        outputSource: aligned_normal_dna_table/table
 
     aligned_tumor_dna_fastqc_data:
         type: File[]
@@ -80,6 +163,9 @@ outputs:
     aligned_tumor_dna_md5sums:
         type: File
         outputSource: aligned_tumor_dna_md5/md5sum
+    aligned_tumor_dna_table2:
+        type: File
+        outputSource: aligned_tumor_dna_table/table
 
     aligned_tumor_rna_fastqc_data:
         type: File[]
@@ -90,6 +176,9 @@ outputs:
     aligned_tumor_rna_md5sums:
         type: File
         outputSource: aligned_tumor_rna_md5/md5sum
+    aligned_tumor_rna_table3:
+        type: File
+        outputSource: aligned_tumor_rna_table/table
 
 steps:
     unaligned_normal_dna_fastqc:
@@ -150,6 +239,25 @@ steps:
                 default: "normal_dna_unaligned"
         out:
             [md5sum]
+    unaligned_normal_dna_table:
+        run: ../tools/generate_fda_tables.cwl
+        in:
+            table_file_name:
+                default: "unaligned_normal_dna_table1.csv"
+            table_num:
+                default: "table1"
+            md5sum_file: unaligned_normal_dna_md5/md5sum
+            fastqc_zips: unaligned_normal_dna_fastqc/fastqc_all_data
+            unaligned_metrics: unaligned_normal_dna_metrics/unaligned_stats
+            sample_name: normal_dna_sample_name
+            sequencing_platform: dna_sequencing_platform
+            sequencing_instrument: dna_sequencing_instrument
+            sequencing_kit: dna_sequencing_kit
+            single_or_paired_end: dna_single_or_paired_end
+            sequencing_type: dna_sequencing_type
+            spike_in_error_rate: normal_dna_spike_in_error_rate
+        out:
+            [table]
 
 
     unaligned_tumor_dna_fastqc:
@@ -210,6 +318,25 @@ steps:
                 default: "tumor_dna_unaligned"
         out:
             [md5sum]
+    unaligned_tumor_dna_table:
+        run: ../tools/generate_fda_tables.cwl
+        in:
+            table_file_name:
+                default: "unaligned_tumor_dna_table1.csv"
+            table_num:
+                default: "table1"
+            md5sum_file: unaligned_tumor_dna_md5/md5sum
+            fastqc_zips: unaligned_tumor_dna_fastqc/fastqc_all_data
+            unaligned_metrics: unaligned_tumor_dna_metrics/unaligned_stats
+            sample_name: tumor_dna_sample_name
+            sequencing_platform: dna_sequencing_platform
+            sequencing_instrument: dna_sequencing_instrument
+            sequencing_kit: dna_sequencing_kit
+            single_or_paired_end: dna_single_or_paired_end
+            sequencing_type: dna_sequencing_type
+            spike_in_error_rate: tumor_dna_spike_in_error_rate
+        out:
+            [table]
 
 
     unaligned_tumor_rna_fastqc:
@@ -270,6 +397,25 @@ steps:
                 default: "tumor_rna_unaligned"
         out:
             [md5sum]
+    unaligned_tumor_rna_table:
+        run: ../tools/generate_fda_tables.cwl
+        in:
+            table_file_name:
+                default: "unaligned_tumor_rna_table1.csv"
+            table_num:
+                default: "table1"
+            md5sum_file: unaligned_tumor_rna_md5/md5sum
+            fastqc_zips: unaligned_tumor_rna_fastqc/fastqc_all_data
+            unaligned_metrics: unaligned_tumor_rna_metrics/unaligned_stats
+            sample_name: rna_sample_name
+            sequencing_platform: rna_sequencing_platform
+            sequencing_instrument: rna_sequencing_instrument
+            sequencing_kit: rna_sequencing_kit
+            single_or_paired_end: rna_single_or_paired_end
+            sequencing_type: rna_sequencing_type
+            spike_in_error_rate: rna_spike_in_error_rate
+        out:
+            [table]
 
     aligned_normal_dna_cram_index:
         run: ../tools/index_cram.cwl
@@ -313,6 +459,32 @@ steps:
                 default: "normal_dna_aligned"
         out:
             [md5sum]
+    aligned_normal_dna_table:
+        run: ../tools/generate_fda_tables.cwl
+        in:
+            table_file_name:
+                default: "aligned_normal_dna_table2.csv"
+            table_num:
+                default: "table2"
+            md5sum_file: aligned_normal_dna_md5/md5sum
+            fastqc_zips: aligned_normal_dna_fastqc/fastqc_all_data
+            aligned_metrics: aligned_normal_dna_metrics/aligned_stats
+            alignment_summary_metrics: normal_alignment_summary_metrics
+            duplication_metrics: normal_duplication_metrics
+            insert_size_metrics: normal_insert_size_metrics
+            hs_metrics: normal_hs_metrics
+            flagstat: normal_flagstat
+            sample_name: normal_dna_sample_name
+            sequencing_platform: dna_sequencing_platform
+            sequencing_instrument: dna_sequencing_instrument
+            sequencing_kit: dna_sequencing_kit
+            single_or_paired_end: dna_single_or_paired_end
+            source:
+                default: "Normal sample"
+            total_DNA: normal_dna_total_DNA
+            reference_genome: reference_genome
+        out:
+            [table]
 
 
     aligned_tumor_dna_cram_index:
@@ -357,6 +529,32 @@ steps:
                 default: "tumor_dna_aligned"
         out:
             [md5sum]
+    aligned_tumor_dna_table:
+        run: ../tools/generate_fda_tables.cwl
+        in:
+            table_file_name:
+                default: "aligned_tumor_dna_table2.csv"
+            table_num:
+                default: "table2"
+            md5sum_file: aligned_tumor_dna_md5/md5sum
+            fastqc_zips: aligned_tumor_dna_fastqc/fastqc_all_data
+            aligned_metrics: aligned_tumor_dna_metrics/aligned_stats
+            alignment_summary_metrics: tumor_alignment_summary_metrics
+            duplication_metrics: tumor_duplication_metrics
+            insert_size_metrics: tumor_insert_size_metrics
+            hs_metrics: tumor_hs_metrics
+            flagstat: tumor_flagstat
+            sample_name: tumor_dna_sample_name
+            sequencing_platform: dna_sequencing_platform
+            sequencing_instrument: dna_sequencing_instrument
+            sequencing_kit: dna_sequencing_kit
+            single_or_paired_end: dna_single_or_paired_end
+            source:
+                default: "Tumor sample"
+            total_DNA: tumor_dna_total_DNA
+            reference_genome: reference_genome
+        out:
+            [table]
 
 
     aligned_tumor_rna_fastqc:
@@ -388,3 +586,28 @@ steps:
                 default: "tumor_rna_aligned"
         out:
             [md5sum]
+    aligned_tumor_rna_table:
+        run: ../tools/generate_fda_tables.cwl
+        in:
+            table_file_name:
+                default: "aligned_tumor_rna_table3.csv"
+            table_num:
+                default: "table3"
+            md5sum_file: aligned_tumor_rna_md5/md5sum
+            fastqc_zips: aligned_tumor_rna_fastqc/fastqc_all_data
+            aligned_metrics: aligned_tumor_rna_metrics/aligned_stats
+            rna_metrics: rna_metrics
+            sample_name: rna_sample_name
+            sequencing_platform: rna_sequencing_platform
+            sequencing_instrument: rna_sequencing_instrument
+            sequencing_kit: rna_sequencing_kit
+            single_or_paired_end: rna_single_or_paired_end
+            source:
+                default: "Tumor sample"
+            total_RNA: rna_total_RNA
+            RIN_score: rna_RIN_score
+            freq_normalization_method: rna_freq_normalization_method
+            annotation_file: rna_annotation_file
+            reference_genome: reference_genome
+        out:
+            [table]

--- a/definitions/subworkflows/generate_fda_metrics.cwl
+++ b/definitions/subworkflows/generate_fda_metrics.cwl
@@ -271,12 +271,24 @@ steps:
         out:
             [md5sum]
 
-
+    aligned_normal_dna_cram_index:
+        run: ../tools/index_cram.cwl
+        in:
+            cram: aligned_normal_dna
+        out:
+            [indexed_cram]
+    aligned_normal_dna_cram_to_bam:
+        run: ../tools/cram_to_bam.cwl
+        in:
+            reference: reference
+            cram: aligned_normal_dna_cram_index/indexed_cram
+        out:
+            [bam]
     aligned_normal_dna_fastqc:
         run: ../tools/fastqc.cwl
         in:
             input_files:
-                source: aligned_normal_dna
+                source: aligned_normal_dna_cram_to_bam/bam
                 valueFrom: ${ return [self]; }
         out:
             [fastqc_all_data]
@@ -285,7 +297,7 @@ steps:
         in:
             reference: reference
             input_files:
-                source: aligned_normal_dna
+                source: aligned_normal_dna_cram_to_bam/bam
                 valueFrom: ${ return [self]; }
             output_name:
                 default: "normal_dna"
@@ -295,7 +307,7 @@ steps:
         run: ../tools/md5sum.cwl
         in:
             input_files:
-                source: aligned_normal_dna
+                source: aligned_normal_dna_cram_to_bam/bam
                 valueFrom: ${ return [self]; }
             output_name:
                 default: "normal_dna_aligned"
@@ -303,11 +315,24 @@ steps:
             [md5sum]
 
 
+    aligned_tumor_dna_cram_index:
+        run: ../tools/index_cram.cwl
+        in:
+            cram: aligned_tumor_dna
+        out:
+            [indexed_cram]
+    aligned_tumor_dna_cram_to_bam:
+        run: ../tools/cram_to_bam.cwl
+        in:
+            reference: reference
+            cram: aligned_tumor_dna_cram_index/indexed_cram
+        out:
+            [bam]
     aligned_tumor_dna_fastqc:
         run: ../tools/fastqc.cwl
         in:
             input_files:
-                source: aligned_tumor_dna
+                source: aligned_tumor_dna_cram_to_bam/bam
                 valueFrom: ${ return [self]; }
         out:
             [fastqc_all_data]
@@ -316,7 +341,7 @@ steps:
         in:
             reference: reference
             input_files:
-                source: aligned_tumor_dna
+                source: aligned_tumor_dna_cram_to_bam/bam
                 valueFrom: ${ return [self]; }
             output_name:
                 default: "tumor_dna"
@@ -326,7 +351,7 @@ steps:
         run: ../tools/md5sum.cwl
         in:
             input_files:
-                source: aligned_tumor_dna
+                source: aligned_tumor_dna_cram_to_bam/bam
                 valueFrom: ${ return [self]; }
             output_name:
                 default: "tumor_dna_aligned"

--- a/definitions/tools/aligned_seq_fda_stats.cwl
+++ b/definitions/tools/aligned_seq_fda_stats.cwl
@@ -98,7 +98,7 @@ requirements:
                 Main();
 
                 # this program is terminated here
-                exit 1;
+                exit 0;
 
 
 
@@ -377,7 +377,9 @@ requirements:
 
 inputs:
     reference:
-        type: File
+        type:
+            - string
+            - File
         inputBinding:
             position: 1
     input_files:

--- a/definitions/tools/aligned_seq_fda_stats.cwl
+++ b/definitions/tools/aligned_seq_fda_stats.cwl
@@ -1,0 +1,390 @@
+#! /usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: ['/usr/bin/perl', 'aligned_stats.pl']
+requirements:
+    - class: DockerRequirement
+      dockerPull: "registry.gsc.wustl.edu/apipe-builder/genome_perl_environment:compute1-52"
+    - class: ResourceRequirement
+      ramMin: 16000
+    - class: StepInputExpressionRequirement
+    - class: InitialWorkDirRequirement
+      listing:
+      - entryname: 'aligned_stats.pl'
+        entry: |
+		#!/usr/bin/perl
+
+		# It is free software; you can redistribute it and/or modify it under the terms of
+		# the GNU General Public License (GPLv3) as published by the Free Software Foundation.
+		#
+		# McDonnell Genome Institute
+		# Washington University School of Medicine
+		# 4444 Forest Park Ave
+		# St. Louis, Missouri 63108
+		# 
+		# http://genome.wustl.edu
+
+
+		# includes perl modules
+		use strict;
+		use warnings;
+		use Carp;
+
+		use FileHandle;
+		use File::Basename;
+		use File::Spec::Functions; 
+		use Cwd;
+
+
+		# predeclares global variable names
+		use vars qw/$version $about $is_windows $scriptname $scriptdir/;
+
+		# finds the perl script name and path
+		$scriptname = basename($0, '.pl') . '.pl';
+		$scriptdir = getcwd;       # dirname($0);
+
+
+
+		## ------------ About the program ------------------------------------- #
+
+		# the version
+		$version = '1.6';
+
+		$about = qq!
+		BAM flag statistics $version
+		Usage: $scriptname [FASTA] [FILE1] [FILE2] [FILE3] ...
+		Print out flag statistics calculated from FILE(s).
+		FASTA is the reference sequence fastq file.
+		FILE(s) format can be SAM, BAM, and CRAM.
+
+		Example:
+		  \$ $scriptname all_sequences.fa normal.bam tumor.cram
+		!;
+
+
+
+		## ------------ Setting global variables ------------------------------------- #
+
+		# predeclares global variable names
+		use vars qw/@paths $samtools $pathfasta/;
+
+		# lists the full paths of fastq or BAM files
+		# (default: empty from @ARGV)
+		@paths = (
+		    # H_NJ-HCC1395-HCC1395_BL
+		    #'/storage1/fs1/bga/Active/johnegarza/fastqc_hcc1395/DNA_normal/aligned/normal.bam',
+		    #'/storage1/fs1/bga/Active/shared/gmsroot/model_data/80beed84e3104595862e7a2c7b7f896e/build8b9e77b87b0144b8a025288e92434686/tmp/cromwell-executions/immuno.cwl/58c62cbc-026b-4c9b-8d21-04b0aa4a20e8/call-somatic/somatic_exome.cwl/b24174a4-a185-4fe4-a222-50cfb2ffb305/call-normal_index_cram/inputs/1389193938/normal.bam.cram',
+		    
+		    #'/storage1/fs1/bga/Active/shared/gmsroot/model_data/80beed84e3104595862e7a2c7b7f896e/build191d8f37d22a4d79b2591c01cb80948e/results/normal.bam.cram'
+		);
+
+
+		# specifies the reference sequence FASTA file
+		# (default: undef from @ARGV)
+		$pathfasta = undef;
+		#$pathfasta = '/gscmnt/gc2560/core/model_data/2887491634/build21f22873ebe0486c8e6f69c15435aa96/all_sequences.fa';
+
+		# specifies the program paths
+		# docker(registry.gsc.wustl.edu/apipe-builder/genome_perl_environment:compute1-52)
+		$samtools = "/usr/bin/samtools";                                  # Version: 1.10 (using htslib 1.10.2-3)
+
+
+
+		## ------------ Main subroutine ---------------------------------------------- #
+		# prints the program information
+		print($about);
+
+		# main subroutine
+		Main();
+
+		# this program is terminated here
+		exit 1;
+
+
+
+		## ------------ Library of the main subroutine ----------------------------- #
+
+		sub Main {
+		    # local variables
+		    my $default_zero = 0;
+		    
+		    
+		    # gets the input file format
+		    if (defined $pathfasta)
+		    {
+			croak "Invalid reference sequence path: $pathfasta" unless -e $pathfasta;
+		    }
+		    else
+		    {
+			$pathfasta = shift @ARGV if (@ARGV > 0);
+			
+			croak "Invalid reference sequence path: $pathfasta" unless -e $pathfasta;
+		    }
+		    
+		    # gets the full input paths
+		    unless (@paths > 0)
+		    {
+			@paths = @ARGV if (@ARGV > 0);
+			
+			croak "paths required" unless @paths > 0;
+		    }
+		    
+		    
+		    #
+		    my $n = 0;                  # total number of lines
+		    my (%count);
+		    foreach my $path (@paths)
+		    {
+			# creates a file handler
+			my $fh;
+			if ($path =~ /\.bam$/)
+			{
+			    $fh = FileHandle->new("$samtools view $path |");
+			}
+			elsif ($path =~ /\.cram$/)
+			{
+			    $fh = FileHandle->new("$samtools view -T $pathfasta $path |");
+			}
+			else
+			{
+			    # from a .sam or .fastq text file
+			    $fh = FileHandle->new($path, "r");
+			}
+			
+			
+			# reads a file
+			croak "Cannot find a file: $path" unless -e $path;
+			croak "Cannot open a file: $path" unless defined $fh;
+			while (my $i = $fh->getline)
+			{
+			    next if substr($i, 0, 1) eq '@';
+			    
+			    chomp $i;
+			    
+			    my @fields = split /\t/, $i;
+			    
+			    # gets a FLAG value
+			    #my $qname = $fields[0];
+			    my $flag = $fields[1];
+			    
+			    # parses the flag
+			    my ($unmapped, $reverse, $first, $last, $secondary, $failed, $duplicate, $supplementary);
+			    if ($flag & 0x4)
+			    {
+			       # print "segment unmapped\n";
+			       $unmapped = 1;
+			    }
+			    
+			    if ($flag & 0x10)
+			    {
+			       #print "SEQ being reverse complemented\n";
+			       $reverse = 1;
+			    }
+			    
+			    if ($flag & 0x40)
+			    {
+				#print "first in pair\n";
+				$first = 1;
+			    }
+			    
+			    if ($flag & 0x80)
+			    {
+				#print "the last segment in the template\n";
+				$last = 1;
+			    }
+			    
+			    if ($flag & 0x100)
+			    {
+			       #print "secondary alignment\n";
+			       $secondary = 1;
+			    }
+			    
+			    if ($flag & 0x200)
+			    {
+			       #print "not passing quality controls\n";
+			       $failed = 1;
+			    }
+			    
+			    if ($flag & 0x400)
+			    {
+			       #print "PCR or optical duplicate\n";
+			       $duplicate = 1;
+			    }
+			    
+			    if ($flag & 0x800)
+			    {
+			       #print "supplementary alignment\n";
+			       $supplementary = 1;
+			    }
+			    
+			    
+			    # sorts reads
+			    if ($failed)
+			    {
+				$count{failed} ++;
+			    }
+			    elsif ($duplicate)
+			    {
+				$count{duplicate} ++;
+				
+				
+				if ($unmapped)
+				{
+				    $count{"duplicate\tunmapped"} ++;
+				}
+				else
+				{
+				    # counts only the primary non-duplicate alignment 
+				    if ($secondary || $supplementary)
+				    {
+					# skipped
+					$count{"duplicate\tfiltered"} ++;
+				    }
+				    else
+				    {
+					$count{"duplicate\tprimary"} ++;
+					
+					
+					if ($reverse)
+					{
+					    $count{"duplicate\tprimary\treverse"} ++;
+					}
+					else
+					{
+					    $count{"duplicate\tprimary\tforward"} ++;
+					}
+				    }
+				}
+			    }
+			    else
+			    {
+				$count{unique} ++;
+				
+				
+				if ($unmapped)
+				{
+				    $count{"unique\tunmapped"} ++;
+				    
+				    
+				    if ($first)
+				    {
+					$count{"unique\tunmapped\tfirst"} ++;
+				    }
+				    elsif ($last)
+				    {
+					$count{"unique\tunmapped\tlast"} ++;
+				    }
+				    else
+				    {
+					croak "Exception in first and last: $i"
+				    }
+				}
+				else
+				{
+				    # counts only the primary non-duplicate alignment 
+				    if ($secondary || $supplementary)
+				    {
+					# skipped
+					$count{"unique\tfiltered"} ++;
+				    }
+				    else
+				    {
+					$count{"unique\tprimary"} ++;
+					
+					
+					if ($reverse)
+					{
+					    $count{"unique\tprimary\treverse"} ++;
+					}
+					else
+					{
+					    $count{"unique\tprimary\tforward"} ++;
+					}
+					
+					if ($first)
+					{
+					    $count{"unique\tprimary\tfirst"} ++;
+					}
+					elsif ($last)
+					{
+					    $count{"unique\tprimary\tlast"} ++;
+					}
+					else
+					{
+					    croak "Exception in first and last: $i"
+					}
+				    }
+				}
+			    }
+			    
+			    
+			    unless ($secondary || $supplementary)
+			    {
+				$n ++;        # total sequencing read number matching that from fastq files
+			    }
+			}
+			
+			
+			# prints out a progress message
+			printf "\n  %d reads (cumulative) from %s", $n, $path;
+			
+			
+			# closes the file handler
+			$fh->close;
+		    }
+		    
+		    
+		    # for missing values
+		    $count{"duplicate\tunmapped"} = $default_zero unless exists $count{"duplicate\tunmapped"};
+		    $count{failed} = $default_zero unless exists $count{failed};
+		    
+		    
+		    # prints out the summary
+		    printf "\n\n[Flag summary from %d file(s)]", scalar(@paths);
+		    printf "\nTotal Read Count (R1 + R2)\t%s", $n;                                                                                # total sequencing read number
+		    printf "\nQC-failed Read Count\t%s", $count{failed};                  # QC-failed reads in flagstat
+		    printf "\nUnique Read Pairs\t%s\t%s (%%)", $count{"unique\tprimary\tfirst"} + $count{"unique\tunmapped\tfirst"}, ($count{"unique\tprimary\tfirst"} + $count{"unique\tunmapped\tfirst"}) / $n * 100 * 2;
+		    printf "\nTotal Mapped Reads\t%s\t%s (%%)", $count{"duplicate\tprimary"} + $count{"unique\tprimary"}, ($count{"duplicate\tprimary"} + $count{"unique\tprimary"}) / $n * 100;
+		    printf "\nNon-Mapped Reads\t%s\t%s (%%)", $count{"duplicate\tunmapped"} + $count{"unique\tunmapped"}, ($count{"duplicate\tunmapped"} + $count{"unique\tunmapped"}) / $n * 100;
+		    printf "\nUnique Mapped Reads\t%s\t%s (%%)", $count{"unique\tprimary"}, $count{"unique\tprimary"} / $n * 100;
+		    printf "\nMapped Read Duplication\t%s\t%s (%%)", $count{"duplicate\tprimary"}, $count{"duplicate\tprimary"} / $n * 100;
+		    printf "\nStrand ratio (forward, reverse, reverse/forward of unique mapped)\t%s\t%s\t%s", $count{"unique\tprimary\tforward"}, $count{"unique\tprimary\treverse"}, $count{"unique\tprimary\treverse"} / $count{"unique\tprimary\tforward"};
+		    
+		    # Sequence length statistics
+		    printf "\n\n\n[Sequencing read alignment statistics]\n";
+		    printhash2(%count);
+		    
+		    
+		    # the end of the main subroutine
+		}
+
+
+
+		## ------------ Library of subroutines --------------------------------------- #
+
+
+		sub printhash2 {
+		    # prints a hash
+		    my (%hash) = @_;
+
+		    # local variables
+		    
+		    foreach my $key (sort keys %hash)
+		    {
+			printf "%s\t%s\n", $key, $hash{$key};
+		    }
+		}
+
+inputs:
+    input_files:
+        type: File[]
+        inputBinding:
+            position: 1
+    output_name:
+        type: string?
+        default: "$(inputs.input_files[0].basename).txt"
+stdout: $(inputs.output_name)
+outputs:
+    aligned_stats:
+        type: stdout
+

--- a/definitions/tools/aligned_seq_fda_stats.cwl
+++ b/definitions/tools/aligned_seq_fda_stats.cwl
@@ -12,368 +12,368 @@ requirements:
       listing:
       - entryname: 'aligned_stats.pl'
         entry: |
-		#!/usr/bin/perl
+                #!/usr/bin/perl
 
-		# It is free software; you can redistribute it and/or modify it under the terms of
-		# the GNU General Public License (GPLv3) as published by the Free Software Foundation.
-		#
-		# McDonnell Genome Institute
-		# Washington University School of Medicine
-		# 4444 Forest Park Ave
-		# St. Louis, Missouri 63108
-		# 
-		# http://genome.wustl.edu
-
-
-		# includes perl modules
-		use strict;
-		use warnings;
-		use Carp;
-
-		use FileHandle;
-		use File::Basename;
-		use File::Spec::Functions; 
-		use Cwd;
+                # It is free software; you can redistribute it and/or modify it under the terms of
+                # the GNU General Public License (GPLv3) as published by the Free Software Foundation.
+                #
+                # McDonnell Genome Institute
+                # Washington University School of Medicine
+                # 4444 Forest Park Ave
+                # St. Louis, Missouri 63108
+                # 
+                # http://genome.wustl.edu
 
 
-		# predeclares global variable names
-		use vars qw/$version $about $is_windows $scriptname $scriptdir/;
+                # includes perl modules
+                use strict;
+                use warnings;
+                use Carp;
 
-		# finds the perl script name and path
-		$scriptname = basename($0, '.pl') . '.pl';
-		$scriptdir = getcwd;       # dirname($0);
+                use FileHandle;
+                use File::Basename;
+                use File::Spec::Functions; 
+                use Cwd;
 
 
+                # predeclares global variable names
+                use vars qw/$version $about $is_windows $scriptname $scriptdir/;
 
-		## ------------ About the program ------------------------------------- #
-
-		# the version
-		$version = '1.6';
-
-		$about = qq!
-		BAM flag statistics $version
-		Usage: $scriptname [FASTA] [FILE1] [FILE2] [FILE3] ...
-		Print out flag statistics calculated from FILE(s).
-		FASTA is the reference sequence fastq file.
-		FILE(s) format can be SAM, BAM, and CRAM.
-
-		Example:
-		  \$ $scriptname all_sequences.fa normal.bam tumor.cram
-		!;
+                # finds the perl script name and path
+                $scriptname = basename($0, '.pl') . '.pl';
+                $scriptdir = getcwd;       # dirname($0);
 
 
 
-		## ------------ Setting global variables ------------------------------------- #
+                ## ------------ About the program ------------------------------------- #
 
-		# predeclares global variable names
-		use vars qw/@paths $samtools $pathfasta/;
+                # the version
+                $version = '1.6';
 
-		# lists the full paths of fastq or BAM files
-		# (default: empty from @ARGV)
-		@paths = (
-		    # H_NJ-HCC1395-HCC1395_BL
-		    #'/storage1/fs1/bga/Active/johnegarza/fastqc_hcc1395/DNA_normal/aligned/normal.bam',
-		    #'/storage1/fs1/bga/Active/shared/gmsroot/model_data/80beed84e3104595862e7a2c7b7f896e/build8b9e77b87b0144b8a025288e92434686/tmp/cromwell-executions/immuno.cwl/58c62cbc-026b-4c9b-8d21-04b0aa4a20e8/call-somatic/somatic_exome.cwl/b24174a4-a185-4fe4-a222-50cfb2ffb305/call-normal_index_cram/inputs/1389193938/normal.bam.cram',
-		    
-		    #'/storage1/fs1/bga/Active/shared/gmsroot/model_data/80beed84e3104595862e7a2c7b7f896e/build191d8f37d22a4d79b2591c01cb80948e/results/normal.bam.cram'
-		);
+                $about = qq!
+                BAM flag statistics $version
+                Usage: $scriptname [FASTA] [FILE1] [FILE2] [FILE3] ...
+                Print out flag statistics calculated from FILE(s).
+                FASTA is the reference sequence fastq file.
+                FILE(s) format can be SAM, BAM, and CRAM.
 
-
-		# specifies the reference sequence FASTA file
-		# (default: undef from @ARGV)
-		$pathfasta = undef;
-		#$pathfasta = '/gscmnt/gc2560/core/model_data/2887491634/build21f22873ebe0486c8e6f69c15435aa96/all_sequences.fa';
-
-		# specifies the program paths
-		# docker(registry.gsc.wustl.edu/apipe-builder/genome_perl_environment:compute1-52)
-		$samtools = "/usr/bin/samtools";                                  # Version: 1.10 (using htslib 1.10.2-3)
+                Example:
+                  \$ $scriptname all_sequences.fa normal.bam tumor.cram
+                !;
 
 
 
-		## ------------ Main subroutine ---------------------------------------------- #
-		# prints the program information
-		print($about);
+                ## ------------ Setting global variables ------------------------------------- #
 
-		# main subroutine
-		Main();
+                # predeclares global variable names
+                use vars qw/@paths $samtools $pathfasta/;
 
-		# this program is terminated here
-		exit 1;
+                # lists the full paths of fastq or BAM files
+                # (default: empty from @ARGV)
+                @paths = (
+                    # H_NJ-HCC1395-HCC1395_BL
+                    #'/storage1/fs1/bga/Active/johnegarza/fastqc_hcc1395/DNA_normal/aligned/normal.bam',
+                    #'/storage1/fs1/bga/Active/shared/gmsroot/model_data/80beed84e3104595862e7a2c7b7f896e/build8b9e77b87b0144b8a025288e92434686/tmp/cromwell-executions/immuno.cwl/58c62cbc-026b-4c9b-8d21-04b0aa4a20e8/call-somatic/somatic_exome.cwl/b24174a4-a185-4fe4-a222-50cfb2ffb305/call-normal_index_cram/inputs/1389193938/normal.bam.cram',
+                    
+                    #'/storage1/fs1/bga/Active/shared/gmsroot/model_data/80beed84e3104595862e7a2c7b7f896e/build191d8f37d22a4d79b2591c01cb80948e/results/normal.bam.cram'
+                );
 
 
+                # specifies the reference sequence FASTA file
+                # (default: undef from @ARGV)
+                $pathfasta = undef;
+                #$pathfasta = '/gscmnt/gc2560/core/model_data/2887491634/build21f22873ebe0486c8e6f69c15435aa96/all_sequences.fa';
 
-		## ------------ Library of the main subroutine ----------------------------- #
-
-		sub Main {
-		    # local variables
-		    my $default_zero = 0;
-		    
-		    
-		    # gets the input file format
-		    if (defined $pathfasta)
-		    {
-			croak "Invalid reference sequence path: $pathfasta" unless -e $pathfasta;
-		    }
-		    else
-		    {
-			$pathfasta = shift @ARGV if (@ARGV > 0);
-			
-			croak "Invalid reference sequence path: $pathfasta" unless -e $pathfasta;
-		    }
-		    
-		    # gets the full input paths
-		    unless (@paths > 0)
-		    {
-			@paths = @ARGV if (@ARGV > 0);
-			
-			croak "paths required" unless @paths > 0;
-		    }
-		    
-		    
-		    #
-		    my $n = 0;                  # total number of lines
-		    my (%count);
-		    foreach my $path (@paths)
-		    {
-			# creates a file handler
-			my $fh;
-			if ($path =~ /\.bam$/)
-			{
-			    $fh = FileHandle->new("$samtools view $path |");
-			}
-			elsif ($path =~ /\.cram$/)
-			{
-			    $fh = FileHandle->new("$samtools view -T $pathfasta $path |");
-			}
-			else
-			{
-			    # from a .sam or .fastq text file
-			    $fh = FileHandle->new($path, "r");
-			}
-			
-			
-			# reads a file
-			croak "Cannot find a file: $path" unless -e $path;
-			croak "Cannot open a file: $path" unless defined $fh;
-			while (my $i = $fh->getline)
-			{
-			    next if substr($i, 0, 1) eq '@';
-			    
-			    chomp $i;
-			    
-			    my @fields = split /\t/, $i;
-			    
-			    # gets a FLAG value
-			    #my $qname = $fields[0];
-			    my $flag = $fields[1];
-			    
-			    # parses the flag
-			    my ($unmapped, $reverse, $first, $last, $secondary, $failed, $duplicate, $supplementary);
-			    if ($flag & 0x4)
-			    {
-			       # print "segment unmapped\n";
-			       $unmapped = 1;
-			    }
-			    
-			    if ($flag & 0x10)
-			    {
-			       #print "SEQ being reverse complemented\n";
-			       $reverse = 1;
-			    }
-			    
-			    if ($flag & 0x40)
-			    {
-				#print "first in pair\n";
-				$first = 1;
-			    }
-			    
-			    if ($flag & 0x80)
-			    {
-				#print "the last segment in the template\n";
-				$last = 1;
-			    }
-			    
-			    if ($flag & 0x100)
-			    {
-			       #print "secondary alignment\n";
-			       $secondary = 1;
-			    }
-			    
-			    if ($flag & 0x200)
-			    {
-			       #print "not passing quality controls\n";
-			       $failed = 1;
-			    }
-			    
-			    if ($flag & 0x400)
-			    {
-			       #print "PCR or optical duplicate\n";
-			       $duplicate = 1;
-			    }
-			    
-			    if ($flag & 0x800)
-			    {
-			       #print "supplementary alignment\n";
-			       $supplementary = 1;
-			    }
-			    
-			    
-			    # sorts reads
-			    if ($failed)
-			    {
-				$count{failed} ++;
-			    }
-			    elsif ($duplicate)
-			    {
-				$count{duplicate} ++;
-				
-				
-				if ($unmapped)
-				{
-				    $count{"duplicate\tunmapped"} ++;
-				}
-				else
-				{
-				    # counts only the primary non-duplicate alignment 
-				    if ($secondary || $supplementary)
-				    {
-					# skipped
-					$count{"duplicate\tfiltered"} ++;
-				    }
-				    else
-				    {
-					$count{"duplicate\tprimary"} ++;
-					
-					
-					if ($reverse)
-					{
-					    $count{"duplicate\tprimary\treverse"} ++;
-					}
-					else
-					{
-					    $count{"duplicate\tprimary\tforward"} ++;
-					}
-				    }
-				}
-			    }
-			    else
-			    {
-				$count{unique} ++;
-				
-				
-				if ($unmapped)
-				{
-				    $count{"unique\tunmapped"} ++;
-				    
-				    
-				    if ($first)
-				    {
-					$count{"unique\tunmapped\tfirst"} ++;
-				    }
-				    elsif ($last)
-				    {
-					$count{"unique\tunmapped\tlast"} ++;
-				    }
-				    else
-				    {
-					croak "Exception in first and last: $i"
-				    }
-				}
-				else
-				{
-				    # counts only the primary non-duplicate alignment 
-				    if ($secondary || $supplementary)
-				    {
-					# skipped
-					$count{"unique\tfiltered"} ++;
-				    }
-				    else
-				    {
-					$count{"unique\tprimary"} ++;
-					
-					
-					if ($reverse)
-					{
-					    $count{"unique\tprimary\treverse"} ++;
-					}
-					else
-					{
-					    $count{"unique\tprimary\tforward"} ++;
-					}
-					
-					if ($first)
-					{
-					    $count{"unique\tprimary\tfirst"} ++;
-					}
-					elsif ($last)
-					{
-					    $count{"unique\tprimary\tlast"} ++;
-					}
-					else
-					{
-					    croak "Exception in first and last: $i"
-					}
-				    }
-				}
-			    }
-			    
-			    
-			    unless ($secondary || $supplementary)
-			    {
-				$n ++;        # total sequencing read number matching that from fastq files
-			    }
-			}
-			
-			
-			# prints out a progress message
-			printf "\n  %d reads (cumulative) from %s", $n, $path;
-			
-			
-			# closes the file handler
-			$fh->close;
-		    }
-		    
-		    
-		    # for missing values
-		    $count{"duplicate\tunmapped"} = $default_zero unless exists $count{"duplicate\tunmapped"};
-		    $count{failed} = $default_zero unless exists $count{failed};
-		    
-		    
-		    # prints out the summary
-		    printf "\n\n[Flag summary from %d file(s)]", scalar(@paths);
-		    printf "\nTotal Read Count (R1 + R2)\t%s", $n;                                                                                # total sequencing read number
-		    printf "\nQC-failed Read Count\t%s", $count{failed};                  # QC-failed reads in flagstat
-		    printf "\nUnique Read Pairs\t%s\t%s (%%)", $count{"unique\tprimary\tfirst"} + $count{"unique\tunmapped\tfirst"}, ($count{"unique\tprimary\tfirst"} + $count{"unique\tunmapped\tfirst"}) / $n * 100 * 2;
-		    printf "\nTotal Mapped Reads\t%s\t%s (%%)", $count{"duplicate\tprimary"} + $count{"unique\tprimary"}, ($count{"duplicate\tprimary"} + $count{"unique\tprimary"}) / $n * 100;
-		    printf "\nNon-Mapped Reads\t%s\t%s (%%)", $count{"duplicate\tunmapped"} + $count{"unique\tunmapped"}, ($count{"duplicate\tunmapped"} + $count{"unique\tunmapped"}) / $n * 100;
-		    printf "\nUnique Mapped Reads\t%s\t%s (%%)", $count{"unique\tprimary"}, $count{"unique\tprimary"} / $n * 100;
-		    printf "\nMapped Read Duplication\t%s\t%s (%%)", $count{"duplicate\tprimary"}, $count{"duplicate\tprimary"} / $n * 100;
-		    printf "\nStrand ratio (forward, reverse, reverse/forward of unique mapped)\t%s\t%s\t%s", $count{"unique\tprimary\tforward"}, $count{"unique\tprimary\treverse"}, $count{"unique\tprimary\treverse"} / $count{"unique\tprimary\tforward"};
-		    
-		    # Sequence length statistics
-		    printf "\n\n\n[Sequencing read alignment statistics]\n";
-		    printhash2(%count);
-		    
-		    
-		    # the end of the main subroutine
-		}
+                # specifies the program paths
+                # docker(registry.gsc.wustl.edu/apipe-builder/genome_perl_environment:compute1-52)
+                $samtools = "/usr/bin/samtools";                                  # Version: 1.10 (using htslib 1.10.2-3)
 
 
 
-		## ------------ Library of subroutines --------------------------------------- #
+                ## ------------ Main subroutine ---------------------------------------------- #
+                # prints the program information
+                print($about);
+
+                # main subroutine
+                Main();
+
+                # this program is terminated here
+                exit 1;
 
 
-		sub printhash2 {
-		    # prints a hash
-		    my (%hash) = @_;
 
-		    # local variables
-		    
-		    foreach my $key (sort keys %hash)
-		    {
-			printf "%s\t%s\n", $key, $hash{$key};
-		    }
-		}
+                ## ------------ Library of the main subroutine ----------------------------- #
+
+                sub Main {
+                    # local variables
+                    my $default_zero = 0;
+                    
+                    
+                    # gets the input file format
+                    if (defined $pathfasta)
+                    {
+                        croak "Invalid reference sequence path: $pathfasta" unless -e $pathfasta;
+                    }
+                    else
+                    {
+                        $pathfasta = shift @ARGV if (@ARGV > 0);
+                        
+                        croak "Invalid reference sequence path: $pathfasta" unless -e $pathfasta;
+                    }
+                    
+                    # gets the full input paths
+                    unless (@paths > 0)
+                    {
+                        @paths = @ARGV if (@ARGV > 0);
+                        
+                        croak "paths required" unless @paths > 0;
+                    }
+                    
+                    
+                    #
+                    my $n = 0;                  # total number of lines
+                    my (%count);
+                    foreach my $path (@paths)
+                    {
+                        # creates a file handler
+                        my $fh;
+                        if ($path =~ /\.bam$/)
+                        {
+                            $fh = FileHandle->new("$samtools view $path |");
+                        }
+                        elsif ($path =~ /\.cram$/)
+                        {
+                            $fh = FileHandle->new("$samtools view -T $pathfasta $path |");
+                        }
+                        else
+                        {
+                            # from a .sam or .fastq text file
+                            $fh = FileHandle->new($path, "r");
+                        }
+                        
+                        
+                        # reads a file
+                        croak "Cannot find a file: $path" unless -e $path;
+                        croak "Cannot open a file: $path" unless defined $fh;
+                        while (my $i = $fh->getline)
+                        {
+                            next if substr($i, 0, 1) eq '@';
+                            
+                            chomp $i;
+                            
+                            my @fields = split /\t/, $i;
+                            
+                            # gets a FLAG value
+                            #my $qname = $fields[0];
+                            my $flag = $fields[1];
+                            
+                            # parses the flag
+                            my ($unmapped, $reverse, $first, $last, $secondary, $failed, $duplicate, $supplementary);
+                            if ($flag & 0x4)
+                            {
+                               # print "segment unmapped\n";
+                               $unmapped = 1;
+                            }
+                            
+                            if ($flag & 0x10)
+                            {
+                               #print "SEQ being reverse complemented\n";
+                               $reverse = 1;
+                            }
+                            
+                            if ($flag & 0x40)
+                            {
+                                #print "first in pair\n";
+                                $first = 1;
+                            }
+                            
+                            if ($flag & 0x80)
+                            {
+                                #print "the last segment in the template\n";
+                                $last = 1;
+                            }
+                            
+                            if ($flag & 0x100)
+                            {
+                               #print "secondary alignment\n";
+                               $secondary = 1;
+                            }
+                            
+                            if ($flag & 0x200)
+                            {
+                               #print "not passing quality controls\n";
+                               $failed = 1;
+                            }
+                            
+                            if ($flag & 0x400)
+                            {
+                               #print "PCR or optical duplicate\n";
+                               $duplicate = 1;
+                            }
+                            
+                            if ($flag & 0x800)
+                            {
+                               #print "supplementary alignment\n";
+                               $supplementary = 1;
+                            }
+                            
+                            
+                            # sorts reads
+                            if ($failed)
+                            {
+                                $count{failed} ++;
+                            }
+                            elsif ($duplicate)
+                            {
+                                $count{duplicate} ++;
+                                
+                                
+                                if ($unmapped)
+                                {
+                                    $count{"duplicate\tunmapped"} ++;
+                                }
+                                else
+                                {
+                                    # counts only the primary non-duplicate alignment 
+                                    if ($secondary || $supplementary)
+                                    {
+                                        # skipped
+                                        $count{"duplicate\tfiltered"} ++;
+                                    }
+                                    else
+                                    {
+                                        $count{"duplicate\tprimary"} ++;
+                                        
+                                        
+                                        if ($reverse)
+                                        {
+                                            $count{"duplicate\tprimary\treverse"} ++;
+                                        }
+                                        else
+                                        {
+                                            $count{"duplicate\tprimary\tforward"} ++;
+                                        }
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                $count{unique} ++;
+                                
+                                
+                                if ($unmapped)
+                                {
+                                    $count{"unique\tunmapped"} ++;
+                                    
+                                    
+                                    if ($first)
+                                    {
+                                        $count{"unique\tunmapped\tfirst"} ++;
+                                    }
+                                    elsif ($last)
+                                    {
+                                        $count{"unique\tunmapped\tlast"} ++;
+                                    }
+                                    else
+                                    {
+                                        croak "Exception in first and last: $i"
+                                    }
+                                }
+                                else
+                                {
+                                    # counts only the primary non-duplicate alignment 
+                                    if ($secondary || $supplementary)
+                                    {
+                                        # skipped
+                                        $count{"unique\tfiltered"} ++;
+                                    }
+                                    else
+                                    {
+                                        $count{"unique\tprimary"} ++;
+                                        
+                                        
+                                        if ($reverse)
+                                        {
+                                            $count{"unique\tprimary\treverse"} ++;
+                                        }
+                                        else
+                                        {
+                                            $count{"unique\tprimary\tforward"} ++;
+                                        }
+                                        
+                                        if ($first)
+                                        {
+                                            $count{"unique\tprimary\tfirst"} ++;
+                                        }
+                                        elsif ($last)
+                                        {
+                                            $count{"unique\tprimary\tlast"} ++;
+                                        }
+                                        else
+                                        {
+                                            croak "Exception in first and last: $i"
+                                        }
+                                    }
+                                }
+                            }
+                            
+                            
+                            unless ($secondary || $supplementary)
+                            {
+                                $n ++;        # total sequencing read number matching that from fastq files
+                            }
+                        }
+                        
+                        
+                        # prints out a progress message
+                        printf "\n  %d reads (cumulative) from %s", $n, $path;
+                        
+                        
+                        # closes the file handler
+                        $fh->close;
+                    }
+                    
+                    
+                    # for missing values
+                    $count{"duplicate\tunmapped"} = $default_zero unless exists $count{"duplicate\tunmapped"};
+                    $count{failed} = $default_zero unless exists $count{failed};
+                    
+                    
+                    # prints out the summary
+                    printf "\n\n[Flag summary from %d file(s)]", scalar(@paths);
+                    printf "\nTotal Read Count (R1 + R2)\t%s", $n;                                                                                # total sequencing read number
+                    printf "\nQC-failed Read Count\t%s", $count{failed};                  # QC-failed reads in flagstat
+                    printf "\nUnique Read Pairs\t%s\t%s (%%)", $count{"unique\tprimary\tfirst"} + $count{"unique\tunmapped\tfirst"}, ($count{"unique\tprimary\tfirst"} + $count{"unique\tunmapped\tfirst"}) / $n * 100 * 2;
+                    printf "\nTotal Mapped Reads\t%s\t%s (%%)", $count{"duplicate\tprimary"} + $count{"unique\tprimary"}, ($count{"duplicate\tprimary"} + $count{"unique\tprimary"}) / $n * 100;
+                    printf "\nNon-Mapped Reads\t%s\t%s (%%)", $count{"duplicate\tunmapped"} + $count{"unique\tunmapped"}, ($count{"duplicate\tunmapped"} + $count{"unique\tunmapped"}) / $n * 100;
+                    printf "\nUnique Mapped Reads\t%s\t%s (%%)", $count{"unique\tprimary"}, $count{"unique\tprimary"} / $n * 100;
+                    printf "\nMapped Read Duplication\t%s\t%s (%%)", $count{"duplicate\tprimary"}, $count{"duplicate\tprimary"} / $n * 100;
+                    printf "\nStrand ratio (forward, reverse, reverse/forward of unique mapped)\t%s\t%s\t%s", $count{"unique\tprimary\tforward"}, $count{"unique\tprimary\treverse"}, $count{"unique\tprimary\treverse"} / $count{"unique\tprimary\tforward"};
+                    
+                    # Sequence length statistics
+                    printf "\n\n\n[Sequencing read alignment statistics]\n";
+                    printhash2(%count);
+                    
+                    
+                    # the end of the main subroutine
+                }
+
+
+
+                ## ------------ Library of subroutines --------------------------------------- #
+
+
+                sub printhash2 {
+                    # prints a hash
+                    my (%hash) = @_;
+
+                    # local variables
+                    
+                    foreach my $key (sort keys %hash)
+                    {
+                        printf "%s\t%s\n", $key, $hash{$key};
+                    }
+                }
 
 inputs:
     reference:

--- a/definitions/tools/aligned_seq_fda_stats.cwl
+++ b/definitions/tools/aligned_seq_fda_stats.cwl
@@ -376,14 +376,18 @@ requirements:
 		}
 
 inputs:
+    reference:
+        type: File
+        inputBinding:
+            position: 1
     input_files:
         type: File[]
         inputBinding:
-            position: 1
+            position: 2
     output_name:
         type: string?
-        default: "$(inputs.input_files[0].basename).txt"
-stdout: $(inputs.output_name)
+        default: $(inputs.input_files[0].basename)
+stdout: "$(inputs.output_name)_aligned_metrics.txt"
 outputs:
     aligned_stats:
         type: stdout

--- a/definitions/tools/aligned_seq_fda_stats.cwl
+++ b/definitions/tools/aligned_seq_fda_stats.cwl
@@ -4,7 +4,7 @@ class: CommandLineTool
 baseCommand: ['/usr/bin/perl', 'aligned_stats.pl']
 requirements:
     - class: DockerRequirement
-      dockerPull: "registry.gsc.wustl.edu/apipe-builder/genome_perl_environment:compute1-52"
+      dockerPull: "mgibio/cle:v1.4.2"
     - class: ResourceRequirement
       ramMin: 16000
     - class: StepInputExpressionRequirement
@@ -86,7 +86,7 @@ requirements:
 
                 # specifies the program paths
                 # docker(registry.gsc.wustl.edu/apipe-builder/genome_perl_environment:compute1-52)
-                $samtools = "/usr/bin/samtools";                                  # Version: 1.10 (using htslib 1.10.2-3)
+                $samtools = "/opt/samtools/bin/samtools";                                  # Version: 1.10 (using htslib 1.10.2-3)
 
 
 

--- a/definitions/tools/fastqc.cwl
+++ b/definitions/tools/fastqc.cwl
@@ -2,7 +2,7 @@
 
 class: CommandLineTool
 cwlVersion: "v1.0"
-label: "Report metrics on bam files using fastqc"
+label: "Report metrics on bam or fastq files using fastqc"
 requirements:
     - class: ResourceRequirement
       ramMin: 32000
@@ -11,21 +11,16 @@ requirements:
       dockerPull: mgibio/fastqc:0.11.9
 
 baseCommand: ["/usr/bin/perl", "/usr/local/bin/FastQC/fastqc"]
-arguments: ["-q", "--extract", "-o", "$(runtime.outdir)"]
+arguments: ["-q", "-o", "$(runtime.outdir)"]
 
 inputs:
-  bam:
-    type: File
+  input_files:
+    type: File[]
     inputBinding:
         position: 1
 
 outputs:
     fastqc_all_data:
-      type: Directory
+      type: File[]
       outputBinding:
-        glob: "$(inputs.bam.nameroot)_fastqc"
-
-    fastqc_txt_report:
-      type: File
-      outputBinding:
-        glob: "$(inputs.bam.nameroot)_fastqc/fastqc_data.txt"
+        glob: "*.zip"

--- a/definitions/tools/fastqc_bam_metrics.cwl
+++ b/definitions/tools/fastqc_bam_metrics.cwl
@@ -1,0 +1,31 @@
+#!/usr/bin/env cwl-runner
+
+class: CommandLineTool
+cwlVersion: "v1.0"
+label: "Report metrics on bam files using fastqc"
+requirements:
+    - class: ResourceRequirement
+      ramMin: 32000
+      coresMin: 2
+    - class: DockerRequirement
+      dockerPull: mgibio/fastqc:0.11.9
+
+baseCommand: ["/usr/bin/perl", "/usr/local/bin/FastQC/fastqc"]
+arguments: ["-q", "--extract", "-o", "$(runtime.outdir)"]
+
+inputs:
+  bam:
+    type: File
+    inputBinding:
+        position: 1
+
+outputs:
+    fastqc_all_data:
+      type: Directory
+      outputBinding:
+        glob: "$(inputs.bam.nameroot)_fastqc"
+
+    fastqc_txt_report:
+      type: File
+      outputBinding:
+        glob: "$(inputs.bam.nameroot)_fastqc/fastqc_data.txt"

--- a/definitions/tools/generate_fda_tables.cwl
+++ b/definitions/tools/generate_fda_tables.cwl
@@ -1,0 +1,471 @@
+#! /usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+label: "Script to create FDA-requested summary tables"
+requirements:
+    - class: DockerRequirement
+      dockerPull: "python:3.7.4-slim-buster"
+    - class: ResourceRequirement
+      ramMin: 8000
+    - class: InitialWorkDirRequirement
+      listing:
+      - entryname: 'generate_tables.py'
+        entry: |
+            import argparse, zipfile, os
+
+            parser = argparse.ArgumentParser()
+
+            #data files to be parsed
+            parser.add_argument('--table', choices=['table1', 'table2', 'table3'], required=True)
+            parser.add_argument('--md5sum_file', required=True)
+            parser.add_argument('--fastqc_zips', nargs='*', required=True)
+            parser.add_argument('--aligned_metrics')
+            parser.add_argument('--unaligned_metrics')
+            parser.add_argument('--alignment_summary_metrics')
+            parser.add_argument('--duplication_metrics')
+            parser.add_argument('--insert_size_metrics')
+            parser.add_argument('--hs_metrics')
+            parser.add_argument('--rna_metrics')
+            parser.add_argument('--flagstat')
+
+            #inputs to immuno pipeline
+            parser.add_argument('--sequencing_platform', default='NOT_PROVIDED')
+            parser.add_argument('--sequencing_instrument', default='NOT_PROVIDED')
+            parser.add_argument('--sequencing_kit', default='NOT_PROVIDED')
+            parser.add_argument('--sequencing_type', default='NOT_PROVIDED')
+            parser.add_argument('--single_or_paired_end', default='NOT_PROVIDED')
+            parser.add_argument('--spike_in_error_rate', default='NOT_PROVIDED')
+            parser.add_argument('--source', default='NOT_PROVIDED')
+            parser.add_argument('--total_DNA', default='NOT_PROVIDED')
+            parser.add_argument('--reference_genome', default='NOT_PROVIDED')
+            parser.add_argument('--total_RNA', default='NOT_PROVIDED')
+            parser.add_argument('--RIN_score', default='NOT_PROVIDED')
+            parser.add_argument('--freq_normalization_method', default='NOT_PROVIDED')
+            parser.add_argument('--annotation_file', default='NOT_PROVIDED')
+            parser.add_argument('--sample_name', default='NOT_PROVIDED')
+
+            parser.add_argument('--table_file_name', required=True)
+
+            args = parser.parse_args()
+
+            # map table row names to values pulled directly from command line inputs
+            args_to_table_fields = {
+                "Sequencing Platform": args.sequencing_platform,
+                "Sequencing Instrument": args.sequencing_instrument,
+                "Sequencing Kit": args.sequencing_kit,
+                "Sequencing Type": args.sequencing_type,
+                "Single or Paired End": args.single_or_paired_end,
+                "Spike in Error Rate (%)": args.spike_in_error_rate,
+                "Source": args.source,
+                "Total DNA(ng)": args.total_DNA,
+                "Reference Genome": args.reference_genome,
+                "Total RNA (ng)": args.total_RNA,
+                "RIN score": args.RIN_score,
+                "Frequency Normalization Method": args.freq_normalization_method,
+                "Annotation File": args.annotation_file,
+                "Sample Name": args.sample_name,
+                "FastQC Plots Provided?": 'Yes'
+            }
+
+            # the following 2 methods produce nested dictionaries, with the top level keys
+            # corresponding to file names and their sub-dictionaries containing table row
+            # names and values
+
+            def parse_md5sums(md5_file):
+                with open(md5_file) as f:
+                    parsed_data = [line.split() for line in f.read().splitlines()]
+                extracted_data = {}
+                for md5sum, filepath in parsed_data:
+                    filename = os.path.basename(filepath)
+                    extracted_data[filename] = {"MD5 File Checksum": md5sum}
+                    extracted_data[filename]['File'] = filename
+                return extracted_data
+
+            def parse_fastqc_zips(zip_list, table_num):
+
+                #define mappings from field name in fastqc data to row label in table
+                fieldname_to_t1_label = {
+                    "Total Sequences": "Total Number of Reads",
+                    "%GC": "GC Content (%)"
+                }
+
+                fieldname_to_t2_label = {
+                    "Sequence length": "Read Length"
+                }
+
+                fieldname_to_t3_label = {
+                    "Sequence length": "Read Length (nt)", 
+                    "Total Sequences": "Total read (read count)"
+                }
+
+                #helper to choose proper mapping dict for requested table
+                table_to_map_dict = {
+                    "table1": fieldname_to_t1_label,
+                    "table2": fieldname_to_t2_label,
+                    "table3": fieldname_to_t3_label
+                }
+
+                field_map = table_to_map_dict[table_num]
+
+                extracted_data = {}
+                for zip_file in zip_list:
+                    with zipfile.ZipFile(zip_file) as myzip:
+                        #remove .zip extension to get path within unzipped archive
+                        zipfile_basename = os.path.basename(zip_file)
+                        zipfile_nameroot = os.path.splitext(zipfile_basename)[0]
+                        datafile_archive_path = zipfile_nameroot + '/fastqc_data.txt'
+                        with myzip.open(datafile_archive_path) as myfile:
+                            #the file is split into sections using this string as a
+                            #delimiter; all required info is in the first section
+                            raw_chunk = myfile.read().decode().split('>>END_MODULE')[0]
+
+                    #split chunk on newlines, then split each line on tabs
+                    parsed_data = [line.split('\t') for line in raw_chunk.splitlines()]
+                    #ensure filename, which is used as a key for sub-dictionaries,
+                    #is set once & only once; it's the first data field in the chunk,
+                    #so the sub-dict is safely created before it's used to store data
+                    key_unset = True
+                    for (field_name, field_data) in parsed_data:
+                        if key_unset and field_name == 'Filename':
+                            key = field_data
+                            extracted_data[key] = {}
+                            key_unset = False
+                        elif not key_unset and field_name in field_map:
+                            extracted_data[key][ field_map[field_name] ] = field_data
+
+                return extracted_data
+
+            # the remaining methods produce single-level dictionaries, with keys
+            # corresponding to table row names
+
+            # the next two methods parse the outputs of Gue Su's custom metrics scripts
+
+            def parse_aligned_metrics(metrics_file, table_num):
+                fieldname_to_t2_label = {
+                    "Total Read Count (R1 + R2)": "Total Read Count",
+                    "Unique Read Pairs": "Unique Read Pairs",
+                    "Total Mapped Reads": "Total Mapped Reads (%)",
+                    "Non-Mapped Reads": "Non-Mapped Reads (%)",
+                    "Unique Mapped Reads": "Unique Mapped Reads (%)",
+                    "Mapped Read Duplication": "Mapped Read Duplication (%)",
+                    "Strand ratio (forward, reverse, reverse/forward of unique mapped)": "Strand Specificity (%)"
+                }
+
+                fieldname_to_t3_label = {
+                    "QC-failed Read Count": "Filtered (read count)",
+                    "Total Mapped Reads": "Total mapped reads (%)",
+                    "Non-Mapped Reads": "Non-mapped reads (%)",
+                    "Unique Mapped Reads": "Unique mapped reads (%)",
+                    "Strand ratio (forward, reverse, reverse/forward of unique mapped)": "Strand specificity (%)"
+                }
+
+                table_to_map_dict = {
+                    "table2": fieldname_to_t2_label,
+                    "table3": fieldname_to_t3_label
+                }
+
+                field_map = table_to_map_dict[table_num]
+
+                with open(metrics_file) as f:
+                    parsed_data = [line.split('\t') for line in f.read().splitlines()]
+                extracted_data = {}
+                for parsed_line in parsed_data:
+                    if len(parsed_line) < 2:
+                        continue
+                    field_name = parsed_line[0]
+                    field_data = parsed_line[-1]
+                    if field_name in field_map:
+                        extracted_data[ field_map[field_name] ] = field_data
+
+                return extracted_data
+
+            def parse_unaligned_metrics(metrics_file):
+
+                field_map = {
+                    "Median Basecall Quality Score": "Median Phred Score",
+                    "Bases with N": "Bases with N (%)",
+                    "Bases with >= Q30": "Bases with >= Q30 (%)"
+                }
+
+                with open(metrics_file) as f:
+                    parsed_data = [line.split('\t') for line in f.read().splitlines()]
+                extracted_data = {}
+                for parsed_line in parsed_data:
+                    if len(parsed_line) < 2:
+                        continue
+                    field_name = parsed_line[0]
+                    field_data = parsed_line[-1]
+                    if field_name in field_map:
+                        extracted_data[ field_map[field_name] ] = field_data
+
+                return extracted_data
+
+            # the remaining methods parse various picard output files
+
+            def parse_alignment_summary_metrics(alignment_summary_metrics):
+                with open(alignment_summary_metrics) as f:
+                    parsed_data = [line.split('\t') for line in f.read().splitlines()]
+                extracted_data = {}
+                for parsed_line in parsed_data:
+                    if parsed_line[0] == 'PAIR':
+                        extracted_data['PCT_READS_ALIGNED_IN_PAIRS'] = parsed_line[17]
+                    elif parsed_line[0] == 'FIRST_OF_PAIR':
+                        extracted_data['PF_MISMATCH_RATE_1'] = parsed_line[12]
+                    elif parsed_line[0] == 'SECOND_OF_PAIR':
+                        extracted_data['PF_MISMATCH_RATE_2'] = parsed_line[12]
+                return extracted_data
+
+            def indices_from_field_list(header_line, fields):
+                field_to_index = {}
+                for index, field in enumerate(header_line):
+                    if field in fields:
+                        field_to_index[field] = index
+                        fields.remove(field)
+                assert(len(fields) == 0)
+                return field_to_index
+
+            def parse_duplication_metrics(duplication_metrics):
+                with open(duplication_metrics) as f:
+                    raw_chunk = f.read().split('\n\n')[1]
+                pct_dup = raw_chunk.splitlines()[2].split()[8]
+                return {'PERCENT_DUPLICATION': pct_dup}
+
+            def parse_insert_size_metrics(insert_size_metrics):
+                with open(insert_size_metrics) as f:
+                    raw_chunk = f.read().split('\n\n')[1]
+                insert_size = raw_chunk.splitlines()[2].split()[5]
+                return {'MEAN_INSERT_SIZE': insert_size}
+
+            def parse_hs_metrics(hs_metrics):
+                with open(hs_metrics) as f:
+                    raw_chunk = f.read().split('\n\n')[1]
+                parsed_chunk = [line.split() for line in raw_chunk.splitlines()]
+                header_line = parsed_chunk[1]
+                data_line = parsed_chunk[2]
+                fields = set(['PCT_USABLE_BASES_ON_TARGET', 'PCT_EXC_OFF_TARGET', 'MEAN_TARGET_COVERAGE', 'PCT_TARGET_BASES_20X'])
+                field_to_index = indices_from_field_list(header_line, fields)
+                extracted_data = {}
+                for field in field_to_index:
+                    extracted_data[field] = data_line[ field_to_index[field] ]
+                return extracted_data
+                
+            def parse_rna_metrics(rna_metrics):
+                with open(rna_metrics) as f:
+                    raw_chunk = f.read().split('\n\n')[1]
+                parsed_chunk = [line.split() for line in raw_chunk.splitlines()]
+                header_line = parsed_chunk[1]
+                data_line = parsed_chunk[2]
+                fields = set([
+                    'PCT_CODING_BASES', 'PCT_UTR_BASES', 'PCT_INTRONIC_BASES', 'PCT_INTERGENIC_BASES', 'PCT_CORRECT_STRAND_READS',
+                    'MEDIAN_5PRIME_BIAS', 'MEDIAN_3PRIME_BIAS', 'MEDIAN_5PRIME_TO_3PRIME_BIAS'])
+                field_to_index = indices_from_field_list(header_line, fields)
+                extracted_data = {}
+                for field in field_to_index:
+                    extracted_data[field] = data_line[ field_to_index[field] ]
+                return extracted_data
+
+            def parse_flagstat(flagstat):
+                with open(flagstat) as f:
+                    return {'Filtered Read Count': f.readlines()[0].split()[2]}
+
+            def aggregate_dicts(md5_dict, fastqc_dict, *flat_dicts):
+                final_dict = md5_dict.copy()
+                for key in final_dict:
+                    # merge the 2 nested dicts, both in the form {filename: {table_field: val, ...}}
+                    final_dict[key].update(fastqc_dict[key])
+                    # copy in any given flat dicts, in the form {table_field: val, ...}
+                    # vals in flat dicts not keyed to filename are assumed to apply across all files
+                    for flat_dict in flat_dicts:
+                        final_dict[key].update(flat_dict)
+                return final_dict
+
+            def generate_table(table_rows, val_dict):
+                table_list = []
+                for row in table_rows:
+                    row_list = [row]
+                    for filename_key in sorted(val_dict):
+                        row_list.append(val_dict[filename_key][row])
+                    table_list.append(row_list)
+                return table_list
+
+            def generate_table1(file_args, string_arg_dict):
+                table_rows = ('Sample Name', 'File', 'MD5 File Checksum', 'Sequencing Platform',
+                    'Sequencing Instrument', 'Sequencing Kit', 'Single or Paired End', 'Sequencing Type',
+                    'Total Number of Reads', 'Median Phred Score', 'GC Content (%)', 'Bases with N (%)',
+                    'Bases with >= Q30 (%)', 'Spike in Error Rate (%)', 'FastQC Plots Provided?')
+
+                md5_dict = parse_md5sums(file_args.md5sum_file)
+                fastqc_dict = parse_fastqc_zips(file_args.fastqc_zips, file_args.table)
+                unaligned_dict = parse_unaligned_metrics(file_args.unaligned_metrics)
+
+                table_dict = aggregate_dicts(md5_dict, fastqc_dict, string_arg_dict, unaligned_dict)
+
+                table = generate_table(table_rows, table_dict)
+                return table
+
+            def generate_table2(file_args, string_arg_dict):
+                table_rows = ('Sample Name', 'File', 'MD5 File Checksum', 'Sequencing Platform',
+                    'Sequencing Instrument', 'Sequencing Kit', 'Single or Paired End', 'Source', 'Total DNA(ng)',
+                    'Read Length', 'Total Read Count', 'Filtered Read Count', 'Unique Read Pairs', 'Total Mapped Reads (%)',
+                    'Non-Mapped Reads (%)', 'Unique Mapped Reads (%)', 'Mapped Read Duplication (%)', 'Strand Specificity (%)',
+                    'Reference Genome', 'PCT_USABLE_BASES_ON_TARGET', 'PCT_EXC_OFF_TARGET', 'PERCENT_DUPLICATION',
+                    'MEAN_TARGET_COVERAGE', 'PCT_TARGET_BASES_20X', 'PCT_READS_ALIGNED_IN_PAIRS', 'MEAN_INSERT_SIZE',
+                    'PF_MISMATCH_RATE_1', 'PF_MISMATCH_RATE_2')
+
+                md5_dict = parse_md5sums(file_args.md5sum_file)
+                fastqc_dict = parse_fastqc_zips(file_args.fastqc_zips, file_args.table)
+                aligned_dict = parse_aligned_metrics(file_args.aligned_metrics, file_args.table)
+                alignment_summary_dict = parse_alignment_summary_metrics(args.alignment_summary_metrics)
+                duplication_dict = parse_duplication_metrics(args.duplication_metrics)
+                insert_size_dict = parse_insert_size_metrics(args.insert_size_metrics)
+                hs_dict = parse_hs_metrics(args.hs_metrics)
+                flagstat_dict = parse_flagstat(args.flagstat)
+
+                table_dict = aggregate_dicts(md5_dict, fastqc_dict, string_arg_dict, aligned_dict,
+                    alignment_summary_dict, duplication_dict, insert_size_dict, hs_dict, flagstat_dict)
+
+                table = generate_table(table_rows, table_dict)
+                return table
+
+            def generate_table3(file_args, string_arg_dict):
+                table_rows = ('Sample Name', 'File', 'MD5 File Checksum', 'Sequencing Platform',
+                    'Sequencing Instrument', 'Sequencing Kit', 'Single or Paired End', 'Source', 'Total RNA (ng)',
+                    'RIN score', 'Read Length (nt)', 'Total read (read count)', 'Filtered (read count)', 'Total mapped reads (%)',
+                    'Non-mapped reads (%)', 'Unique mapped reads (%)', 'Strand specificity (%)', 'Frequency Normalization Method',
+                    'Annotation File', 'Reference Genome', 'PCT_CODING_BASES', 'PCT_UTR_BASES', 'PCT_INTRONIC_BASES', 'PCT_INTERGENIC_BASES',
+                    'PCT_CORRECT_STRAND_READS', 'MEDIAN_5PRIME_BIAS', 'MEDIAN_3PRIME_BIAS', 'MEDIAN_5PRIME_TO_3PRIME_BIAS')
+
+                md5_dict = parse_md5sums(file_args.md5sum_file)
+                fastqc_dict = parse_fastqc_zips(file_args.fastqc_zips, file_args.table)
+                aligned_dict = parse_aligned_metrics(file_args.aligned_metrics, file_args.table)
+                rna_dict = parse_rna_metrics(args.rna_metrics)
+
+                table_dict = aggregate_dicts(md5_dict, fastqc_dict, string_arg_dict, aligned_dict, rna_dict)
+
+                table = generate_table(table_rows, table_dict)
+                return table
+
+            if args.table == 'table1':
+                table = generate_table1(args, args_to_table_fields)
+            elif args.table == 'table2':
+                table = generate_table2(args, args_to_table_fields)
+            else:
+                table = generate_table3(args, args_to_table_fields)
+
+            with open(args.table_file_name, 'w+') as f:
+                for line in table:
+                    f.write(','.join(line) + '\n')
+
+
+baseCommand: ['python', 'generate_tables.py']
+inputs:
+    table_file_name:
+        type: string?
+        inputBinding:
+            prefix: "--table_file_name"
+    table_num:
+        type: string
+        inputBinding:
+            prefix: "--table"
+    md5sum_file:
+        type: File
+        inputBinding:
+            prefix: "--md5sum_file"
+    fastqc_zips:
+        type: File[]
+        inputBinding:
+            prefix: "--fastqc_zips"
+    aligned_metrics:
+        type: File?
+        inputBinding:
+            prefix: "--aligned_metrics"
+    unaligned_metrics:
+        type: File?
+        inputBinding:
+            prefix: "--unaligned_metrics"
+    alignment_summary_metrics:
+        type: File?
+        inputBinding:
+            prefix: "--alignment_summary_metrics"
+    duplication_metrics:
+        type: File?
+        inputBinding:
+            prefix: "--duplication_metrics"
+    insert_size_metrics:
+        type: File?
+        inputBinding:
+            prefix: "--insert_size_metrics"
+    hs_metrics:
+        type: File?
+        inputBinding:
+            prefix: "--hs_metrics"
+    rna_metrics:
+        type: File?
+        inputBinding:
+            prefix: "--rna_metrics"
+    flagstat:
+        type: File?
+        inputBinding:
+            prefix: "--flagstat"
+
+    sequencing_platform:
+        type: string?
+        inputBinding:
+            prefix: "--sequencing_platform"
+    sequencing_instrument:
+        type: string?
+        inputBinding:
+            prefix: "--sequencing_instrument"
+    sequencing_kit:
+        type: string?
+        inputBinding:
+            prefix: "--sequencing_kit"
+    sequencing_type:
+        type: string?
+        inputBinding:
+            prefix: "--sequencing_type"
+    single_or_paired_end:
+        type: string?
+        inputBinding:
+            prefix: "--single_or_paired_end"
+    spike_in_error_rate:
+        type: string?
+        inputBinding:
+            prefix: "--spike_in_error_rate"
+    source:
+        type: string?
+        inputBinding:
+            prefix: "--source"
+    total_DNA:
+        type: string?
+        inputBinding:
+            prefix: "--total_DNA"
+    reference_genome:
+        type: string?
+        inputBinding:
+            prefix: "--reference_genome"
+    total_RNA:
+        type: string?
+        inputBinding:
+            prefix: "--total_RNA"
+    RIN_score:
+        type: string?
+        inputBinding:
+            prefix: "--RIN_score"
+    freq_normalization_method:
+        type: string?
+        inputBinding:
+            prefix: "--freq_normalization_method"
+    annotation_file:
+        type: string?
+        inputBinding:
+            prefix: "--annotation_file"
+    sample_name:
+        type: string?
+        inputBinding:
+            prefix: "--sample_name"
+outputs:
+    table:
+        type: File
+        outputBinding:
+            glob: $(inputs.table_file_name)

--- a/definitions/tools/md5sum.cwl
+++ b/definitions/tools/md5sum.cwl
@@ -1,0 +1,23 @@
+#! /usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: ['/usr/bin/md5sum']
+requirements:
+    - class: DockerRequirement
+      dockerPull: "ubuntu:bionic"
+    - class: ResourceRequirement
+      ramMin: 16000
+    - class: StepInputExpressionRequirement
+
+inputs:
+    input_files:
+        type: File[]
+        inputBinding:
+            position: 1
+    output_name:
+        type: string?
+        default: $(inputs.input_files[0].basename)
+stdout: "$(inputs.output_name).md5"
+outputs:
+    md5sum:
+        type: stdout

--- a/definitions/tools/unaligned_seq_fda_stats.cwl
+++ b/definitions/tools/unaligned_seq_fda_stats.cwl
@@ -398,8 +398,8 @@ inputs:
             position: 1
     output_name:
         type: string?
-        default: "$(inputs.input_files[0].basename).txt"
-stdout: $(inputs.output_name)
+        default: $(inputs.input_files[0].basename)
+stdout: "$(inputs.output_name)_unaligned_metrics.txt"
 outputs:
     unaligned_stats:
         type: stdout

--- a/definitions/tools/unaligned_seq_fda_stats.cwl
+++ b/definitions/tools/unaligned_seq_fda_stats.cwl
@@ -1,0 +1,405 @@
+#! /usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: ['/usr/bin/perl', 'unaligned_stats.pl']
+requirements:
+    - class: DockerRequirement
+      dockerPull: "registry.gsc.wustl.edu/apipe-builder/genome_perl_environment:compute1-52"
+    - class: ResourceRequirement
+      ramMin: 16000
+    - class: StepInputExpressionRequirement
+    - class: InitialWorkDirRequirement
+      listing:
+      - entryname: 'unaligned_stats.pl'
+        entry: |
+		#!/usr/bin/perl
+
+		# It is free software; you can redistribute it and/or modify it under the terms of
+		# the GNU General Public License (GPLv3) as published by the Free Software Foundation.
+		#
+		# McDonnell Genome Institute
+		# Washington University School of Medicine
+		# 4444 Forest Park Ave
+		# St. Louis, Missouri 63108
+		# 
+		# http://genome.wustl.edu
+
+
+		# includes perl modules
+		use strict;
+		use warnings;
+		use Carp;
+
+		use FileHandle;
+		use File::Basename;
+		use File::Spec::Functions; 
+		use Cwd;
+
+
+		# predeclares global variable names
+		use vars qw/$version $about $is_windows $scriptname $scriptdir/;
+
+		# finds the perl script name and path
+		$scriptname = basename($0, '.pl') . '.pl';
+		$scriptdir = getcwd;       # dirname($0);
+
+
+
+		## ------------ About the program ------------------------------------- #
+
+		# the version
+		$version = '1.7';
+
+		$about = qq!
+		FASTQ statistics $version
+		Usage: $scriptname [FILE1] [FILE2] [FILE3] ...
+		Print out statistics calculated from FILE(s).
+
+		Example:
+		  \$ $scriptname read1.fastq.gz read2.fastq.gz
+		!;
+
+
+
+		## ------------ Setting global variables ------------------------------------- #
+
+		# predeclares global variable names
+		use vars qw/$format @paths $filter $bzcat $zcat $samtools $base $offset/;
+
+		# defines the format of input files
+		# (required, "fastq" or "bam")
+		#$format = "fastq";
+		#$format = "bam";
+
+		# lists the full paths of fastq or BAM files
+		@paths = (
+		    # H_NJ-HCC1395-HCC1395_BL
+		    #"/storage1/fs1/bga/Active/gchang/work/14_BGA-WALKER/211012-immuno2cwl-fastq/2.fastq/H_NJ-HCC1395-HCC1395_BL-H7HY2CCXX.3.R1.fastq.gz",
+		    #"/storage1/fs1/bga/Active/gchang/work/14_BGA-WALKER/211012-immuno2cwl-fastq/2.fastq/H_NJ-HCC1395-HCC1395_BL-H7HY2CCXX.3.R2.fastq.gz",
+		    #"/storage1/fs1/bga/Active/gchang/work/14_BGA-WALKER/211012-immuno2cwl-fastq/2.fastq/H_NJ-HCC1395-HCC1395_BL-H7HY2CCXX.4.R1.fastq.gz",
+		    #"/storage1/fs1/bga/Active/gchang/work/14_BGA-WALKER/211012-immuno2cwl-fastq/2.fastq/H_NJ-HCC1395-HCC1395_BL-H7HY2CCXX.4.R2.fastq.gz",
+		    
+		    #"/gscmnt/gc2560/core/instrument_data/2895499331/csf_150397221/gerald_H7HY2CCXX_3_TGACCACG.bam",
+		    #"/gscmnt/gc2560/core/instrument_data/2895499399/csf_150397349/gerald_H7HY2CCXX_4_TGACCACG.bam",
+		);
+
+		# defines the minimum base call quality score to filter
+		# inclusive, for example, Bases with >= Q30
+		$filter = 30;
+
+
+		# specifies the program paths
+		# docker(registry.gsc.wustl.edu/apipe-builder/genome_perl_environment:compute1-52)
+		$bzcat = "/usr/bin/bzcat";                                             # Version 1.0.8
+		$zcat = "/usr/bin/zcat";                                                # zcat (gzip) 1.10
+		$samtools = "/usr/bin/samtools";                                  # Version: 1.10 (using htslib 1.10.2-3)
+
+		# specifies the N letter to count
+		# (default: "N")
+		$base = 'N';
+
+		# defines the offset to calculate the base call quality score from the Phred +33 encoded by ASCII characters
+		# For example, 33 = 63.06707094 - 30.06707094 (see below)
+		$offset = 33;
+
+
+
+		## ------------ Main subroutine ---------------------------------------------- #
+		# prints the program information
+		print($about);
+
+		# main subroutine
+		Main();
+
+		# this program is terminated here
+		exit 1;
+
+
+
+		## ------------ Library of the main subroutine ----------------------------- #
+
+		sub Main {
+		    # local variables
+		    
+		    # gets the full input paths
+		    unless (@paths > 0)
+		    {
+			@paths = @ARGV if (@ARGV > 0);
+			
+			croak "paths required" unless @paths > 0;
+		    }
+		    
+		    
+		    $format = "fastq"
+
+		    # opens input files
+		    my $n = 0;                  # total number of lines
+		    my $nbase = 0;
+		    my (%freq, %count);
+		    foreach my $path (@paths)
+		    {
+			# creates a file handler
+			my $fh;
+			if ($path =~ /\.gz$/)
+			{
+			    $fh = FileHandle->new("$zcat $path |");
+			}
+			elsif ($path =~ /\.bam$/)
+			{
+			    $format = "bam"
+			    $fh = FileHandle->new("$samtools view $path |");
+			}
+			elsif ($path =~ /\.bz2$/)
+			{
+			    $fh = FileHandle->new("$bzcat $path |");
+			}
+			else
+			{
+			    # from a .sam or .fastq text file
+			    $fh = FileHandle->new($path, "r");
+			}
+			
+			
+			# reads a file
+			croak "Cannot find a file: $path" unless -e $path;
+			croak "Cannot open a file: $path" unless defined $fh;
+			if ($format eq "fastq")
+			{
+			    while (my $i = $fh->getline)
+			    {
+				if ($n % 4 == 3)
+				{
+				    chomp $i;
+				    
+				    # updates the frequency/count hashes
+				    update_hash($i, \%freq, \%count, $offset);
+				}
+				elsif ($n % 4 == 1)
+				{
+				    chomp $i;
+				    
+				    # counts the frequency of a letter
+				    $nbase += count_base($i, $base);
+				}
+				
+				
+				$n ++;
+			    }
+			}
+			elsif ($format eq "bam")
+			{
+			    while (my $i = $fh->getline)
+			    {
+				next if substr($i, 0, 1) eq '@';
+				
+				chomp $i;
+				
+				my @fields = split /\t/, $i;
+				
+				# gets a QUAL value
+				# my $qual = $fields[10];
+				
+				# updates the frequency/count hashes
+				update_hash($fields[10], \%freq, \%count, $offset);
+				
+				# counts the frequency of a letter
+				$nbase += count_base($fields[9], $base);
+				
+				
+				$n ++;
+			    }
+			}
+			else
+			{
+			    croak "Invalid input file format: $format";
+			}
+			
+			
+			#
+			printf "\n  %d lines (cumulative) read from %s", $n, $path;
+			
+			
+			# closes the file handler
+			$fh->close;
+		    }
+		    
+		    
+		    # calculates the total number of base calls and sequences
+		    my ($nseq, $ncall) = (0, 0);
+		    foreach my $len (sort {$a <=> $b} keys %count)
+		    {
+			$ncall += $len * $count{$len};
+			$nseq += $count{$len};
+		    }
+		    
+		    croak "Exception: Invalid total number of sequences, $nseq" unless $nseq == ($format eq "fastq") ? $n / 4 : $n;
+		    
+		    
+
+		    # calculates the median and mean from a frequency hash
+		    my ($median, $mean, $ncall2) = stat_freq(%freq);
+		    croak "Exception: invalid count number of base calls" unless $ncall == $ncall2;
+		    
+		    # filters with the minimum base call quality score
+		    my $nfilter = 0;
+		    foreach my $score (keys %freq)
+		    {
+			if ($filter <= $score)
+			{
+			    $nfilter += $freq{$score};
+			}
+		    }
+		    
+		    
+		    # prints out the summary
+		    printf "\n\n[Quality score summary]";
+		    printf "\nTotal Number of Reads\t%s", $nseq;                                                                    # total sequence number
+		    printf "\nTotal Number of basecalls\t%s", $ncall;
+		    printf "\nBases with %s\t%s\t%s (%%)", $base, $nbase, $nbase / $ncall * 100;
+		    printf "\nMedian Basecall Quality Score\t%s", $median;
+		    printf "\nMean Basecall Quality Score\t%s", $mean;
+		    printf "\nBases with >= Q%s\t%d\t%s (%%)", $filter, $nfilter, $nfilter / $ncall * 100;
+		    
+		    
+		    # Base call score frequency
+		    printf "\n\n[Base call score frequency: %d sequences from %d file(s)]\n", $nseq, scalar(@paths);
+		    printhash(%freq);
+		    
+		    # Sequence length statistics
+		    printf "\n\n[Sequence length statistics]\n";
+		    printhash(%count);
+		    
+		    
+		    # the end of the main subroutine
+		}
+
+
+
+		## ------------ Library of subroutines --------------------------------------- #
+
+
+		sub update_hash {
+		    # updates the frequency/count hashes
+		    my ($qual, $freq, $count, $offset) = @_;
+
+		    # local variables
+		    
+		    
+		    # converts characters to ASCII numbers
+		    my @scores = map { unpack("C*", $_ ) - $offset } split("", $qual);
+		    
+		    
+		    # updates the hashes
+		    map { $freq->{$_} ++ } @scores;
+		    
+		    #map { $count{$_} ++ }  split("", $i);
+		    $count->{$#scores + 1} ++;                 # for the sequence length
+		}
+
+
+		sub count_base {
+		    # counts the frequency of a letter
+		    my ($str, $base) = @_;
+		    
+		    # local variables
+		    
+		    
+		    # calculates the frequency of a letter
+		    my $count = 0;
+		    if (index($str, $base) > -1)
+		    {
+			$count = $str =~ s/$base//g;
+		    }
+		    
+		    
+		    return $count;
+		}
+
+
+		sub stat_freq {
+		    # calculates the median and mean from a frequency hash
+		    my (%hash) = @_;
+		    
+		    # local variables
+		    
+		    # as default
+		    # frequency hash: {key => data value, value => data count}
+		    croak "empty frequency hash" unless keys(%hash) > 0;
+		    
+		    
+		    # sorts the data values
+		    my @sort = sort {$a <=> $b} keys %hash;
+		    
+		    # counts the total number of data
+		    my $n = 0;
+		    map { $n += $hash{$_} } @sort;
+		    
+		    # calculates the median index (0-based index)
+		    my @midx = ($n % 2 == 1) ? ((1 + $n) / 2) - 1 : ((1 + $n) / 2 - 1.5, (1 + $n) / 2 - 0.5);
+		    
+		    # calculates the median of base call quality score from the frequency
+		    my ($median, $mean);
+		    my $idx = 0;
+		    for (my $i=0; $i<@sort; $i ++)
+		    {
+			# gets the last index of the given score in the array (1-based)
+			my $score = $sort[$i];
+			$idx += $hash{$score};
+			
+			# calculates the mean and mode
+			$mean += $score * $hash{$score};
+			
+			# calculates the median
+			unless (defined $median)
+			{
+			    if ($midx[0] <= $idx - 1)
+			    {
+				if (@midx == 2)
+				{
+				    if ($midx[1] <= $idx - 1)
+				    {
+					# same as ($score + $score) / 2
+					$median = $score;
+				    }
+				    else
+				    {
+					$median = ($score + $sort[$i + 1]) / 2;
+				    }
+				}
+				else
+				{
+				    $median = $score;
+				}
+			    }
+			}
+		    }
+		    
+		    
+		    return ($median, $mean / $n, $n);
+		}
+
+
+		sub printhash {
+		    # prints a hash
+		    my (%hash) = @_;
+
+		    # local variables
+		    
+		    foreach my $key (sort {$a <=> $b} keys %hash)
+		    {
+			printf "%s\t%s\n", $key, $hash{$key};
+		    }
+		}
+
+inputs:
+    input_files:
+        type: File[]
+        inputBinding:
+            position: 1
+    output_name:
+        type: string?
+        default: "$(inputs.input_files[0].basename).txt"
+stdout: $(inputs.output_name)
+outputs:
+    unaligned_stats:
+        type: stdout

--- a/definitions/tools/unaligned_seq_fda_stats.cwl
+++ b/definitions/tools/unaligned_seq_fda_stats.cwl
@@ -4,7 +4,7 @@ class: CommandLineTool
 baseCommand: ['/usr/bin/perl', 'unaligned_stats.pl']
 requirements:
     - class: DockerRequirement
-      dockerPull: "registry.gsc.wustl.edu/apipe-builder/genome_perl_environment:compute1-52"
+      dockerPull: "mgibio/cle:v1.4.2"
     - class: ResourceRequirement
       ramMin: 16000
     - class: StepInputExpressionRequirement
@@ -92,7 +92,7 @@ requirements:
                 # docker(registry.gsc.wustl.edu/apipe-builder/genome_perl_environment:compute1-52)
                 $bzcat = "/usr/bin/bzcat";                                             # Version 1.0.8
                 $zcat = "/usr/bin/zcat";                                                # zcat (gzip) 1.10
-                $samtools = "/usr/bin/samtools";                                  # Version: 1.10 (using htslib 1.10.2-3)
+                $samtools = "/opt/samtools/bin/samtools";                                  # Version: 1.10 (using htslib 1.10.2-3)
 
                 # specifies the N letter to count
                 # (default: "N")

--- a/definitions/tools/unaligned_seq_fda_stats.cwl
+++ b/definitions/tools/unaligned_seq_fda_stats.cwl
@@ -12,384 +12,384 @@ requirements:
       listing:
       - entryname: 'unaligned_stats.pl'
         entry: |
-		#!/usr/bin/perl
+                #!/usr/bin/perl
 
-		# It is free software; you can redistribute it and/or modify it under the terms of
-		# the GNU General Public License (GPLv3) as published by the Free Software Foundation.
-		#
-		# McDonnell Genome Institute
-		# Washington University School of Medicine
-		# 4444 Forest Park Ave
-		# St. Louis, Missouri 63108
-		# 
-		# http://genome.wustl.edu
-
-
-		# includes perl modules
-		use strict;
-		use warnings;
-		use Carp;
-
-		use FileHandle;
-		use File::Basename;
-		use File::Spec::Functions; 
-		use Cwd;
+                # It is free software; you can redistribute it and/or modify it under the terms of
+                # the GNU General Public License (GPLv3) as published by the Free Software Foundation.
+                #
+                # McDonnell Genome Institute
+                # Washington University School of Medicine
+                # 4444 Forest Park Ave
+                # St. Louis, Missouri 63108
+                # 
+                # http://genome.wustl.edu
 
 
-		# predeclares global variable names
-		use vars qw/$version $about $is_windows $scriptname $scriptdir/;
+                # includes perl modules
+                use strict;
+                use warnings;
+                use Carp;
 
-		# finds the perl script name and path
-		$scriptname = basename($0, '.pl') . '.pl';
-		$scriptdir = getcwd;       # dirname($0);
+                use FileHandle;
+                use File::Basename;
+                use File::Spec::Functions; 
+                use Cwd;
 
 
+                # predeclares global variable names
+                use vars qw/$version $about $is_windows $scriptname $scriptdir/;
 
-		## ------------ About the program ------------------------------------- #
-
-		# the version
-		$version = '1.7';
-
-		$about = qq!
-		FASTQ statistics $version
-		Usage: $scriptname [FILE1] [FILE2] [FILE3] ...
-		Print out statistics calculated from FILE(s).
-
-		Example:
-		  \$ $scriptname read1.fastq.gz read2.fastq.gz
-		!;
+                # finds the perl script name and path
+                $scriptname = basename($0, '.pl') . '.pl';
+                $scriptdir = getcwd;       # dirname($0);
 
 
 
-		## ------------ Setting global variables ------------------------------------- #
+                ## ------------ About the program ------------------------------------- #
 
-		# predeclares global variable names
-		use vars qw/$format @paths $filter $bzcat $zcat $samtools $base $offset/;
+                # the version
+                $version = '1.7';
 
-		# defines the format of input files
-		# (required, "fastq" or "bam")
-		#$format = "fastq";
-		#$format = "bam";
+                $about = qq!
+                FASTQ statistics $version
+                Usage: $scriptname [FILE1] [FILE2] [FILE3] ...
+                Print out statistics calculated from FILE(s).
 
-		# lists the full paths of fastq or BAM files
-		@paths = (
-		    # H_NJ-HCC1395-HCC1395_BL
-		    #"/storage1/fs1/bga/Active/gchang/work/14_BGA-WALKER/211012-immuno2cwl-fastq/2.fastq/H_NJ-HCC1395-HCC1395_BL-H7HY2CCXX.3.R1.fastq.gz",
-		    #"/storage1/fs1/bga/Active/gchang/work/14_BGA-WALKER/211012-immuno2cwl-fastq/2.fastq/H_NJ-HCC1395-HCC1395_BL-H7HY2CCXX.3.R2.fastq.gz",
-		    #"/storage1/fs1/bga/Active/gchang/work/14_BGA-WALKER/211012-immuno2cwl-fastq/2.fastq/H_NJ-HCC1395-HCC1395_BL-H7HY2CCXX.4.R1.fastq.gz",
-		    #"/storage1/fs1/bga/Active/gchang/work/14_BGA-WALKER/211012-immuno2cwl-fastq/2.fastq/H_NJ-HCC1395-HCC1395_BL-H7HY2CCXX.4.R2.fastq.gz",
-		    
-		    #"/gscmnt/gc2560/core/instrument_data/2895499331/csf_150397221/gerald_H7HY2CCXX_3_TGACCACG.bam",
-		    #"/gscmnt/gc2560/core/instrument_data/2895499399/csf_150397349/gerald_H7HY2CCXX_4_TGACCACG.bam",
-		);
-
-		# defines the minimum base call quality score to filter
-		# inclusive, for example, Bases with >= Q30
-		$filter = 30;
-
-
-		# specifies the program paths
-		# docker(registry.gsc.wustl.edu/apipe-builder/genome_perl_environment:compute1-52)
-		$bzcat = "/usr/bin/bzcat";                                             # Version 1.0.8
-		$zcat = "/usr/bin/zcat";                                                # zcat (gzip) 1.10
-		$samtools = "/usr/bin/samtools";                                  # Version: 1.10 (using htslib 1.10.2-3)
-
-		# specifies the N letter to count
-		# (default: "N")
-		$base = 'N';
-
-		# defines the offset to calculate the base call quality score from the Phred +33 encoded by ASCII characters
-		# For example, 33 = 63.06707094 - 30.06707094 (see below)
-		$offset = 33;
+                Example:
+                  \$ $scriptname read1.fastq.gz read2.fastq.gz
+                !;
 
 
 
-		## ------------ Main subroutine ---------------------------------------------- #
-		# prints the program information
-		print($about);
+                ## ------------ Setting global variables ------------------------------------- #
 
-		# main subroutine
-		Main();
+                # predeclares global variable names
+                use vars qw/$format @paths $filter $bzcat $zcat $samtools $base $offset/;
 
-		# this program is terminated here
-		exit 1;
+                # defines the format of input files
+                # (required, "fastq" or "bam")
+                #$format = "fastq";
+                #$format = "bam";
+
+                # lists the full paths of fastq or BAM files
+                @paths = (
+                    # H_NJ-HCC1395-HCC1395_BL
+                    #"/storage1/fs1/bga/Active/gchang/work/14_BGA-WALKER/211012-immuno2cwl-fastq/2.fastq/H_NJ-HCC1395-HCC1395_BL-H7HY2CCXX.3.R1.fastq.gz",
+                    #"/storage1/fs1/bga/Active/gchang/work/14_BGA-WALKER/211012-immuno2cwl-fastq/2.fastq/H_NJ-HCC1395-HCC1395_BL-H7HY2CCXX.3.R2.fastq.gz",
+                    #"/storage1/fs1/bga/Active/gchang/work/14_BGA-WALKER/211012-immuno2cwl-fastq/2.fastq/H_NJ-HCC1395-HCC1395_BL-H7HY2CCXX.4.R1.fastq.gz",
+                    #"/storage1/fs1/bga/Active/gchang/work/14_BGA-WALKER/211012-immuno2cwl-fastq/2.fastq/H_NJ-HCC1395-HCC1395_BL-H7HY2CCXX.4.R2.fastq.gz",
+                    
+                    #"/gscmnt/gc2560/core/instrument_data/2895499331/csf_150397221/gerald_H7HY2CCXX_3_TGACCACG.bam",
+                    #"/gscmnt/gc2560/core/instrument_data/2895499399/csf_150397349/gerald_H7HY2CCXX_4_TGACCACG.bam",
+                );
+
+                # defines the minimum base call quality score to filter
+                # inclusive, for example, Bases with >= Q30
+                $filter = 30;
 
 
+                # specifies the program paths
+                # docker(registry.gsc.wustl.edu/apipe-builder/genome_perl_environment:compute1-52)
+                $bzcat = "/usr/bin/bzcat";                                             # Version 1.0.8
+                $zcat = "/usr/bin/zcat";                                                # zcat (gzip) 1.10
+                $samtools = "/usr/bin/samtools";                                  # Version: 1.10 (using htslib 1.10.2-3)
 
-		## ------------ Library of the main subroutine ----------------------------- #
+                # specifies the N letter to count
+                # (default: "N")
+                $base = 'N';
 
-		sub Main {
-		    # local variables
-		    
-		    # gets the full input paths
-		    unless (@paths > 0)
-		    {
-			@paths = @ARGV if (@ARGV > 0);
-			
-			croak "paths required" unless @paths > 0;
-		    }
-		    
-		    
-		    $format = "fastq"
-
-		    # opens input files
-		    my $n = 0;                  # total number of lines
-		    my $nbase = 0;
-		    my (%freq, %count);
-		    foreach my $path (@paths)
-		    {
-			# creates a file handler
-			my $fh;
-			if ($path =~ /\.gz$/)
-			{
-			    $fh = FileHandle->new("$zcat $path |");
-			}
-			elsif ($path =~ /\.bam$/)
-			{
-			    $format = "bam"
-			    $fh = FileHandle->new("$samtools view $path |");
-			}
-			elsif ($path =~ /\.bz2$/)
-			{
-			    $fh = FileHandle->new("$bzcat $path |");
-			}
-			else
-			{
-			    # from a .sam or .fastq text file
-			    $fh = FileHandle->new($path, "r");
-			}
-			
-			
-			# reads a file
-			croak "Cannot find a file: $path" unless -e $path;
-			croak "Cannot open a file: $path" unless defined $fh;
-			if ($format eq "fastq")
-			{
-			    while (my $i = $fh->getline)
-			    {
-				if ($n % 4 == 3)
-				{
-				    chomp $i;
-				    
-				    # updates the frequency/count hashes
-				    update_hash($i, \%freq, \%count, $offset);
-				}
-				elsif ($n % 4 == 1)
-				{
-				    chomp $i;
-				    
-				    # counts the frequency of a letter
-				    $nbase += count_base($i, $base);
-				}
-				
-				
-				$n ++;
-			    }
-			}
-			elsif ($format eq "bam")
-			{
-			    while (my $i = $fh->getline)
-			    {
-				next if substr($i, 0, 1) eq '@';
-				
-				chomp $i;
-				
-				my @fields = split /\t/, $i;
-				
-				# gets a QUAL value
-				# my $qual = $fields[10];
-				
-				# updates the frequency/count hashes
-				update_hash($fields[10], \%freq, \%count, $offset);
-				
-				# counts the frequency of a letter
-				$nbase += count_base($fields[9], $base);
-				
-				
-				$n ++;
-			    }
-			}
-			else
-			{
-			    croak "Invalid input file format: $format";
-			}
-			
-			
-			#
-			printf "\n  %d lines (cumulative) read from %s", $n, $path;
-			
-			
-			# closes the file handler
-			$fh->close;
-		    }
-		    
-		    
-		    # calculates the total number of base calls and sequences
-		    my ($nseq, $ncall) = (0, 0);
-		    foreach my $len (sort {$a <=> $b} keys %count)
-		    {
-			$ncall += $len * $count{$len};
-			$nseq += $count{$len};
-		    }
-		    
-		    croak "Exception: Invalid total number of sequences, $nseq" unless $nseq == ($format eq "fastq") ? $n / 4 : $n;
-		    
-		    
-
-		    # calculates the median and mean from a frequency hash
-		    my ($median, $mean, $ncall2) = stat_freq(%freq);
-		    croak "Exception: invalid count number of base calls" unless $ncall == $ncall2;
-		    
-		    # filters with the minimum base call quality score
-		    my $nfilter = 0;
-		    foreach my $score (keys %freq)
-		    {
-			if ($filter <= $score)
-			{
-			    $nfilter += $freq{$score};
-			}
-		    }
-		    
-		    
-		    # prints out the summary
-		    printf "\n\n[Quality score summary]";
-		    printf "\nTotal Number of Reads\t%s", $nseq;                                                                    # total sequence number
-		    printf "\nTotal Number of basecalls\t%s", $ncall;
-		    printf "\nBases with %s\t%s\t%s (%%)", $base, $nbase, $nbase / $ncall * 100;
-		    printf "\nMedian Basecall Quality Score\t%s", $median;
-		    printf "\nMean Basecall Quality Score\t%s", $mean;
-		    printf "\nBases with >= Q%s\t%d\t%s (%%)", $filter, $nfilter, $nfilter / $ncall * 100;
-		    
-		    
-		    # Base call score frequency
-		    printf "\n\n[Base call score frequency: %d sequences from %d file(s)]\n", $nseq, scalar(@paths);
-		    printhash(%freq);
-		    
-		    # Sequence length statistics
-		    printf "\n\n[Sequence length statistics]\n";
-		    printhash(%count);
-		    
-		    
-		    # the end of the main subroutine
-		}
+                # defines the offset to calculate the base call quality score from the Phred +33 encoded by ASCII characters
+                # For example, 33 = 63.06707094 - 30.06707094 (see below)
+                $offset = 33;
 
 
 
-		## ------------ Library of subroutines --------------------------------------- #
+                ## ------------ Main subroutine ---------------------------------------------- #
+                # prints the program information
+                print($about);
+
+                # main subroutine
+                Main();
+
+                # this program is terminated here
+                exit 1;
 
 
-		sub update_hash {
-		    # updates the frequency/count hashes
-		    my ($qual, $freq, $count, $offset) = @_;
 
-		    # local variables
-		    
-		    
-		    # converts characters to ASCII numbers
-		    my @scores = map { unpack("C*", $_ ) - $offset } split("", $qual);
-		    
-		    
-		    # updates the hashes
-		    map { $freq->{$_} ++ } @scores;
-		    
-		    #map { $count{$_} ++ }  split("", $i);
-		    $count->{$#scores + 1} ++;                 # for the sequence length
-		}
+                ## ------------ Library of the main subroutine ----------------------------- #
+
+                sub Main {
+                    # local variables
+                    
+                    # gets the full input paths
+                    unless (@paths > 0)
+                    {
+                        @paths = @ARGV if (@ARGV > 0);
+                        
+                        croak "paths required" unless @paths > 0;
+                    }
+                    
+                    
+                    $format = "fastq"
+
+                    # opens input files
+                    my $n = 0;                  # total number of lines
+                    my $nbase = 0;
+                    my (%freq, %count);
+                    foreach my $path (@paths)
+                    {
+                        # creates a file handler
+                        my $fh;
+                        if ($path =~ /\.gz$/)
+                        {
+                            $fh = FileHandle->new("$zcat $path |");
+                        }
+                        elsif ($path =~ /\.bam$/)
+                        {
+                            $format = "bam"
+                            $fh = FileHandle->new("$samtools view $path |");
+                        }
+                        elsif ($path =~ /\.bz2$/)
+                        {
+                            $fh = FileHandle->new("$bzcat $path |");
+                        }
+                        else
+                        {
+                            # from a .sam or .fastq text file
+                            $fh = FileHandle->new($path, "r");
+                        }
+                        
+                        
+                        # reads a file
+                        croak "Cannot find a file: $path" unless -e $path;
+                        croak "Cannot open a file: $path" unless defined $fh;
+                        if ($format eq "fastq")
+                        {
+                            while (my $i = $fh->getline)
+                            {
+                                if ($n % 4 == 3)
+                                {
+                                    chomp $i;
+                                    
+                                    # updates the frequency/count hashes
+                                    update_hash($i, \%freq, \%count, $offset);
+                                }
+                                elsif ($n % 4 == 1)
+                                {
+                                    chomp $i;
+                                    
+                                    # counts the frequency of a letter
+                                    $nbase += count_base($i, $base);
+                                }
+                                
+                                
+                                $n ++;
+                            }
+                        }
+                        elsif ($format eq "bam")
+                        {
+                            while (my $i = $fh->getline)
+                            {
+                                next if substr($i, 0, 1) eq '@';
+                                
+                                chomp $i;
+                                
+                                my @fields = split /\t/, $i;
+                                
+                                # gets a QUAL value
+                                # my $qual = $fields[10];
+                                
+                                # updates the frequency/count hashes
+                                update_hash($fields[10], \%freq, \%count, $offset);
+                                
+                                # counts the frequency of a letter
+                                $nbase += count_base($fields[9], $base);
+                                
+                                
+                                $n ++;
+                            }
+                        }
+                        else
+                        {
+                            croak "Invalid input file format: $format";
+                        }
+                        
+                        
+                        #
+                        printf "\n  %d lines (cumulative) read from %s", $n, $path;
+                        
+                        
+                        # closes the file handler
+                        $fh->close;
+                    }
+                    
+                    
+                    # calculates the total number of base calls and sequences
+                    my ($nseq, $ncall) = (0, 0);
+                    foreach my $len (sort {$a <=> $b} keys %count)
+                    {
+                        $ncall += $len * $count{$len};
+                        $nseq += $count{$len};
+                    }
+                    
+                    croak "Exception: Invalid total number of sequences, $nseq" unless $nseq == ($format eq "fastq") ? $n / 4 : $n;
+                    
+                    
+
+                    # calculates the median and mean from a frequency hash
+                    my ($median, $mean, $ncall2) = stat_freq(%freq);
+                    croak "Exception: invalid count number of base calls" unless $ncall == $ncall2;
+                    
+                    # filters with the minimum base call quality score
+                    my $nfilter = 0;
+                    foreach my $score (keys %freq)
+                    {
+                        if ($filter <= $score)
+                        {
+                            $nfilter += $freq{$score};
+                        }
+                    }
+                    
+                    
+                    # prints out the summary
+                    printf "\n\n[Quality score summary]";
+                    printf "\nTotal Number of Reads\t%s", $nseq;                                                                    # total sequence number
+                    printf "\nTotal Number of basecalls\t%s", $ncall;
+                    printf "\nBases with %s\t%s\t%s (%%)", $base, $nbase, $nbase / $ncall * 100;
+                    printf "\nMedian Basecall Quality Score\t%s", $median;
+                    printf "\nMean Basecall Quality Score\t%s", $mean;
+                    printf "\nBases with >= Q%s\t%d\t%s (%%)", $filter, $nfilter, $nfilter / $ncall * 100;
+                    
+                    
+                    # Base call score frequency
+                    printf "\n\n[Base call score frequency: %d sequences from %d file(s)]\n", $nseq, scalar(@paths);
+                    printhash(%freq);
+                    
+                    # Sequence length statistics
+                    printf "\n\n[Sequence length statistics]\n";
+                    printhash(%count);
+                    
+                    
+                    # the end of the main subroutine
+                }
 
 
-		sub count_base {
-		    # counts the frequency of a letter
-		    my ($str, $base) = @_;
-		    
-		    # local variables
-		    
-		    
-		    # calculates the frequency of a letter
-		    my $count = 0;
-		    if (index($str, $base) > -1)
-		    {
-			$count = $str =~ s/$base//g;
-		    }
-		    
-		    
-		    return $count;
-		}
+
+                ## ------------ Library of subroutines --------------------------------------- #
 
 
-		sub stat_freq {
-		    # calculates the median and mean from a frequency hash
-		    my (%hash) = @_;
-		    
-		    # local variables
-		    
-		    # as default
-		    # frequency hash: {key => data value, value => data count}
-		    croak "empty frequency hash" unless keys(%hash) > 0;
-		    
-		    
-		    # sorts the data values
-		    my @sort = sort {$a <=> $b} keys %hash;
-		    
-		    # counts the total number of data
-		    my $n = 0;
-		    map { $n += $hash{$_} } @sort;
-		    
-		    # calculates the median index (0-based index)
-		    my @midx = ($n % 2 == 1) ? ((1 + $n) / 2) - 1 : ((1 + $n) / 2 - 1.5, (1 + $n) / 2 - 0.5);
-		    
-		    # calculates the median of base call quality score from the frequency
-		    my ($median, $mean);
-		    my $idx = 0;
-		    for (my $i=0; $i<@sort; $i ++)
-		    {
-			# gets the last index of the given score in the array (1-based)
-			my $score = $sort[$i];
-			$idx += $hash{$score};
-			
-			# calculates the mean and mode
-			$mean += $score * $hash{$score};
-			
-			# calculates the median
-			unless (defined $median)
-			{
-			    if ($midx[0] <= $idx - 1)
-			    {
-				if (@midx == 2)
-				{
-				    if ($midx[1] <= $idx - 1)
-				    {
-					# same as ($score + $score) / 2
-					$median = $score;
-				    }
-				    else
-				    {
-					$median = ($score + $sort[$i + 1]) / 2;
-				    }
-				}
-				else
-				{
-				    $median = $score;
-				}
-			    }
-			}
-		    }
-		    
-		    
-		    return ($median, $mean / $n, $n);
-		}
+                sub update_hash {
+                    # updates the frequency/count hashes
+                    my ($qual, $freq, $count, $offset) = @_;
+
+                    # local variables
+                    
+                    
+                    # converts characters to ASCII numbers
+                    my @scores = map { unpack("C*", $_ ) - $offset } split("", $qual);
+                    
+                    
+                    # updates the hashes
+                    map { $freq->{$_} ++ } @scores;
+                    
+                    #map { $count{$_} ++ }  split("", $i);
+                    $count->{$#scores + 1} ++;                 # for the sequence length
+                }
 
 
-		sub printhash {
-		    # prints a hash
-		    my (%hash) = @_;
+                sub count_base {
+                    # counts the frequency of a letter
+                    my ($str, $base) = @_;
+                    
+                    # local variables
+                    
+                    
+                    # calculates the frequency of a letter
+                    my $count = 0;
+                    if (index($str, $base) > -1)
+                    {
+                        $count = $str =~ s/$base//g;
+                    }
+                    
+                    
+                    return $count;
+                }
 
-		    # local variables
-		    
-		    foreach my $key (sort {$a <=> $b} keys %hash)
-		    {
-			printf "%s\t%s\n", $key, $hash{$key};
-		    }
-		}
+
+                sub stat_freq {
+                    # calculates the median and mean from a frequency hash
+                    my (%hash) = @_;
+                    
+                    # local variables
+                    
+                    # as default
+                    # frequency hash: {key => data value, value => data count}
+                    croak "empty frequency hash" unless keys(%hash) > 0;
+                    
+                    
+                    # sorts the data values
+                    my @sort = sort {$a <=> $b} keys %hash;
+                    
+                    # counts the total number of data
+                    my $n = 0;
+                    map { $n += $hash{$_} } @sort;
+                    
+                    # calculates the median index (0-based index)
+                    my @midx = ($n % 2 == 1) ? ((1 + $n) / 2) - 1 : ((1 + $n) / 2 - 1.5, (1 + $n) / 2 - 0.5);
+                    
+                    # calculates the median of base call quality score from the frequency
+                    my ($median, $mean);
+                    my $idx = 0;
+                    for (my $i=0; $i<@sort; $i ++)
+                    {
+                        # gets the last index of the given score in the array (1-based)
+                        my $score = $sort[$i];
+                        $idx += $hash{$score};
+                        
+                        # calculates the mean and mode
+                        $mean += $score * $hash{$score};
+                        
+                        # calculates the median
+                        unless (defined $median)
+                        {
+                            if ($midx[0] <= $idx - 1)
+                            {
+                                if (@midx == 2)
+                                {
+                                    if ($midx[1] <= $idx - 1)
+                                    {
+                                        # same as ($score + $score) / 2
+                                        $median = $score;
+                                    }
+                                    else
+                                    {
+                                        $median = ($score + $sort[$i + 1]) / 2;
+                                    }
+                                }
+                                else
+                                {
+                                    $median = $score;
+                                }
+                            }
+                        }
+                    }
+                    
+                    
+                    return ($median, $mean / $n, $n);
+                }
+
+
+                sub printhash {
+                    # prints a hash
+                    my (%hash) = @_;
+
+                    # local variables
+                    
+                    foreach my $key (sort {$a <=> $b} keys %hash)
+                    {
+                        printf "%s\t%s\n", $key, $hash{$key};
+                    }
+                }
 
 inputs:
     input_files:

--- a/definitions/tools/unaligned_seq_fda_stats.cwl
+++ b/definitions/tools/unaligned_seq_fda_stats.cwl
@@ -112,7 +112,7 @@ requirements:
                 Main();
 
                 # this program is terminated here
-                exit 1;
+                exit 0;
 
 
 
@@ -130,7 +130,7 @@ requirements:
                     }
                     
                     
-                    $format = "fastq"
+                    $format = "fastq";
 
                     # opens input files
                     my $n = 0;                  # total number of lines
@@ -146,7 +146,7 @@ requirements:
                         }
                         elsif ($path =~ /\.bam$/)
                         {
-                            $format = "bam"
+                            $format = "bam";
                             $fh = FileHandle->new("$samtools view $path |");
                         }
                         elsif ($path =~ /\.bz2$/)


### PR DESCRIPTION
This PR adds a new subworkflow to `immuno.cwl` which creates summary tables in csv format containing information requested by the FDA for clinical cases. Several new tools are introduced, including FastQC, which was specifically requested by the FDA, as well as custom scripts for both unaligned and aligned data to calculate requested metrics not generated by FastQC or other existing upstream tools (eg, picard, flagstat). A host of new inputs are added to the `immuno` workflow to gather requested sequencing and sample information (eg, sequencing instrument, total amount of DNA/RNA).