### PR TITLE
Use sambamba for duplicate marking.

### DIFF
--- a/definitions/pipelines/rnaseq.cwl
+++ b/definitions/pipelines/rnaseq.cwl
@@ -150,8 +150,6 @@ steps:
         run: ../tools/mark_duplicates_and_sort.cwl
         in:
             bam: index_bam/indexed_bam
-            input_sort_order: 
-                default: "coordinate"
         out:
             [sorted_bam, metrics_file]
     stringtie:

--- a/definitions/pipelines/rnaseq_star_fusion.cwl
+++ b/definitions/pipelines/rnaseq_star_fusion.cwl
@@ -238,8 +238,6 @@ steps:
         run: ../tools/mark_duplicates_and_sort.cwl
         in:
             bam: sort_bam/sorted_bam
-            input_sort_order:
-                default: "coordinate"
         out:
             [sorted_bam, metrics_file]
     index_bam:

--- a/definitions/pipelines/rnaseq_star_fusion_with_xenosplit.cwl
+++ b/definitions/pipelines/rnaseq_star_fusion_with_xenosplit.cwl
@@ -257,8 +257,6 @@ steps:
         run: ../tools/mark_duplicates_and_sort.cwl
         in:
             bam: sort_bam/sorted_bam
-            input_sort_order:
-                default: "coordinate"
         out:
             [sorted_bam, metrics_file]
     index_bam:


### PR DESCRIPTION
In porting the FDA metrics pipelines to the WDL workflows I ran into that those had been updated to switch duplicate markers but these had not.  This carries that change over to the CWL version.  I haven't tried running it on the immuno.cwl yet--thought I'd open this and see if it's something we wanted to do before running a test.