### PR TITLE
Update docker image to 0.5.4 for handling of case of 0-depth variant.

### DIFF
--- a/definitions/tools/filter_vcf_mapq0.cwl
+++ b/definitions/tools/filter_vcf_mapq0.cwl
@@ -5,7 +5,7 @@ class: CommandLineTool
 label: "filter vcf for variants with high percentage of mapq0 reads"
 requirements:
     - class: DockerRequirement
-      dockerPull: mgibio/mapq0-filter:v0.5.3
+      dockerPull: mgibio/mapq0-filter:v0.5.4
     - class: ResourceRequirement
       ramMin: 8000
       tmpdirMin: 10000


### PR DESCRIPTION
New version is https://hub.docker.com/layers/mgibio/mapq0-filter/v0.5.4/images/sha256-ef5046b3e74bd1689fbf599c2731031213f9436061f791b909bc77779e2137d2?context=explore