### PR TITLE
Upgrade mapq0 filter to v0.5.3

### DIFF
--- a/definitions/tools/filter_vcf_mapq0.cwl
+++ b/definitions/tools/filter_vcf_mapq0.cwl
@@ -5,7 +5,7 @@ class: CommandLineTool
 label: "filter vcf for variants with high percentage of mapq0 reads"
 requirements:
     - class: DockerRequirement
-      dockerPull: mgibio/mapq0-filter:v0.5.2
+      dockerPull: mgibio/mapq0-filter:v0.5.3
     - class: ResourceRequirement
       ramMin: 8000
       tmpdirMin: 10000


### PR DESCRIPTION
This handles variants with no DP information.  (For more details, see genome/docker-mapq0-filter#8.)