### PR TITLE
Fda metrics split on sequence

### DIFF
--- a/definitions/pipelines/immuno.cwl
+++ b/definitions/pipelines/immuno.cwl
@@ -969,7 +969,7 @@ outputs:
         type: File[]
         outputSource: fda_metrics/unaligned_normal_dna_fastqc_data
     unaligned_normal_dna_table_metrics:
-        type: File
+        type: File[]
         outputSource: fda_metrics/unaligned_normal_dna_table_metrics
     unaligned_normal_dna_md5sums:
         type: File
@@ -982,7 +982,7 @@ outputs:
         type: File[]
         outputSource: fda_metrics/unaligned_tumor_dna_fastqc_data
     unaligned_tumor_dna_table_metrics:
-        type: File
+        type: File[]
         outputSource: fda_metrics/unaligned_tumor_dna_table_metrics
     unaligned_tumor_dna_md5sums:
         type: File
@@ -995,7 +995,7 @@ outputs:
         type: File[]
         outputSource: fda_metrics/unaligned_tumor_rna_fastqc_data
     unaligned_tumor_rna_table_metrics:
-        type: File
+        type: File[]
         outputSource: fda_metrics/unaligned_tumor_rna_table_metrics
     unaligned_tumor_rna_md5sums:
         type: File

--- a/definitions/subworkflows/generate_fda_metrics.cwl
+++ b/definitions/subworkflows/generate_fda_metrics.cwl
@@ -108,7 +108,7 @@ outputs:
         outputSource: unaligned_normal_dna_fastqc/fastqc_all_data
     unaligned_normal_dna_table_metrics:
         type: File[]
-        outputSource: unaligned_normal_dna_metrics/unaligned_stats
+        outputSource: rename_unaligned_normal_dna_metrics/unique_files
     unaligned_normal_dna_md5sums:
         type: File
         outputSource: unaligned_normal_dna_md5/md5sum
@@ -121,7 +121,7 @@ outputs:
         outputSource: unaligned_tumor_dna_fastqc/fastqc_all_data
     unaligned_tumor_dna_table_metrics:
         type: File[]
-        outputSource: unaligned_tumor_dna_metrics/unaligned_stats
+        outputSource: rename_unaligned_tumor_dna_metrics/unique_files
     unaligned_tumor_dna_md5sums:
         type: File
         outputSource: unaligned_tumor_dna_md5/md5sum
@@ -134,7 +134,7 @@ outputs:
         outputSource: unaligned_tumor_rna_fastqc/fastqc_all_data
     unaligned_tumor_rna_table_metrics:
         type: File[]
-        outputSource: unaligned_tumor_rna_metrics/unaligned_stats
+        outputSource: rename_unaligned_tumor_rna_metrics/unique_files
     unaligned_tumor_rna_md5sums:
         type: File
         outputSource: unaligned_tumor_rna_md5/md5sum
@@ -219,6 +219,12 @@ steps:
                 default: "normal_dna"
         out:
             [unaligned_stats]
+    rename_unaligned_normal_dna_metrics:
+        run: ../tools/rename_for_staging.cwl
+        in:
+            scatter_files: unaligned_normal_dna_metrics/unaligned_stats
+        out:
+            [unique_files]
     unaligned_normal_dna_md5:
         run: ../tools/md5sum.cwl
         in:
@@ -297,6 +303,12 @@ steps:
                 default: "tumor_dna"
         out:
             [unaligned_stats]
+    rename_unaligned_tumor_dna_metrics:
+        run: ../tools/rename_for_staging.cwl
+        in:
+            scatter_files: unaligned_tumor_dna_metrics/unaligned_stats
+        out:
+            [unique_files]
     unaligned_tumor_dna_md5:
         run: ../tools/md5sum.cwl
         in:
@@ -375,6 +387,12 @@ steps:
                 default: "tumor_rna"
         out:
             [unaligned_stats]
+    rename_unaligned_tumor_rna_metrics:
+        run: ../tools/rename_for_staging.cwl
+        in:
+            scatter_files: unaligned_tumor_rna_metrics/unaligned_stats
+        out:
+            [unique_files]
     unaligned_tumor_rna_md5:
         run: ../tools/md5sum.cwl
         in: 

--- a/definitions/subworkflows/generate_fda_metrics.cwl
+++ b/definitions/subworkflows/generate_fda_metrics.cwl
@@ -8,6 +8,7 @@ requirements:
     - class: SubworkflowFeatureRequirement
     - class: InlineJavascriptRequirement
     - class: StepInputExpressionRequirement
+    - class: ScatterFeatureRequirement
     - class: SchemaDefRequirement
       types:
           - $import: ../types/sequence_data.yml
@@ -106,7 +107,7 @@ outputs:
         type: File[]
         outputSource: unaligned_normal_dna_fastqc/fastqc_all_data
     unaligned_normal_dna_table_metrics:
-        type: File
+        type: File[]
         outputSource: unaligned_normal_dna_metrics/unaligned_stats
     unaligned_normal_dna_md5sums:
         type: File
@@ -119,7 +120,7 @@ outputs:
         type: File[]
         outputSource: unaligned_tumor_dna_fastqc/fastqc_all_data
     unaligned_tumor_dna_table_metrics:
-        type: File
+        type: File[]
         outputSource: unaligned_tumor_dna_metrics/unaligned_stats
     unaligned_tumor_dna_md5sums:
         type: File
@@ -132,7 +133,7 @@ outputs:
         type: File[]
         outputSource: unaligned_tumor_rna_fastqc/fastqc_all_data
     unaligned_tumor_rna_table_metrics:
-        type: File
+        type: File[]
         outputSource: unaligned_tumor_rna_metrics/unaligned_stats
     unaligned_tumor_rna_md5sums:
         type: File
@@ -201,18 +202,17 @@ steps:
             [fastqc_all_data]
     unaligned_normal_dna_metrics:
         run: ../tools/unaligned_seq_fda_stats.cwl
+        scatter: [unaligned_normal_dna]
+        scatterMethod: dotproduct
         in:
             input_files:
                 source: unaligned_normal_dna
                 valueFrom: |
                     ${
                         var files = [];
-                        var i;
-                        for (i = 0; i < self.length; i = i + 1) {
-                            if (self[i].sequence.hasOwnProperty('bam')) { files.push(self[i].sequence.bam); }
-                            if (self[i].sequence.hasOwnProperty('fastq1')) { files.push(self[i].sequence.fastq1); }
-                            if (self[i].sequence.hasOwnProperty('fastq2')) { files.push(self[i].sequence.fastq2); }
-                        }
+                        if (self.sequence.hasOwnProperty('bam')) { files.push(self.sequence.bam); }
+                        if (self.sequence.hasOwnProperty('fastq1')) { files.push(self.sequence.fastq1); }
+                        if (self.sequence.hasOwnProperty('fastq2')) { files.push(self.sequence.fastq2); }
                         return files;
                     }
             output_name:
@@ -280,18 +280,17 @@ steps:
             [fastqc_all_data]
     unaligned_tumor_dna_metrics:
         run: ../tools/unaligned_seq_fda_stats.cwl
+        scatter: [unaligned_tumor_dna]
+        scatterMethod: dotproduct
         in:
             input_files:
                 source: unaligned_tumor_dna
                 valueFrom: |
                     ${
                         var files = [];
-                        var i;
-                        for (i = 0; i < self.length; i = i + 1) {
-                            if (self[i].sequence.hasOwnProperty('bam')) { files.push(self[i].sequence.bam); }
-                            if (self[i].sequence.hasOwnProperty('fastq1')) { files.push(self[i].sequence.fastq1); }
-                            if (self[i].sequence.hasOwnProperty('fastq2')) { files.push(self[i].sequence.fastq2); }
-                        }
+                        if (self.sequence.hasOwnProperty('bam')) { files.push(self.sequence.bam); }
+                        if (self.sequence.hasOwnProperty('fastq1')) { files.push(self.sequence.fastq1); }
+                        if (self.sequence.hasOwnProperty('fastq2')) { files.push(self.sequence.fastq2); }
                         return files;
                     }
             output_name:
@@ -359,18 +358,17 @@ steps:
             [fastqc_all_data]
     unaligned_tumor_rna_metrics:
         run: ../tools/unaligned_seq_fda_stats.cwl
+        scatter: [unaligned_tumor_rna]
+        scatterMethod: dotproduct
         in: 
             input_files:
                 source: unaligned_tumor_rna
                 valueFrom: |
                     ${
                         var files = [];
-                        var i;
-                        for (i = 0; i < self.length; i = i + 1) {
-                            if (self[i].sequence.hasOwnProperty('bam')) { files.push(self[i].sequence.bam); }
-                            if (self[i].sequence.hasOwnProperty('fastq1')) { files.push(self[i].sequence.fastq1); }
-                            if (self[i].sequence.hasOwnProperty('fastq2')) { files.push(self[i].sequence.fastq2); }
-                        }
+                        if (self.sequence.hasOwnProperty('bam')) { files.push(self.sequence.bam); }
+                        if (self.sequence.hasOwnProperty('fastq1')) { files.push(self.sequence.fastq1); }
+                        if (self.sequence.hasOwnProperty('fastq2')) { files.push(self.sequence.fastq2); }
                         return files;
                     }
             output_name:

--- a/definitions/subworkflows/generate_fda_metrics.cwl
+++ b/definitions/subworkflows/generate_fda_metrics.cwl
@@ -625,5 +625,6 @@ steps:
             freq_normalization_method: rna_freq_normalization_method
             annotation_file: rna_annotation_file
             reference_genome: reference_genome
+            unaligned_rna_table: unaligned_tumor_rna_table/table
         out:
             [table]

--- a/definitions/subworkflows/generate_fda_metrics.cwl
+++ b/definitions/subworkflows/generate_fda_metrics.cwl
@@ -459,7 +459,7 @@ steps:
         in:
             reference: reference
             input_files:
-                source: aligned_normal_dna_cram_to_bam/bam
+                source: aligned_normal_dna
                 valueFrom: ${ return [self]; }
             output_name:
                 default: "normal_dna"
@@ -469,7 +469,7 @@ steps:
         run: ../tools/md5sum.cwl
         in:
             input_files:
-                source: aligned_normal_dna_cram_to_bam/bam
+                source: aligned_normal_dna
                 valueFrom: ${ return [self]; }
             output_name:
                 default: "normal_dna_aligned"
@@ -529,7 +529,7 @@ steps:
         in:
             reference: reference
             input_files:
-                source: aligned_tumor_dna_cram_to_bam/bam
+                source: aligned_tumor_dna
                 valueFrom: ${ return [self]; }
             output_name:
                 default: "tumor_dna"
@@ -539,7 +539,7 @@ steps:
         run: ../tools/md5sum.cwl
         in:
             input_files:
-                source: aligned_tumor_dna_cram_to_bam/bam
+                source: aligned_tumor_dna
                 valueFrom: ${ return [self]; }
             output_name:
                 default: "tumor_dna_aligned"

--- a/definitions/subworkflows/generate_fda_metrics.cwl
+++ b/definitions/subworkflows/generate_fda_metrics.cwl
@@ -202,7 +202,7 @@ steps:
             [fastqc_all_data]
     unaligned_normal_dna_metrics:
         run: ../tools/unaligned_seq_fda_stats.cwl
-        scatter: [unaligned_normal_dna]
+        scatter: [input_files]
         scatterMethod: dotproduct
         in:
             input_files:
@@ -280,7 +280,7 @@ steps:
             [fastqc_all_data]
     unaligned_tumor_dna_metrics:
         run: ../tools/unaligned_seq_fda_stats.cwl
-        scatter: [unaligned_tumor_dna]
+        scatter: [input_files]
         scatterMethod: dotproduct
         in:
             input_files:
@@ -358,7 +358,7 @@ steps:
             [fastqc_all_data]
     unaligned_tumor_rna_metrics:
         run: ../tools/unaligned_seq_fda_stats.cwl
-        scatter: [unaligned_tumor_rna]
+        scatter: [input_files]
         scatterMethod: dotproduct
         in: 
             input_files:

--- a/definitions/tools/aligned_seq_fda_stats.cwl
+++ b/definitions/tools/aligned_seq_fda_stats.cwl
@@ -48,14 +48,14 @@ requirements:
                 ## ------------ About the program ------------------------------------- #
 
                 # the version
-                $version = '1.6';
+                $version = '1.8';
 
                 $about = qq!
                 BAM flag statistics $version
                 Usage: $scriptname [FASTA] [FILE1] [FILE2] [FILE3] ...
                 Print out flag statistics calculated from FILE(s).
-                FASTA is the reference sequence fastq file.
-                FILE(s) format can be SAM, BAM, and CRAM.
+                FASTA is required as a reference sequence fasta file.
+                SAM, BAM, and CRAM formats are allowed for FILE(s).
 
                 Example:
                   \$ $scriptname all_sequences.fa normal.bam tumor.cram
@@ -72,9 +72,6 @@ requirements:
                 # (default: empty from @ARGV)
                 @paths = (
                     # H_NJ-HCC1395-HCC1395_BL
-                    #'/storage1/fs1/bga/Active/johnegarza/fastqc_hcc1395/DNA_normal/aligned/normal.bam',
-                    #'/storage1/fs1/bga/Active/shared/gmsroot/model_data/80beed84e3104595862e7a2c7b7f896e/build8b9e77b87b0144b8a025288e92434686/tmp/cromwell-executions/immuno.cwl/58c62cbc-026b-4c9b-8d21-04b0aa4a20e8/call-somatic/somatic_exome.cwl/b24174a4-a185-4fe4-a222-50cfb2ffb305/call-normal_index_cram/inputs/1389193938/normal.bam.cram',
-                    
                     #'/storage1/fs1/bga/Active/shared/gmsroot/model_data/80beed84e3104595862e7a2c7b7f896e/build191d8f37d22a4d79b2591c01cb80948e/results/normal.bam.cram'
                 );
 
@@ -86,7 +83,7 @@ requirements:
 
                 # specifies the program paths
                 # docker(registry.gsc.wustl.edu/apipe-builder/genome_perl_environment:compute1-52)
-                $samtools = "/opt/samtools/bin/samtools";                                  # Version: 1.10 (using htslib 1.10.2-3)
+                $samtools = "/opt/samtools/bin/samtools";                # samtools 1.3.1 using htslib 1.3.2
 
 
 
@@ -116,7 +113,14 @@ requirements:
                     }
                     else
                     {
-                        $pathfasta = shift @ARGV if (@ARGV > 0);
+                        if (@ARGV > 0)
+                        {
+                            $pathfasta = shift @ARGV;
+                        }
+                        else
+                        {
+                            croak "reference sequence FASTA required";
+                        }
                         
                         croak "Invalid reference sequence path: $pathfasta" unless -e $pathfasta;
                     }
@@ -337,6 +341,15 @@ requirements:
                     # for missing values
                     $count{"duplicate\tunmapped"} = $default_zero unless exists $count{"duplicate\tunmapped"};
                     $count{failed} = $default_zero unless exists $count{failed};
+                    
+                    
+                    # prints out the source file information
+                    printf "\n\n[Input file information]";
+                    foreach my $path (@paths)
+                    {
+                        my ($name, $dir, $ext) = fileparse($path, qr/\.[^.]*/);
+                        printf "\n%s\t%s", $name . $ext, $dir;
+                    }
                     
                     
                     # prints out the summary

--- a/definitions/tools/generate_fda_tables.cwl
+++ b/definitions/tools/generate_fda_tables.cwl
@@ -143,7 +143,7 @@ requirements:
             def parse_aligned_metrics(metrics_file, table_num):
                 fieldname_to_t2_label = {
                     "Total Read Count (R1 + R2)": "Total Read Count",
-                    "Unique Read Pairs": "Unique Read Pairs",
+                    "Unique Read Pairs": "Unique Read Pairs (%)",
                     "Total Mapped Reads": "Total Mapped Reads (%)",
                     "Non-Mapped Reads": "Non-Mapped Reads (%)",
                     "Unique Mapped Reads": "Unique Mapped Reads (%)",
@@ -315,7 +315,7 @@ requirements:
             def generate_table2(file_args, string_arg_dict):
                 table_rows = ('Sample Name', 'File', 'MD5 File Checksum', 'Sequencing Platform',
                     'Sequencing Instrument', 'Sequencing Kit', 'Single or Paired End', 'Source', 'Total DNA(ng)',
-                    'Read Length', 'Total Read Count', 'Filtered Read Count', 'Unique Read Pairs', 'Total Mapped Reads (%)',
+                    'Read Length', 'Total Read Count', 'Filtered Read Count', 'Unique Read Pairs (%)', 'Total Mapped Reads (%)',
                     'Non-Mapped Reads (%)', 'Unique Mapped Reads (%)', 'Mapped Read Duplication (%)', 'Strand Specificity (%)',
                     'Reference Genome', 'PCT_USABLE_BASES_ON_TARGET', 'PCT_EXC_OFF_TARGET', 'PERCENT_DUPLICATION',
                     'MEAN_TARGET_COVERAGE', 'PCT_TARGET_BASES_20X', 'PCT_READS_ALIGNED_IN_PAIRS', 'MEAN_INSERT_SIZE',

--- a/definitions/tools/generate_fda_tables.cwl
+++ b/definitions/tools/generate_fda_tables.cwl
@@ -188,22 +188,21 @@ requirements:
                 }
                 extracted_data = {}
                 for metrics_file in metrics_files:
-                    with open(metrics_file) as f:
-                        parsed_data = [line.split('\t') for line in f.read().splitlines()]
-                    file_data = {}
-                    filenames = []
-                    for parsed_line in parsed_data:
-                        if 'cumulative' in parsed_line[0]:
-                            filenames.append(os.path.basename(parsed_line[0].split()[-1]))
 
-                        if len(parsed_line) < 2:
-                            continue
-                        field_name = parsed_line[0]
-                        field_data = parsed_line[-1]
-                        if field_name in field_map:
-                            file_data[ field_map[field_name] ] = field_data
-                    for fname in filenames:
-                        extracted_data[fname] = file_data
+                    with open(metrics_file) as f:
+                        raw_per_file_data = f.read().split('\n\n\n')[1:]
+                    for raw_file_data in raw_per_file_data:
+                        parsed_data = [line.split('\t') for line in raw_file_data.splitlines()]
+                        file_data = {}
+                        filename = ""
+                        for parsed_line in parsed_data:
+                            if 'summary' in parsed_line[0]:
+                                filename = os.path.basename(parsed_line[0].split()[-1][:-1])
+                            field_name = parsed_line[0]
+                            field_data = parsed_line[-1]
+                            if field_name in field_map:
+                                file_data[ field_map[field_name] ] = field_data
+                        extracted_data[filename] = file_data
 
                 return extracted_data
 

--- a/definitions/tools/generate_fda_tables.cwl
+++ b/definitions/tools/generate_fda_tables.cwl
@@ -275,7 +275,7 @@ requirements:
                 with open(flagstat) as f:
                     return {'Filtered Read Count': f.readlines()[0].split()[2]}
 
-            def aggregate_dicts(md5_dict, fastqc_dict, unaligned_dict=None, *flat_dicts):
+            def aggregate_dicts(md5_dict, fastqc_dict, *flat_dicts, unaligned_dict=None):
                 final_dict = md5_dict.copy()
                 for key in final_dict:
                     # merge the nested dicts, which are in the form {filename: {table_field: val, ...}}
@@ -307,7 +307,7 @@ requirements:
                 fastqc_dict = parse_fastqc_zips(file_args.fastqc_zips, file_args.table)
                 unaligned_dict = parse_unaligned_metrics(file_args.unaligned_metrics)
 
-                table_dict = aggregate_dicts(md5_dict, fastqc_dict, unaligned_dict=unaligned_dict, string_arg_dict)
+                table_dict = aggregate_dicts(md5_dict, fastqc_dict, string_arg_dict, unaligned_dict=unaligned_dict)
 
                 table = generate_table(table_rows, table_dict)
                 return table

--- a/definitions/tools/generate_fda_tables.cwl
+++ b/definitions/tools/generate_fda_tables.cwl
@@ -275,11 +275,16 @@ requirements:
                 with open(flagstat) as f:
                     return {'Filtered Read Count': f.readlines()[0].split()[2]}
 
-            def aggregate_dicts(md5_dict, fastqc_dict, *flat_dicts, unaligned_dict=None):
+            def aggregate_dicts(md5_dict, fastqc_dict, *flat_dicts, unaligned_dict=None, rename_key=False):
                 final_dict = md5_dict.copy()
                 for key in final_dict:
+                    alternate_key = key
+                    if rename_key:
+                        nameroot, nameext = os.path.splitext(key)
+                        if nameext == '.cram':
+                            alternate_key = nameroot + '.bam'
                     # merge the nested dicts, which are in the form {filename: {table_field: val, ...}}
-                    final_dict[key].update(fastqc_dict[key])
+                    final_dict[key].update(fastqc_dict[alternate_key])
                     if unaligned_dict:
                         final_dict[key].update(unaligned_dict[key])
                     # copy in any given flat dicts, in the form {table_field: val, ...}
@@ -331,7 +336,7 @@ requirements:
                 flagstat_dict = parse_flagstat(args.flagstat)
 
                 table_dict = aggregate_dicts(md5_dict, fastqc_dict, string_arg_dict, aligned_dict,
-                    alignment_summary_dict, duplication_dict, insert_size_dict, hs_dict, flagstat_dict)
+                    alignment_summary_dict, duplication_dict, insert_size_dict, hs_dict, flagstat_dict, rename_key=True)
 
                 table = generate_table(table_rows, table_dict)
                 return table

--- a/definitions/tools/generate_fda_tables.cwl
+++ b/definitions/tools/generate_fda_tables.cwl
@@ -379,7 +379,7 @@ requirements:
 
             with open(args.table_file_name, 'w+') as f:
                 for line in table:
-                    f.write(','.join(line) + '\n')
+                    f.write(','.join([str(e) for e in line]) + '\n')
 
 
 baseCommand: ['python', 'generate_tables.py']

--- a/definitions/tools/rename_for_staging.cwl
+++ b/definitions/tools/rename_for_staging.cwl
@@ -1,0 +1,34 @@
+#! /usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+label: "Rename file paths with identical basenames so that output staging works"
+requirements:
+    - class: DockerRequirement
+      dockerPull: "python:3.7.4-slim-buster"
+    - class: ResourceRequirement
+      ramMin: 4000
+    - class: InitialWorkDirRequirement
+      listing:
+      - entryname: 'stage_for_renaming.py'
+        entry: |
+            import sys, os, shutil
+
+            file_list = sys.argv[1:]
+
+            for num, f in enumerate(file_list):
+                original_name = os.path.basename(f)
+                name_root, name_ext = os.path.splitext(original_name)
+                new_name = name_root + '.' + str(num+1) + name_ext
+                shutil.copy(f, new_name)
+
+baseCommand: ['python', 'stage_for_renaming.py']
+inputs:
+    scatter_files:
+        type: File[]
+        inputBinding:
+            position: 1
+outputs:
+    unique_files:
+        type: File[]
+        outputBinding:
+            glob: "$(inputs.scatter_files[0].nameroot)*"

--- a/definitions/tools/unaligned_seq_fda_stats.cwl
+++ b/definitions/tools/unaligned_seq_fda_stats.cwl
@@ -13,75 +13,70 @@ requirements:
       - entryname: 'unaligned_stats.pl'
         entry: |
                 #!/usr/bin/perl
-
+                
                 use strict;
                 use warnings;
                 use Carp;
-
+                
                 use FileHandle;
                 use File::Basename;
                 use File::Spec::Functions; 
-
-
+                use IO::Uncompress::AnyUncompress;
+                
+                
                 # sets global variables with the default
-                use vars qw/$filter $base $offset $bzcat $zcat $samtools/;
-
+                use vars qw/$filter $base $offset $samtools/;
+                
                 # defines the minimum base call quality score to filter
                 # inclusive, for example, Bases with >= Q30
                 $filter = 30;
-
-                # defines the basecalling letter to count
-                # (default: "N")
-                $base = 'N';
-
+                
                 # defines the offset to calculate the base call quality score from the Phred +33 encoded by ASCII characters
                 # For example, 33 = 63.06707094 - 30.06707094 (see below)
                 $offset = 33;
-
+                
+                # Please replace count_N() with count_base() below to enable this option.
+                # defines a basecalling letter to count
+                # (default: "N")
+                $base = 'N';        # now inactivated, don't change this.
+                
                 # specifies the program paths in docker(mgibio/cle:v1.4.2)
-                $bzcat = "/bin/bzcat";                                             # Version 1.0.6
-                $zcat = "/bin/zcat";                                                # zcat (gzip) 1.6
                 $samtools = "/opt/samtools/bin/samtools";              # samtools 1.3.1 using htslib 1.3.2
-
-
+                
+                
                 # main subroutine
                 Main();
-
+                
                 # program exits here
                 exit 0;
-
-
+                
+                
                 sub Main {
-                    # gets the paths of input files
+                    # for the paths of input files
                     my @paths = @ARGV if @ARGV > 0;
                     croak "input file path required" unless @paths > 0;
                     
                     
-                    # opens the input files
-                    my (%freq, %count);
+                    # reads input files
+                    my (%freq, %count, %base);
                     my $format = "fastq";
-                    my $n = 0;                  # total number of lines
-                    my $nbase = 0;
+                    my $n = 0;
                     foreach my $path (@paths)
                     {
                         my $fh;
-                        if ($path =~ /\.gz$/)
+                        if ($path =~ /\.gz$/ || $path =~ /\.bz2$/)
                         {
-                            $fh = FileHandle->new("$zcat $path |");
+                            $fh = IO::Uncompress::AnyUncompress->new($path, MultiStream => 1);
                         }
                         elsif ($path =~ /\.bam$/)
                         {
+                            # for MGI legacy instrument data
                             $format = "bam";
                             
                             $fh = FileHandle->new("$samtools view $path |");
                         }
-                        elsif ($path =~ /\.bz2$/)
-                        {
-                            $fh = FileHandle->new("$bzcat $path |");
-                        }
                         else
                         {
-                            # from a .sam or .fastq text file
                             $fh = FileHandle->new($path, "r");
                         }
                         
@@ -97,15 +92,17 @@ requirements:
                                 {
                                     chomp $i;
                                     
-                                    # updates the frequency/count hashes
-                                    update_hash($i, \%freq, \%count, $offset);
+                                    update_hash($i, \%freq, \%count, $offset, $path);
                                 }
                                 elsif ($n % 4 == 1)
                                 {
                                     chomp $i;
                                     
-                                    # counts the frequency of a letter
-                                    $nbase += count_base($i, $base);
+                                    # instead of count_base($i, $base);
+                                    my $nbase = count_N($i);
+                                    
+                                    $base{sum} += $nbase;
+                                    $base{$path} += $nbase;
                                 }
                                 
                                 
@@ -116,17 +113,18 @@ requirements:
                         {
                             while (my $i = $fh->getline)
                             {
-                                next if substr($i, 0, 1) eq '@';
+                                next if index($i, '@') == 0;
                                 chomp $i;
                                 
                                 my @fields = split /\t/, $i;
                                 
-                                # updates the frequency/count hashes
-                                update_hash($fields[10], \%freq, \%count, $offset);
+                                update_hash($fields[10], \%freq, \%count, $offset, $path);
                                 
-                                # counts the frequency of a letter
-                                $nbase += count_base($fields[9], $base);
+                                # instead of count_base($fields[9], $base);
+                                my $nbase = count_N($fields[9]);
                                 
+                                $base{sum} += $nbase;
+                                $base{$path} += $nbase;
                                 
                                 $n ++;
                             }
@@ -142,32 +140,6 @@ requirements:
                     }
                     
                     
-                    # calculates the total number of base calls and sequences
-                    my ($nseq, $ncall) = (0, 0);
-                    foreach my $len (sort {$a <=> $b} keys %count)
-                    {
-                        $ncall += $len * $count{$len};
-                        $nseq += $count{$len};
-                    }
-                    
-                    croak "Exception: Invalid total number of sequences, $nseq" unless $nseq == ($format eq "fastq") ? $n / 4 : $n;
-                    
-
-                    # calculates the median and mean from a frequency hash
-                    my ($median, $mean, $ncall2) = stat_freq(%freq);
-                    croak "Exception: invalid count number of base calls" unless $ncall == $ncall2;
-                    
-                    # counts by the minimum base call quality score
-                    my $nfilter = 0;
-                    foreach my $score (keys %freq)
-                    {
-                        if ($filter <= $score)
-                        {
-                            $nfilter += $freq{$score};
-                        }
-                    }
-                    
-                    
                     # prints out the source file information
                     printf "\n\n[Input file information: %d file(s)]", scalar(@paths);
                     print "\nfile\tdir";
@@ -177,32 +149,79 @@ requirements:
                         printf "\n%s\t%s", $name, $dir;
                     }
                     
-                    # prints out the summary
-                    printf "\n\n[Quality score summary]";
-                    printf "\nTotal Number of Reads\t%s", $nseq;                                                                    # total sequence number
-                    printf "\nTotal Number of basecalls\t%s", $ncall;
-                    printf "\nBases with %s\t%s\t%s (%%)", $base, $nbase, $nbase / $ncall * 100;
-                    printf "\nMedian Basecall Quality Score\t%s", $median;
-                    printf "\nMean Basecall Quality Score\t%s", $mean;
-                    printf "\nBases with >= Q%s\t%d\t%s (%%)", $filter, $nfilter, $nfilter / $ncall * 100;
-                    print "\n\n";
+                    foreach my $key ("sum", @paths)
+                    {
+                        # calculates the total number of base calls and sequences
+                        my ($nseq, $ncall) = (0, 0);
+                        foreach my $len (sort {$a <=> $b} keys %{$count{$key}})
+                        {
+                            $ncall += $len * $count{$key}->{$len};
+                            $nseq += $count{$key}->{$len};
+                        }
+                        
+                        croak "Exception: Invalid number of sequences, $nseq" unless $nseq == ($format eq "fastq") ? $n / 4 : $n;
+                        
+                    
+                        # calculates the median and mean from a frequency hash
+                        my ($median, $mean, $ncall2) = stat_freq($freq{$key});
+                        croak "Exception: invalid count number of base calls" unless $ncall == $ncall2;
+                        
+                        # counts by the minimum base call quality score
+                        my $nfilter = 0;
+                        foreach my $score (keys %{$freq{$key}})
+                        {
+                            if ($filter <= $score)
+                            {
+                                $nfilter += $freq{$key}->{$score};
+                            }
+                        }
+                        
+                        # prints out the summary
+                        printf "\n\n[Quality score summary from %s]", $key eq "sum" ? sprintf("%d file(s)", scalar(@paths)) : $key;
+                        printf "\nTotal Number of Reads\t%s", $nseq;                                                                    # total sequence number
+                        printf "\nTotal Number of basecalls\t%s", $ncall;
+                        printf "\nBases with %s\t%s\t%s (%%)", $base, $base{$key}, $base{$key} / $ncall * 100;
+                        printf "\nMedian Basecall Quality Score\t%s", $median;
+                        printf "\nMean Basecall Quality Score\t%s", $mean;
+                        printf "\nBases with >= Q%s\t%d\t%s (%%)", $filter, $nfilter, $nfilter / $ncall * 100;
+                        print "\n";
+                    }
                 }
-
-
+                
+                
                 sub update_hash {
-                    my ($qual, $freq, $count, $offset) = @_;
+                    my ($qual, $freq, $count, $offset, $path) = @_;
                     
                     # converts characters to ASCII numbers
-                    my @scores = map { unpack("C*", $_ ) - $offset } split("", $qual);
+                    my @scores = map { unpack("C*", $_ ) - $offset } unpack('(a)*', $qual);
                     
-                    # updates the hashes
-                    map { $freq->{$_} ++ } @scores;
+                    # updates the frequency of basecalling score
+                    foreach (@scores)
+                    {
+                        $freq->{sum}->{$_} ++;
+                        $freq->{$path}->{$_} ++;
+                    }
                     
                     # counts the sequence length
-                    $count->{$#scores + 1} ++;
+                    $count->{sum}->{$#scores + 1} ++;
+                    $count->{$path}->{$#scores + 1} ++;
                 }
-
-
+                
+                
+                sub count_N {
+                    my ($str) = @_;
+                    
+                    # calculates the frequency of "N"
+                    my $count = 0;
+                    if (index($str, 'N') > -1)
+                    {
+                        $count = $str =~ tr/N//;
+                    }
+                    
+                    return $count;
+                }
+                
+                
                 sub count_base {
                     my ($str, $base) = @_;
                     
@@ -215,20 +234,20 @@ requirements:
                     
                     return $count;
                 }
-
-
+                
+                
                 sub stat_freq {
-                    my (%hash) = @_;
+                    my ($hash) = @_;
                     
                     # frequency hash: {key => data value, value => data count}
-                    croak "empty frequency hash" unless keys(%hash) > 0;
+                    croak "empty frequency hash" unless keys(%$hash) > 0;
                     
                     # sorts the data values
-                    my @sort = sort {$a <=> $b} keys %hash;
+                    my @sort = sort {$a <=> $b} keys %$hash;
                     
                     # counts the total number of data
                     my $n = 0;
-                    map { $n += $hash{$_} } @sort;
+                    map { $n += $hash->{$_} } @sort;
                     
                     # calculates the median index (0-based index)
                     my @midx = ($n % 2 == 1) ? ((1 + $n) / 2) - 1 : ((1 + $n) / 2 - 1.5, (1 + $n) / 2 - 0.5);
@@ -240,10 +259,10 @@ requirements:
                     {
                         # gets the last index of the given score in the array (1-based)
                         my $score = $sort[$i];
-                        $idx += $hash{$score};
+                        $idx += $hash->{$score};
                         
                         # to calculate the mean
-                        $mean += $score * $hash{$score};
+                        $mean += $score * $hash->{$score};
                         
                         # calculates the median
                         unless (defined $median)
@@ -254,7 +273,6 @@ requirements:
                                 {
                                     if ($midx[1] <= $idx - 1)
                                     {
-                                        # same as ($score + $score) / 2
                                         $median = $score;
                                     }
                                     else


### PR DESCRIPTION
This PR introduces a CWL scatter across individual sequence elements (a bam or pair of fastqs) of the input array for each of the 3 unaligned inputs (normal DNA, tumor DNA, tumor RNA) when calculating statistics to be reported to the FDA in clinical cases. Previously, some statistics were calculated using data from all sequence files for an input at once, which is less accurate.