### PR TITLE
actually allow nounset for tumor only mutect runs

### DIFF
--- a/definitions/tools/mutect.cwl
+++ b/definitions/tools/mutect.cwl
@@ -17,7 +17,7 @@ requirements:
       - entryname: 'Mutect2.sh'
         entry: |
             #!/bin/bash
-            set -eou pipefail
+            set -eo pipefail
 
             export tumor_bam="$3"
             export intervals="$4"


### PR DESCRIPTION
having the `nounset` option set does not allow mutect to run in tumor only mode. The normal bam is an optional input and the bash script exits before running when the normal bam is not provided. 