### PR TITLE
update vt docker image

### DIFF
--- a/definitions/tools/vt_decompose.cwl
+++ b/definitions/tools/vt_decompose.cwl
@@ -6,7 +6,7 @@ label: "run vt decompose"
 baseCommand: ["vt", "decompose"]
 requirements:
     - class: DockerRequirement
-      dockerPull: quay.io/biocontainers/vt:0.57721--hf74b74d_1
+      dockerPull: quay.io/biocontainers/vt:0.57721--h064f3d2_11
     - class: ResourceRequirement
       ramMin: 4000
 arguments:


### PR DESCRIPTION
the previous docker image does not work on compute1:
```
0.57721--hf74b74d_1: Pulling from biocontainers/vt
[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of quay.io/biocontainers/vt:0.57721--hf74b74d_1 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
Jun 26 09:58:09 docker1_starter[750233]: CRITICAL:         docker pull failed
```
updating to new one that does