### PR TITLE
FDA table generation: the output `table_file_name` is required

### DIFF
--- a/definitions/tools/generate_fda_tables.cwl
+++ b/definitions/tools/generate_fda_tables.cwl
@@ -360,7 +360,7 @@ requirements:
 baseCommand: ['python', 'generate_tables.py']
 inputs:
     table_file_name:
-        type: string?
+        type: string
         inputBinding:
             prefix: "--table_file_name"
     table_num:


### PR DESCRIPTION
The python script requires this to be specified (and currently all callers do specify it), so let's make it required to help prevent any future mistakes.